### PR TITLE
Store more job details to the job_instance table

### DIFF
--- a/src/eda_server/api/job.py
+++ b/src/eda_server/api/job.py
@@ -61,7 +61,10 @@ async def create_job_instance(
 
     job_uuid = str(uuid.uuid4())
 
-    query = sa.insert(models.job_instances).values(uuid=job_uuid)
+    query = sa.insert(models.job_instances).values(
+        uuid=job_uuid,
+        name=playbook_row.name,
+    )
     result = await db.execute(query)
     await db.commit()
     (job_instance_id,) = result.inserted_primary_key

--- a/src/eda_server/api/websocket.py
+++ b/src/eda_server/api/websocket.py
@@ -274,7 +274,14 @@ async def handle_ansible_rulebook(data: dict, db: AsyncSession):
 
 
 async def handle_jobs(data: dict, db: AsyncSession):
-    query = insert(models.job_instances).values(uuid=data.get("job_id"))
+    query = insert(models.job_instances).values(
+        uuid=data.get("job_id"),
+        name=data.get("name"),
+        action=data.get("action"),
+        ruleset=data.get("ruleset"),
+        hosts=data.get("hosts"),
+        rule=data.get("rule"),
+    )
     result = await db.execute(query)
     await db.commit()
     (job_instance_id,) = result.inserted_primary_key

--- a/src/eda_server/db/migrations/versions/202210171900_c703cd56f6b0_update_job_instance_table_columns.py
+++ b/src/eda_server/db/migrations/versions/202210171900_c703cd56f6b0_update_job_instance_table_columns.py
@@ -1,0 +1,41 @@
+"""Update job_instance table columns.
+
+Revision ID: c703cd56f6b0
+Revises: abfdc233b4b0
+Create Date: 2022-10-17 19:00:22.804697+00:00
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c703cd56f6b0"
+down_revision = "abfdc233b4b0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "job_instance", sa.Column("action", sa.String(), nullable=True)
+    )
+    op.add_column(
+        "job_instance", sa.Column("name", sa.String(), nullable=True)
+    )
+    op.add_column(
+        "job_instance", sa.Column("ruleset", sa.String(), nullable=True)
+    )
+    op.add_column(
+        "job_instance", sa.Column("rule", sa.String(), nullable=True)
+    )
+    op.add_column(
+        "job_instance", sa.Column("hosts", sa.String(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("job_instance", "hosts")
+    op.drop_column("job_instance", "rule")
+    op.drop_column("job_instance", "ruleset")
+    op.drop_column("job_instance", "name")
+    op.drop_column("job_instance", "action")

--- a/src/eda_server/db/models/job.py
+++ b/src/eda_server/db/models/job.py
@@ -33,6 +33,11 @@ job_instances = sa.Table(
         primary_key=True,
     ),
     sa.Column("uuid", postgresql.UUID),
+    sa.Column("action", sa.String),
+    sa.Column("name", sa.String),
+    sa.Column("ruleset", sa.String),
+    sa.Column("rule", sa.String),
+    sa.Column("hosts", sa.String),
 )
 
 activation_instance_job_instances = sa.Table(


### PR DESCRIPTION
Store more job details: `playbook/module name, ruleset name, action, hosts and inventory` to the `job_instance` table for the purpose of debug or job rerun.


Resolves: [AAP-5081](https://issues.redhat.com/browse/AAP-5081)
Depends: https://github.com/ansible/ansible-rulebook/pull/166