### PR TITLE
Add podman specific health check when waiting for postgres container

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -192,7 +192,7 @@ tasks:
       Run eda.sh with specified CLI arguments.
 
       Example:
-        $ task minikube -- services-start
+        $ task minikube -- build
     cmds:
       - task: version:check:bash
       - '{{.MINIKUBE_CMD}} {{.CLI_ARGS}}'

--- a/scripts/eda_dev.sh
+++ b/scripts/eda_dev.sh
@@ -94,8 +94,6 @@ start-events-services() {
     log-debug "docker-compose -p eda-server -f tools/docker/docker-compose.yml up -d postgres"
     docker-compose -p eda-server -f tools/docker/docker-compose.yml up -d postgres
 
-    local heath_check=".State.Health.Status"
-
     #
     # The below code is needed do to Podman versions pre V4, us a different string variation of
     # the key for health check.
@@ -104,6 +102,8 @@ start-events-services() {
     #
     # Default is to use the Docker key value, if both Podman and Docker are installed.
     #
+    local heath_check=".State.Health.Status"
+
     if which docker &> /dev/null; then
       heath_check="${heath_check}"
       log-debug "Using docker installation"
@@ -111,13 +111,13 @@ start-events-services() {
 
     elif which podman &> /dev/null; then
       _podman_version=$(podman -v)
-      _podman_major_version=$(podman -v | awk -F'[ .]' '{print $(NF-2)}')
+      _podman_major_version=$(podman -v | awk '{print substr($3,0,1)}')
 
       log-debug "Using podman installation"
       log-debug "podman version: ${_podman_version}"
       log-debug "Using docker installation"
 
-      if [ "${_podman_major_version}" -lt 4 ]; then
+      if [ "${_podman_major_version}" -lt "4" ]; then
         heath_check=".State.Healthcheck.Status"
         log-debug "Set healthcheck flag: ${heath_check}"
       fi

--- a/scripts/eda_dev.sh
+++ b/scripts/eda_dev.sh
@@ -95,12 +95,12 @@ start-events-services() {
     docker-compose -p eda-server -f tools/docker/docker-compose.yml up -d postgres
 
     #
-    # The below code is needed do to Podman versions pre V4, us a different string variation of
-    # the key for health check.
+    # Podman versions previous to v4 use a different string variation for health check.
+    #
     # Reference:
     #      https://github.com/containers/podman/issues/11645
     #
-    # Default is to use the Docker key value, if both Podman and Docker are installed.
+    # Default is to use the Docker key value if both Podman and Docker are installed.
     #
     local heath_check=".State.Health.Status"
 

--- a/scripts/eda_dev.sh
+++ b/scripts/eda_dev.sh
@@ -100,27 +100,26 @@ start-events-services() {
     # Reference:
     #      https://github.com/containers/podman/issues/11645
     #
-    # Default is to use the Docker key value if both Podman and Docker are installed.
+    # Default is to check if podman is installed. If true then use podman.
     #
     local heath_check=".State.Health.Status"
 
-    if which docker &> /dev/null; then
-      heath_check="${heath_check}"
-      log-debug "Using docker installation"
-      log-debug "Set healthcheck flag: ${heath_check}"
-
-    elif which podman &> /dev/null; then
+    if which podman &> /dev/null; then
       _podman_version=$(podman -v)
       _podman_major_version=$(podman -v | awk '{print substr($3,0,1)}')
 
-      log-debug "Using podman installation"
+      log-info "Using podman installation"
       log-debug "podman version: ${_podman_version}"
-      log-debug "Using docker installation"
 
       if [ "${_podman_major_version}" -lt "4" ]; then
         heath_check=".State.Healthcheck.Status"
         log-debug "Set healthcheck flag: ${heath_check}"
       fi
+    elif which docker &> /dev/null; then
+      heath_check="${heath_check}"
+      log-info "Using docker installation"
+      log-debug "docker version: $(docker -v)"
+      log-debug "Set healthcheck flag: ${heath_check}"
     fi
 
     local _cnt=0


### PR DESCRIPTION
[[AAP-6275](https://issues.redhat.com/browse/AAP-6275)] - eda_dev.sh script healthcheck fails on older versions of Podman