### PR TITLE
Rework project repository clone

### DIFF
--- a/src/eda_server/api/rulebook.py
+++ b/src/eda_server/api/rulebook.py
@@ -214,7 +214,7 @@ async def create_rulebook(
     (id_,) = result.inserted_primary_key
 
     rulebook_data = yaml.safe_load(rulebook.rulesets)
-    await insert_rulebook_related_data(id_, rulebook_data, db)
+    await insert_rulebook_related_data(db, id_, rulebook_data)
     await db.commit()
 
     return {**rulebook.dict(), "id": id_}

--- a/src/eda_server/schema/project.py
+++ b/src/eda_server/schema/project.py
@@ -14,7 +14,6 @@ def strict_not_empty_str():
 
 
 class ProjectCreate(BaseModel):
-    git_hash: Optional[StrictStr]
     url: StrictStr
     name: strict_not_empty_str()
     description: Optional[StrictStr] = ""
@@ -22,6 +21,7 @@ class ProjectCreate(BaseModel):
 
 class ProjectRead(ProjectCreate):
     id: int
+    git_hash: Optional[StrictStr]
     created_at: datetime
     modified_at: datetime
 

--- a/src/eda_server/utils/subprocess.py
+++ b/src/eda_server/utils/subprocess.py
@@ -1,0 +1,60 @@
+import asyncio
+import subprocess
+from typing import Any, Optional
+
+__all__ = (
+    "TimeoutExpired",
+    "CalledProcessError",
+    "CompletedProcess",
+)
+
+
+TimeoutExpired = subprocess.TimeoutExpired
+
+CalledProcessError = subprocess.CalledProcessError
+
+CompletedProcess = subprocess.CompletedProcess
+
+
+async def run(
+    *cmd: str,
+    timeout: Optional[int] = None,
+    check: bool = False,
+    encoding: Optional[str] = None,
+    **kwargs: Any,
+):
+    """Asynchronous analogue of the ``subprocess.run`` call.
+
+    :param cmd: The arguments used to launch the process.
+    :param timeout: If the timeout expires, the child process will be killed.
+    :param check: If ``True`` and the process exists with non-zero exit code,
+        a ``CalledProcessError`` exception will be raised.
+    :param encoding: If set, stdout and stderr are decoded with
+        specified encoding.
+    :param kwargs: Passed to the ``asyncio.create_subprocess_exec``.
+    :return:
+    """
+    process = await asyncio.create_subprocess_exec(*cmd, **kwargs)
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout)
+    except asyncio.TimeoutError:
+        process.kill()
+        await process.wait()
+        # NOTE(cutwater): This is a workaround for issue in CPython
+        #  https://github.com/python/cpython/issues/88050
+        #  which is expected to be fixed in 3.11
+        process._transport.close()
+        raise subprocess.TimeoutExpired(cmd, timeout, None, None)
+
+    if encoding is not None:
+        if stdout is not None:
+            stdout = stdout.decode(encoding)
+        if stderr is not None:
+            stderr = stderr.decode(encoding)
+
+    if check and process.returncode != 0:
+        raise subprocess.CalledProcessError(
+            process.returncode, cmd, stdout, stderr
+        )
+
+    return subprocess.CompletedProcess(cmd, process.returncode, stdout, stderr)


### PR DESCRIPTION
* Fix `git clone` waiting for interactive input when trying to clone private or non-existing GitHub repository.
* Add timeout for `git` commands.
* The `git_hash` project field is now read only.

Resolves: https://issues.redhat.com/browse/AAP-4833
Resolves: https://issues.redhat.com/browse/AAP-6185