### PR TITLE
Fix 500 error bug on Activation Instance creation

### DIFF
--- a/src/eda_server/messages.py
+++ b/src/eda_server/messages.py
@@ -1,5 +1,12 @@
 from typing import NamedTuple
 
+from pydantic import BaseModel
+
 
 class JobEnd(NamedTuple):
     job_id: str
+
+
+class ActivationErrorMessage(BaseModel):
+    message: str
+    detail: str


### PR DESCRIPTION
Fix an internal server error bug that occurs when creating Activation Instance.

When creating Activation Instance through the following endpoint http://localhost:8080/api/activation_instance , an ambiguous 500 internal server error is thrown. Add a fix to generate more meaningful error message. 

Testing: 
1. Try to create an Activation Instance on http://localhost:8080/api/activation_instance with the following bad request body:
```
{
    "name": "test",
    "rulebook_id": "1",
    "inventory_id": "1",
    "extra_var_id": "1",
    "project_id": "1",
    "working_directory": "/tmp",
    "execution_environment": "adfdf"
}
```
2. Verify that you get a response similar to the following:
```
{
    "message": "Error occurred while activating rulesets.",
    "detail": "DockerError(404, 'No such image: adfdf:latest')"
}
```

Resolves: AAP-6256