### PR TITLE
[AAP-5991] Add API permission checks

### DIFF
--- a/src/eda_server/api/activation.py
+++ b/src/eda_server/api/activation.py
@@ -11,6 +11,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from eda_server import schema
+from eda_server.auth import requires_permission
 from eda_server.config import Settings, get_settings
 from eda_server.db import models
 from eda_server.db.dependency import get_db_session, get_db_session_factory
@@ -19,6 +20,7 @@ from eda_server.db.utils.lostream import PGLargeObject, decode_bytes_buff
 from eda_server.managers import updatemanager
 from eda_server.messages import ActivationErrorMessage
 from eda_server.ruleset import activate_rulesets, inactivate_rulesets
+from eda_server.types import Action, ResourceType
 
 logger = logging.getLogger("eda_server")
 
@@ -31,6 +33,9 @@ router = APIRouter(tags=["activations"])
     "/api/activations",
     response_model=schema.ActivationBaseRead,
     operation_id="create_activation",
+    dependencies=[
+        Depends(requires_permission(ResourceType.ACTIVATION, Action.CREATE)),
+    ],
 )
 async def create_activation(
     activation: schema.ActivationCreate,
@@ -77,6 +82,9 @@ async def create_activation(
     "/api/activations/{activation_id}",
     response_model=schema.ActivationRead,
     operation_id="show_activation",
+    dependencies=[
+        Depends(requires_permission(ResourceType.ACTIVATION, Action.READ)),
+    ],
 )
 async def read_activation(
     activation_id: int, db: AsyncSession = Depends(get_db_session)
@@ -138,6 +146,9 @@ async def read_activation(
     "/api/activations",
     response_model=List[schema.ActivationRead],
     operation_id="list_activations",
+    dependencies=[
+        Depends(requires_permission(ResourceType.ACTIVATION, Action.READ)),
+    ],
 )
 async def list_activations(
     db: AsyncSession = Depends(get_db_session),
@@ -157,6 +168,9 @@ async def list_activations(
     "/api/activations/{activation_id}",
     response_model=schema.ActivationBaseRead,
     operation_id="update_activation",
+    dependencies=[
+        Depends(requires_permission(ResourceType.ACTIVATION, Action.UPDATE)),
+    ],
 )
 async def update_activation(
     activation_id: int,
@@ -202,6 +216,9 @@ async def update_activation(
     "/api/activations/{activation_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     operation_id="delete_activation",
+    dependencies=[
+        Depends(requires_permission(ResourceType.ACTIVATION, Action.DELETE)),
+    ],
 )
 async def delete_activation(
     activation_id: int, db: AsyncSession = Depends(get_db_session)
@@ -253,6 +270,13 @@ async def read_output(proc, activation_instance_id, db_session_factory):
         }
     },
     operation_id="create_activation_instance",
+    dependencies=[
+        Depends(
+            requires_permission(
+                ResourceType.ACTIVATION_INSTANCE, Action.CREATE
+            )
+        ),
+    ],
 )
 async def create_activation_instance(
     a: schema.ActivationInstanceCreate,
@@ -331,16 +355,32 @@ async def create_activation_instance(
     return {**a.dict(), "id": id_}
 
 
-@router.post("/api/deactivate", operation_id="deactivate_activation_instance")
+# FIXME(cutwater): The URL is not related to activation instances.
+# TODO(cutwater): Maybe should be "activation_instance:deactivate"
+@router.post(
+    "/api/deactivate",
+    operation_id="deactivate_activation_instance",
+    dependencies=[
+        Depends(
+            requires_permission(
+                ResourceType.ACTIVATION_INSTANCE, Action.UPDATE
+            )
+        ),
+    ],
+)
 async def deactivate(activation_instance_id: int):
     await inactivate_rulesets(activation_instance_id)
-    return
 
 
 @router.get(
     "/api/activation_instances",
     response_model=List[schema.ActivationInstanceBaseRead],
     operation_id="list_activation_instances",
+    dependencies=[
+        Depends(
+            requires_permission(ResourceType.ACTIVATION_INSTANCE, Action.READ)
+        ),
+    ],
 )
 async def list_activation_instances(
     db: AsyncSession = Depends(get_db_session),
@@ -354,6 +394,11 @@ async def list_activation_instances(
     "/api/activation_instance/{activation_instance_id}",
     response_model=schema.ActivationInstanceRead,
     operation_id="read_activation_instance",
+    dependencies=[
+        Depends(
+            requires_permission(ResourceType.ACTIVATION_INSTANCE, Action.READ)
+        ),
+    ],
 )
 async def read_activation_instance(
     activation_instance_id: int, db: AsyncSession = Depends(get_db_session)
@@ -384,6 +429,13 @@ async def read_activation_instance(
     "/api/activation_instance/{activation_instance_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     operation_id="delete_activation_instance",
+    dependencies=[
+        Depends(
+            requires_permission(
+                ResourceType.ACTIVATION_INSTANCE, Action.DELETE
+            )
+        ),
+    ],
 )
 async def delete_activation_instance(
     activation_instance_id: int, db: AsyncSession = Depends(get_db_session)
@@ -402,11 +454,15 @@ async def delete_activation_instance(
     "/api/activation_instance_logs",
     operation_id="list_activation_instance_logs",
     response_model=List[schema.ActivationLog],
+    dependencies=[
+        Depends(
+            requires_permission(ResourceType.ACTIVATION_INSTANCE, Action.READ)
+        ),
+    ],
 )
 async def stream_activation_instance_logs(
     activation_instance_id: int,
     db: AsyncSession = Depends(get_db_session),
-    settings: Settings = Depends(get_settings),
 ):
     query = sa.select(models.activation_instances.c.large_data_id).where(
         models.activation_instances.c.id == activation_instance_id
@@ -431,6 +487,11 @@ async def stream_activation_instance_logs(
     "/api/activation_instance_job_instances/{activation_instance_id}",
     response_model=List[schema.ActivationInstanceJobInstance],
     operation_id="list_activation_instance_job_instances",
+    dependencies=[
+        Depends(
+            requires_permission(ResourceType.ACTIVATION_INSTANCE, Action.READ)
+        ),
+    ],
 )
 async def list_activation_instance_job_instances(
     activation_instance_id: int, db: AsyncSession = Depends(get_db_session)

--- a/src/eda_server/api/audit_rule.py
+++ b/src/eda_server/api/audit_rule.py
@@ -6,8 +6,10 @@ from fastapi.exceptions import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from eda_server import schema
+from eda_server.auth import requires_permission
 from eda_server.db import models
 from eda_server.db.dependency import get_db_session
+from eda_server.types import Action, ResourceType
 
 router = APIRouter(tags=["audit_rules"])
 
@@ -16,6 +18,9 @@ router = APIRouter(tags=["audit_rules"])
     "/api/audit/rule/{rule_id}/details",
     response_model=schema.AuditRule,
     operation_id="read_audit_rule_details",
+    dependencies=[
+        Depends(requires_permission(ResourceType.AUDIT_RULE, Action.READ)),
+    ],
 )
 async def read_audit_rule_details(
     rule_id: int, db: AsyncSession = Depends(get_db_session)
@@ -67,6 +72,9 @@ async def read_audit_rule_details(
     "/api/audit/rule/{rule_id}/jobs",
     response_model=List[schema.AuditRuleJobInstance],
     operation_id="list_audit_rule_jobs",
+    dependencies=[
+        Depends(requires_permission(ResourceType.AUDIT_RULE, Action.READ)),
+    ],
 )
 async def list_audit_rule_jobs(
     rule_id: int, db: AsyncSession = Depends(get_db_session)
@@ -100,6 +108,9 @@ async def list_audit_rule_jobs(
     "/api/audit/rule/{rule_id}/hosts",
     response_model=List[schema.AuditRuleHost],
     operation_id="list_audit_rule_hosts",
+    dependencies=[
+        Depends(requires_permission(ResourceType.AUDIT_RULE, Action.READ)),
+    ],
 )
 async def list_audit_rule_hosts(
     rule_id: int, db: AsyncSession = Depends(get_db_session)
@@ -145,6 +156,9 @@ async def list_audit_rule_hosts(
     "/api/audit/rule/{rule_id}/events",
     response_model=List[schema.AuditRuleJobInstanceEvent],
     operation_id="list_audit_rule_events",
+    dependencies=[
+        Depends(requires_permission(ResourceType.AUDIT_RULE, Action.READ)),
+    ],
 )
 async def list_audit_rule_events(
     rule_id: int, db: AsyncSession = Depends(get_db_session)

--- a/src/eda_server/api/job.py
+++ b/src/eda_server/api/job.py
@@ -10,10 +10,12 @@ from fastapi.exceptions import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from eda_server import schema
+from eda_server.auth import requires_permission
 from eda_server.db import models
 from eda_server.db.dependency import get_db_session, get_db_session_factory
 from eda_server.managers import taskmanager
 from eda_server.ruleset import run_job, write_job_events
+from eda_server.types import Action, ResourceType
 
 logger = logging.getLogger("eda_server")
 
@@ -26,6 +28,7 @@ router = APIRouter(tags=["jobs"])
     "/api/job_instances/",
     response_model=List[schema.JobInstanceBaseRead],
     operation_id="list_job_instances",
+    dependencies=[Depends(requires_permission(ResourceType.JOB, Action.READ))],
 )
 async def list_job_instances(db: AsyncSession = Depends(get_db_session)):
     query = sa.select(models.job_instances)
@@ -37,6 +40,9 @@ async def list_job_instances(db: AsyncSession = Depends(get_db_session)):
     "/api/job_instance/",
     response_model=schema.JobInstanceRead,
     operation_id="create_job_instance",
+    dependencies=[
+        Depends(requires_permission(ResourceType.JOB, Action.CREATE))
+    ],
 )
 async def create_job_instance(
     j: schema.JobInstanceCreate,
@@ -95,6 +101,7 @@ async def create_job_instance(
     "/api/job_instance/{job_instance_id}",
     response_model=schema.JobInstanceBaseRead,
     operation_id="read_job_instance",
+    dependencies=[Depends(requires_permission(ResourceType.JOB, Action.READ))],
 )
 async def read_job_instance(
     job_instance_id: int, db: AsyncSession = Depends(get_db_session)
@@ -110,6 +117,9 @@ async def read_job_instance(
     "/api/job_instance/{job_instance_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     operation_id="delete_job_instance",
+    dependencies=[
+        Depends(requires_permission(ResourceType.JOB, Action.DELETE))
+    ],
 )
 async def delete_job_instance(
     job_instance_id: int, db: AsyncSession = Depends(get_db_session)
@@ -127,6 +137,7 @@ async def delete_job_instance(
 @router.get(
     "/api/job_instance_events/{job_instance_id}",
     operation_id="read_job_instance_events",
+    dependencies=[Depends(requires_permission(ResourceType.JOB, Action.READ))],
 )
 async def read_job_instance_events(
     job_instance_id: int, db: AsyncSession = Depends(get_db_session)

--- a/src/eda_server/api/project.py
+++ b/src/eda_server/api/project.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from eda_server import schema
+from eda_server.auth import requires_permission
 from eda_server.db.dependency import get_db_session
 from eda_server.db.models.project import (
     extra_vars,
@@ -15,6 +16,7 @@ from eda_server.db.models.project import (
 )
 from eda_server.db.models.rulebook import rulebooks
 from eda_server.project import GitCommandFailed, import_project
+from eda_server.types import Action, ResourceType
 
 router = APIRouter()
 
@@ -34,6 +36,9 @@ async def project_by_name_exists_or_404(db: AsyncSession, project_name: str):
     response_model=List[schema.ProjectList],
     operation_id="list_projects",
     tags=["projects"],
+    dependencies=[
+        Depends(requires_permission(ResourceType.PROJECT, Action.READ))
+    ],
 )
 async def list_projects(db: AsyncSession = Depends(get_db_session)):
     query = sa.select(projects.c.id, projects.c.url, projects.c.name)
@@ -47,6 +52,9 @@ async def list_projects(db: AsyncSession = Depends(get_db_session)):
     operation_id="create_project",
     status_code=status.HTTP_201_CREATED,
     tags=["projects"],
+    dependencies=[
+        Depends(requires_permission(ResourceType.PROJECT, Action.CREATE))
+    ],
 )
 async def create_project(
     data: schema.ProjectCreate, db: AsyncSession = Depends(get_db_session)
@@ -72,6 +80,9 @@ async def create_project(
     response_model=schema.ProjectDetail,
     operation_id="read_project",
     tags=["projects"],
+    dependencies=[
+        Depends(requires_permission(ResourceType.PROJECT, Action.READ))
+    ],
 )
 async def read_project(
     project_id: int, db: AsyncSession = Depends(get_db_session)
@@ -127,6 +138,9 @@ async def read_project(
     response_model=schema.ProjectRead,
     operation_id="update_project",
     tags=["projects"],
+    dependencies=[
+        Depends(requires_permission(ResourceType.PROJECT, Action.UPDATE))
+    ],
 )
 async def update_project(
     project_id: int,
@@ -184,6 +198,9 @@ async def update_project(
     status_code=status.HTTP_204_NO_CONTENT,
     operation_id="delete_project",
     tags=["projects"],
+    dependencies=[
+        Depends(requires_permission(ResourceType.PROJECT, Action.DELETE))
+    ],
 )
 async def delete_project(
     project_id: int, db: AsyncSession = Depends(get_db_session)
@@ -201,6 +218,9 @@ async def delete_project(
     response_model=List[schema.PlaybookRead],
     operation_id="list_playbooks",
     tags=["playbooks"],
+    dependencies=[
+        Depends(requires_permission(ResourceType.PLAYBOOK, Action.READ))
+    ],
 )
 async def list_playbooks(db: AsyncSession = Depends(get_db_session)):
     query = sa.select(playbooks)
@@ -213,6 +233,9 @@ async def list_playbooks(db: AsyncSession = Depends(get_db_session)):
     response_model=schema.PlaybookRead,
     operation_id="read_playbook",
     tags=["playbooks"],
+    dependencies=[
+        Depends(requires_permission(ResourceType.PLAYBOOK, Action.READ))
+    ],
 )
 async def read_playbook(
     playbook_id: int, db: AsyncSession = Depends(get_db_session)
@@ -232,6 +255,9 @@ async def read_playbook(
     response_model=List[schema.InventoryRead],
     operation_id="list_inventories",
     tags=["inventories"],
+    dependencies=[
+        Depends(requires_permission(ResourceType.INVENTORY, Action.READ))
+    ],
 )
 async def list_inventories(db: AsyncSession = Depends(get_db_session)):
     query = sa.select(inventories)
@@ -244,6 +270,9 @@ async def list_inventories(db: AsyncSession = Depends(get_db_session)):
     response_model=schema.InventoryRead,
     operation_id="read_inventory",
     tags=["inventories"],
+    dependencies=[
+        Depends(requires_permission(ResourceType.INVENTORY, Action.READ))
+    ],
 )
 async def read_inventory(
     inventory_id: int, db: AsyncSession = Depends(get_db_session)
@@ -263,6 +292,9 @@ async def read_inventory(
     response_model=schema.InventoryRead,
     operation_id="create_inventory",
     tags=["inventories"],
+    dependencies=[
+        Depends(requires_permission(ResourceType.INVENTORY, Action.CREATE))
+    ],
 )
 async def create_inventory(
     i: schema.InventoryCreate, db: AsyncSession = Depends(get_db_session)
@@ -279,6 +311,9 @@ async def create_inventory(
     response_model=List[schema.ExtraVarsRead],
     operation_id="list_extra_vars",
     tags=["extra vars"],
+    dependencies=[
+        Depends(requires_permission(ResourceType.EXTRA_VAR, Action.READ))
+    ],
 )
 async def list_extra_vars(db: AsyncSession = Depends(get_db_session)):
     query = sa.select(extra_vars)
@@ -291,6 +326,9 @@ async def list_extra_vars(db: AsyncSession = Depends(get_db_session)):
     response_model=schema.ExtraVarsRead,
     operation_id="read_extra_var",
     tags=["extra vars"],
+    dependencies=[
+        Depends(requires_permission(ResourceType.EXTRA_VAR, Action.READ))
+    ],
 )
 async def read_extra_var(
     extra_var_id: int, db: AsyncSession = Depends(get_db_session)
@@ -310,6 +348,9 @@ async def read_extra_var(
     response_model=schema.ExtraVarsRead,
     operation_id="create_extra_vars",
     tags=["extra vars"],
+    dependencies=[
+        Depends(requires_permission(ResourceType.EXTRA_VAR, Action.CREATE))
+    ],
 )
 async def create_extra_vars(
     e: schema.ExtraVarsCreate, db: AsyncSession = Depends(get_db_session)

--- a/src/eda_server/api/rulebook.py
+++ b/src/eda_server/api/rulebook.py
@@ -6,9 +6,11 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from eda_server import schema
+from eda_server.auth import requires_permission
 from eda_server.db import models
 from eda_server.db.dependency import get_db_session
 from eda_server.project import insert_rulebook_related_data
+from eda_server.types import Action, ResourceType
 
 router = APIRouter(tags=["rulebooks"])
 
@@ -22,6 +24,9 @@ router = APIRouter(tags=["rulebooks"])
     "/api/rules",
     response_model=List[schema.Rule],
     operation_id="list_rules",
+    dependencies=[
+        Depends(requires_permission(ResourceType.RULEBOOK, Action.READ)),
+    ],
 )
 async def list_rules(db: AsyncSession = Depends(get_db_session)):
     query = (
@@ -57,6 +62,9 @@ async def list_rules(db: AsyncSession = Depends(get_db_session)):
     "/api/rules/{rule_id}",
     response_model=schema.Rule,
     operation_id="read_rule",
+    dependencies=[
+        Depends(requires_permission(ResourceType.RULEBOOK, Action.READ)),
+    ],
 )
 async def read_rule(rule_id: int, db: AsyncSession = Depends(get_db_session)):
     query = (
@@ -150,6 +158,9 @@ BASE_RULESET_SELECT = (
     "/api/rulesets",
     response_model=List[schema.Ruleset],
     operation_id="list_rulesets",
+    dependencies=[
+        Depends(requires_permission(ResourceType.RULEBOOK, Action.READ)),
+    ],
 )
 async def list_rulesets(db: AsyncSession = Depends(get_db_session)):
     cur = await db.execute(BASE_RULESET_SELECT)
@@ -161,6 +172,9 @@ async def list_rulesets(db: AsyncSession = Depends(get_db_session)):
     "/api/rulesets/{ruleset_id}",
     response_model=schema.RulesetDetail,
     operation_id="read_ruleset",
+    dependencies=[
+        Depends(requires_permission(ResourceType.RULEBOOK, Action.READ)),
+    ],
 )
 async def get_ruleset(
     ruleset_id: int, db: AsyncSession = Depends(get_db_session)
@@ -201,7 +215,13 @@ rulebook_fire_count = (
 ).cte("rulebook_fire_count")
 
 
-@router.post("/api/rulebooks", operation_id="create_rulebook")
+@router.post(
+    "/api/rulebooks",
+    operation_id="create_rulebook",
+    dependencies=[
+        Depends(requires_permission(ResourceType.RULEBOOK, Action.CREATE)),
+    ],
+)
 async def create_rulebook(
     rulebook: schema.RulebookCreate, db: AsyncSession = Depends(get_db_session)
 ):
@@ -224,6 +244,9 @@ async def create_rulebook(
     "/api/rulebooks",
     operation_id="list_rulebooks",
     response_model=List[schema.RulebookList],
+    dependencies=[
+        Depends(requires_permission(ResourceType.RULEBOOK, Action.READ)),
+    ],
 )
 async def list_rulebooks(db: AsyncSession = Depends(get_db_session)):
     query = (
@@ -255,6 +278,9 @@ async def list_rulebooks(db: AsyncSession = Depends(get_db_session)):
     "/api/rulebooks/{rulebook_id}",
     operation_id="read_rulebook",
     response_model=schema.RulebookRead,
+    dependencies=[
+        Depends(requires_permission(ResourceType.RULEBOOK, Action.READ)),
+    ],
 )
 async def read_rulebook(
     rulebook_id: int, db: AsyncSession = Depends(get_db_session)
@@ -294,7 +320,11 @@ async def read_rulebook(
 
 
 @router.get(
-    "/api/rulebook_json/{rulebook_id}", operation_id="read_rulebook_json"
+    "/api/rulebook_json/{rulebook_id}",
+    operation_id="read_rulebook_json",
+    dependencies=[
+        Depends(requires_permission(ResourceType.RULEBOOK, Action.READ)),
+    ],
 )
 async def read_rulebook_json(
     rulebook_id: int, db: AsyncSession = Depends(get_db_session)
@@ -336,6 +366,9 @@ async def read_rulebook_json(
     "/api/rulebooks/{rulebook_id}/rulesets",
     operation_id="list_rulebook_rulesets",
     response_model=List[schema.RulebookRulesetList],
+    dependencies=[
+        Depends(requires_permission(ResourceType.RULEBOOK, Action.READ)),
+    ],
 )
 async def list_rulebook_rulesets(
     rulebook_id: int, db: AsyncSession = Depends(get_db_session)

--- a/src/eda_server/api/task.py
+++ b/src/eda_server/api/task.py
@@ -1,11 +1,19 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from eda_server.auth import requires_permission
 from eda_server.managers import taskmanager
+from eda_server.types import Action, ResourceType
 
 router = APIRouter(prefix="/api/tasks", tags=["tasks"])
 
 
-@router.get("", operation_id="list_tasks")
+@router.get(
+    "",
+    operation_id="list_tasks",
+    dependencies=[
+        Depends(requires_permission(ResourceType.TASK, Action.READ))
+    ],
+)
 async def list_tasks():
     tasks = [
         {

--- a/src/eda_server/api/user.py
+++ b/src/eda_server/api/user.py
@@ -7,8 +7,10 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from eda_server import auth, schema
+from eda_server.auth import requires_permission
 from eda_server.db import models
 from eda_server.db.dependency import get_db_session
+from eda_server.types import Action, ResourceType
 from eda_server.users import current_active_user, fastapi_users
 
 router = APIRouter(prefix="/api/users", tags=["users"])
@@ -65,6 +67,9 @@ async def list_me_roles(
     "/{user_id}/roles",
     operation_id="list_user_roles",
     response_model=List[schema.RoleRead],
+    dependencies=[
+        Depends(requires_permission(ResourceType.USER, Action.READ))
+    ],
 )
 async def list_user_roles(
     user_id: uuid.UUID,
@@ -79,6 +84,9 @@ async def list_user_roles(
     "/{user_id}/roles/{role_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     operation_id="add_user_role",
+    dependencies=[
+        Depends(requires_permission(ResourceType.USER, Action.UPDATE))
+    ],
 )
 async def add_user_role(
     user_id: uuid.UUID,
@@ -101,6 +109,9 @@ async def add_user_role(
     "/{user_id}/roles/{role_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     operation_id="remove_user_role",
+    dependencies=[
+        Depends(requires_permission(ResourceType.USER, Action.UPDATE))
+    ],
 )
 async def remove_user_role(
     user_id: uuid.UUID,
@@ -132,6 +143,9 @@ async def list_me_permissions(
     "/{user_id}/permissions",
     operation_id="list_user_permissions",
     response_model=List[str],
+    dependencies=[
+        Depends(requires_permission(ResourceType.USER, Action.READ))
+    ],
 )
 async def list_user_permissions(
     user_id: uuid.UUID,

--- a/src/eda_server/db/migrations/versions/202210261523_f592f6ef1e3a_new_rbac_enum_values.py
+++ b/src/eda_server/db/migrations/versions/202210261523_f592f6ef1e3a_new_rbac_enum_values.py
@@ -1,0 +1,36 @@
+"""New RBAC enum values.
+
+Revision ID: f592f6ef1e3a
+Revises: c703cd56f6b0
+Create Date: 2022-10-26 15:23:06.016126+00:00
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f592f6ef1e3a"
+down_revision = "c703cd56f6b0"
+branch_labels = None
+depends_on = None
+
+
+RESOURCE_TYPES = [
+    "activation",
+    "activation_instance",
+    "audit_rule",
+    "job",
+    "task",
+]
+ADD_RESOURCE_TYPE_QUERY = """\
+ALTER TYPE "resource_type_enum" ADD VALUE IF NOT EXISTS '{value}'
+"""
+
+
+def upgrade() -> None:
+    for value in RESOURCE_TYPES:
+        op.execute(sa.text(ADD_RESOURCE_TYPE_QUERY.format(value=value)))
+
+
+def downgrade() -> None:
+    pass

--- a/src/eda_server/types.py
+++ b/src/eda_server/types.py
@@ -2,6 +2,12 @@ from enum import Enum
 
 
 class ResourceType(Enum):
+    ACTIVATION = "activation"
+    ACTIVATION_INSTANCE = "activation_instance"
+    AUDIT_RULE = "audit_rule"
+    JOB = "job"
+    TASK = "task"
+    USER = "user"
     PROJECT = "project"
     INVENTORY = "inventory"
     EXTRA_VAR = "extra_var"

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -1,0 +1,42 @@
+from unittest import mock
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from eda_server.auth import check_permission
+from eda_server.db import models
+from eda_server.users import UserDatabase, current_active_user
+from tests.integration.utils.app import override_dependencies
+
+
+@pytest_asyncio.fixture
+async def admin_user(db: AsyncSession):
+    user = await UserDatabase(db).create(
+        {
+            "email": "admin@example.com",
+            "hashed_password": "",
+            "is_superuser": True,
+        }
+    )
+    # NOTE(cutwater): Commit transaction implicitly opened by
+    #   UserDatabase as a side effect. Need better API for creating users.
+    await db.commit()
+    return user
+
+
+@pytest.fixture
+def app(app: FastAPI, admin_user: models.User):
+    dependencies = {
+        current_active_user: lambda: admin_user,
+    }
+    with override_dependencies(app, dependencies):
+        yield app
+
+
+@pytest.fixture
+def check_permission_spy():
+    m = mock.AsyncMock(wraps=check_permission)
+    with mock.patch("eda_server.auth.check_permission", m):
+        yield m

--- a/tests/integration/api/test_inventory.py
+++ b/tests/integration/api/test_inventory.py
@@ -1,53 +1,17 @@
+from unittest import mock
+
 import sqlalchemy as sa
 from fastapi import status as status_codes
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from eda_server.db import models
-
-TEST_RULESET_SIMPLE = """
----
-- name: Test simple
-  hosts: all
-  sources:
-    - name: range
-      range:
-        limit: 5
-  rules:
-    - name:
-      condition: event.i == 1
-      action:
-        debug:
-"""
+from eda_server.types import Action, ResourceType
 
 
-async def test_create_rulebook(client: AsyncClient, db: AsyncSession):
-    response = await client.post(
-        "/api/rulebooks",
-        json={
-            "name": "test-ruleset-1.yml",
-            "rulesets": TEST_RULESET_SIMPLE,
-        },
-    )
-    assert response.status_code == status_codes.HTTP_200_OK
-    data = response.json()
-    assert "id" in data
-    assert data["name"] == "test-ruleset-1.yml"
-
-    rulesets = (await db.execute(sa.select(models.rulesets))).all()
-    assert len(rulesets) == 1
-    ruleset = rulesets[0]
-    assert ruleset["rulebook_id"] == data["id"]
-    assert ruleset["name"] == "Test simple"
-
-    rules = (await db.execute(sa.select(models.rules))).all()
-    assert len(rules) == 1
-    rule = rules[0]
-    assert rule["ruleset_id"] == ruleset["id"]
-    assert rule["action"] == {"debug": None}
-
-
-async def test_create_inventory(client: AsyncClient):
+async def test_create_inventory(
+    client: AsyncClient, check_permission_spy: mock.Mock
+):
     response = await client.post(
         "/api/inventory/",
         json={
@@ -60,9 +24,14 @@ async def test_create_inventory(client: AsyncClient):
     assert "id" in data
     assert data["name"] == "test-inventory-01"
     assert data["inventory"] == "all: {}"  # noqa: P103
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.INVENTORY, Action.CREATE
+    )
 
 
-async def test_list_inventories(client: AsyncClient, db: AsyncSession):
+async def test_list_inventories(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     query = sa.insert(models.inventories).values(
         name="test-list-inventories-01", inventory="{}"  # noqa: P103
     )
@@ -80,9 +49,14 @@ async def test_list_inventories(client: AsyncClient, db: AsyncSession):
             "project_id": None,
         }
     ]
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.INVENTORY, Action.READ
+    )
 
 
-async def test_read_inventory_not_found(client: AsyncClient):
+async def test_read_inventory_not_found(
+    client: AsyncClient, check_permission_spy: mock.Mock
+):
 
     response = await client.get("/api/inventory/42")
 

--- a/tests/integration/api/test_playbook.py
+++ b/tests/integration/api/test_playbook.py
@@ -1,3 +1,4 @@
+# TODO(cutwater): Add unit tests for API endpoints
 from fastapi import status as status_codes
 from httpx import AsyncClient
 

--- a/tests/integration/api/test_project.py
+++ b/tests/integration/api/test_project.py
@@ -4,9 +4,11 @@ from unittest import mock
 import sqlalchemy as sa
 from fastapi import status as status_codes
 from httpx import AsyncClient
+from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from eda_server.db import models
+from eda_server.types import Action, ResourceType
 
 TEST_PROJECT = {
     "url": "https://git.example.com/sample/test-project",
@@ -43,76 +45,67 @@ TEST_RULEBOOK = """
 TEST_PLAYBOOK = TEST_RULEBOOK
 
 
-async def test_create_delete_project(client: AsyncClient, db: AsyncSession):
+async def test_delete_project(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     query = sa.insert(models.projects).values(
         url=TEST_PROJECT["url"],
         name=TEST_PROJECT["name"],
         description=TEST_PROJECT["description"],
     )
     result = await db.execute(query)
-
-    (inserted_project_id,) = result.inserted_primary_key
+    (project_id,) = result.inserted_primary_key
 
     query = sa.insert(models.extra_vars).values(
         name="vars.yml",
         extra_var=TEST_EXTRA_VAR,
-        project_id=inserted_project_id,
+        project_id=project_id,
     )
     await db.execute(query)
 
     query = sa.insert(models.inventories).values(
         name="inventory.yml",
         inventory=TEST_INVENTORY,
-        project_id=inserted_project_id,
+        project_id=project_id,
     )
     await db.execute(query)
 
     query = sa.insert(models.rulebooks).values(
         name="ruleset.yml",
         rulesets=TEST_RULEBOOK,
-        project_id=inserted_project_id,
+        project_id=project_id,
     )
     await db.execute(query)
 
     query = sa.insert(models.playbooks).values(
         name="hello.yml",
         playbook=TEST_PLAYBOOK,
-        project_id=inserted_project_id,
+        project_id=project_id,
     )
     await db.execute(query)
+    await db.commit()
 
-    projects = (await db.execute(sa.select(models.projects))).all()
-    assert len(projects) == 1
-
-    extra_vars = (await db.execute(sa.select(models.extra_vars))).all()
-    assert len(extra_vars) == 1
-
-    inventories = (await db.execute(sa.select(models.inventories))).all()
-    assert len(inventories) == 1
-
-    rulebooks = (await db.execute(sa.select(models.rulebooks))).all()
-    assert len(rulebooks) == 1
-
-    playbooks = (await db.execute(sa.select(models.playbooks))).all()
-    assert len(playbooks) == 1
-
-    response = await client.delete(f"/api/projects/{projects[0].id}")
+    response = await client.delete(f"/api/projects/{project_id}")
     assert response.status_code == status_codes.HTTP_204_NO_CONTENT
+    assert 0 == await db.scalar(
+        sa.select(func.count()).select_from(models.projects)
+    )
+    assert 0 == await db.scalar(
+        sa.select(func.count()).select_from(models.extra_vars)
+    )
+    assert 0 == await db.scalar(
+        sa.select(func.count()).select_from(models.inventories)
+    )
+    assert 0 == await db.scalar(
+        sa.select(func.count()).select_from(models.rulebooks)
+    )
+    assert 0 == await db.scalar(
+        sa.select(func.count()).select_from(models.playbooks)
+    )
 
-    projects = (await db.execute(sa.select(models.projects))).all()
-    assert len(projects) == 0
-
-    extra_vars = (await db.execute(sa.select(models.extra_vars))).all()
-    assert len(extra_vars) == 0
-
-    inventories = (await db.execute(sa.select(models.inventories))).all()
-    assert len(inventories) == 0
-
-    rulebooks = (await db.execute(sa.select(models.rulebooks))).all()
-    assert len(rulebooks) == 0
-
-    playbooks = (await db.execute(sa.select(models.playbooks))).all()
-    assert len(playbooks) == 0
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.PROJECT, Action.DELETE
+    )
 
 
 async def test_delete_project_not_found(client: AsyncClient):
@@ -129,6 +122,7 @@ async def test_create_project(
     tempfile: mock.Mock(),
     client: AsyncClient,
     db: AsyncSession,
+    check_permission_spy: mock.Mock,
 ):
     tempfile.return_value.__enter__.return_value = "/tmp/test-create-project"
     found_hash = hashlib.sha1(b"test").hexdigest()
@@ -154,11 +148,12 @@ async def test_create_project(
     sync_project.assert_called_once_with(
         db, project["id"], project["large_data_id"], "/tmp/test-create-project"
     )
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.PROJECT, Action.CREATE
+    )
 
 
-async def test_create_project_bad_entity(
-    client: AsyncClient, db: AsyncSession
-):
+async def test_create_project_bad_entity(client: AsyncClient):
     bad_project = {
         "url": None,
         "name": "Test Name",
@@ -218,7 +213,9 @@ async def test_create_project_missing_name(client: AsyncClient):
     assert response.status_code == status_codes.HTTP_422_UNPROCESSABLE_ENTITY
 
 
-async def test_get_project(client: AsyncClient, db: AsyncSession):
+async def test_read_project(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     query = sa.insert(models.projects).values(
         url=TEST_PROJECT["url"],
         name=TEST_PROJECT["name"],
@@ -237,9 +234,12 @@ async def test_get_project(client: AsyncClient, db: AsyncSession):
     data = response.json()
     assert data["name"] == TEST_PROJECT["name"]
     assert data["url"] == TEST_PROJECT["url"]
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.PROJECT, Action.READ
+    )
 
 
-async def test_get_project_not_found(client: AsyncClient, db: AsyncSession):
+async def test_read_project_not_found(client: AsyncClient, db: AsyncSession):
 
     query = sa.insert(models.projects).values(
         url=TEST_PROJECT["url"],
@@ -254,8 +254,9 @@ async def test_get_project_not_found(client: AsyncClient, db: AsyncSession):
     assert response.status_code == status_codes.HTTP_404_NOT_FOUND
 
 
-async def test_edit_project(client: AsyncClient, db: AsyncSession):
-
+async def test_update_project(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     query = sa.insert(models.projects).values(
         url=TEST_PROJECT["url"],
         name=TEST_PROJECT["name"],
@@ -278,9 +279,12 @@ async def test_edit_project(client: AsyncClient, db: AsyncSession):
     data = response.json()
     assert data["name"] == "new test name"
     assert data["url"] == TEST_PROJECT["url"]
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.PROJECT, Action.UPDATE
+    )
 
 
-async def test_edit_project_missing(client: AsyncClient, db: AsyncSession):
+async def test_update_project_missing(client: AsyncClient):
 
     response = await client.patch(
         "/api/projects/-1",
@@ -290,7 +294,7 @@ async def test_edit_project_missing(client: AsyncClient, db: AsyncSession):
     assert response.status_code == status_codes.HTTP_404_NOT_FOUND
 
 
-async def test_edit_project_bad_name(client: AsyncClient, db: AsyncSession):
+async def test_update_project_bad_name(client: AsyncClient):
 
     response = await client.patch(
         "/api/projects/1",
@@ -300,7 +304,9 @@ async def test_edit_project_bad_name(client: AsyncClient, db: AsyncSession):
     assert response.status_code == status_codes.HTTP_422_UNPROCESSABLE_ENTITY
 
 
-async def test_edit_project_unique_name(client: AsyncClient, db: AsyncSession):
+async def test_update_project_unique_name(
+    client: AsyncClient, db: AsyncSession
+):
 
     test_projects_values = [
         {
@@ -364,7 +370,9 @@ async def test_edit_project_unique_name(client: AsyncClient, db: AsyncSession):
     assert data["detail"] == expected_msg
 
 
-async def test_get_projects(client: AsyncClient, db: AsyncSession):
+async def test_list_projects(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
 
     test_project_two = {
         "url": "https://github.com/benthomasson/eda-project",
@@ -393,3 +401,6 @@ async def test_get_projects(client: AsyncClient, db: AsyncSession):
     assert len(data) == 2
     assert data[0]["name"] == TEST_PROJECT["name"]
     assert data[1]["url"] == test_project_two["url"]
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.PROJECT, Action.READ
+    )

--- a/tests/integration/api/test_rule.py
+++ b/tests/integration/api/test_rule.py
@@ -1,9 +1,12 @@
+from unittest import mock
+
 import sqlalchemy as sa
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status as status_codes
 
 from eda_server.db import models
+from eda_server.types import Action, ResourceType
 
 TEST_RULESET_SIMPLE = """
 ---
@@ -89,7 +92,9 @@ async def _create_rules(db: AsyncSession):
     return project, rulebook, ruleset, rules
 
 
-async def test_list_rules(client: AsyncClient, db: AsyncSession):
+async def test_list_rules(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     _, _, ruleset, rules = await _create_rules(db)
 
     response = await client.get("/api/rules")
@@ -107,8 +112,14 @@ async def test_list_rules(client: AsyncClient, db: AsyncSession):
         for rule in rules
     ]
 
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.RULEBOOK, Action.READ
+    )
 
-async def test_read_rule(client: AsyncClient, db: AsyncSession):
+
+async def test_read_rule(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     _, _, ruleset, rules = await _create_rules(db)
 
     response = await client.get(f"/api/rules/{rules[0].id}")
@@ -123,8 +134,14 @@ async def test_read_rule(client: AsyncClient, db: AsyncSession):
         },
     }
 
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.RULEBOOK, Action.READ
+    )
 
-async def test_list_rulesets(client: AsyncClient, db: AsyncSession):
+
+async def test_list_rulesets(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     _, rulebook, ruleset, rules = await _create_rules(db)
 
     response = await client.get("/api/rulesets")
@@ -137,8 +154,14 @@ async def test_list_rulesets(client: AsyncClient, db: AsyncSession):
         }
     ]
 
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.RULEBOOK, Action.READ
+    )
 
-async def test_read_ruleset(client: AsyncClient, db: AsyncSession):
+
+async def test_read_ruleset(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     project, rulebook, ruleset, rules = await _create_rules(db)
     response = await client.get(f"/api/rulesets/{ruleset.id}")
     assert response.status_code == status_codes.HTTP_200_OK
@@ -158,7 +181,11 @@ async def test_read_ruleset(client: AsyncClient, db: AsyncSession):
         },
     }
 
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.RULEBOOK, Action.READ
+    )
 
-async def test_read_ruleset_not_found(client: AsyncClient, db: AsyncSession):
+
+async def test_read_ruleset_not_found(client: AsyncClient):
     response = await client.get("/api/rulesets/-1")
     assert response.status_code == status_codes.HTTP_404_NOT_FOUND

--- a/tests/integration/api/test_rulebook.py
+++ b/tests/integration/api/test_rulebook.py
@@ -1,8 +1,62 @@
+from unittest import mock
+
+import sqlalchemy as sa
 from fastapi import status as status_codes
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from eda_server.db import models
+from eda_server.types import Action, ResourceType
+
+TEST_RULESET_SIMPLE = """
+---
+- name: Test simple
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name:
+      condition: event.i == 1
+      action:
+        debug:
+"""
 
 
 async def test_read_rulebook_not_found(client: AsyncClient):
     response = await client.get("/api/rulebooks/42")
 
     assert response.status_code == status_codes.HTTP_404_NOT_FOUND
+
+
+async def test_create_rulebook(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
+    response = await client.post(
+        "/api/rulebooks",
+        json={
+            "name": "test-ruleset-1.yml",
+            "rulesets": TEST_RULESET_SIMPLE,
+        },
+    )
+    assert response.status_code == status_codes.HTTP_200_OK
+    data = response.json()
+    assert "id" in data
+    assert data["name"] == "test-ruleset-1.yml"
+
+    rulesets = (await db.execute(sa.select(models.rulesets))).all()
+    assert len(rulesets) == 1
+    ruleset = rulesets[0]
+    assert ruleset["rulebook_id"] == data["id"]
+    assert ruleset["name"] == "Test simple"
+
+    rules = (await db.execute(sa.select(models.rules))).all()
+    assert len(rules) == 1
+    rule = rules[0]
+    assert rule["ruleset_id"] == ruleset["id"]
+    assert rule["action"] == {"debug": None}
+
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.RULEBOOK, Action.CREATE
+    )

--- a/tests/integration/api/test_user.py
+++ b/tests/integration/api/test_user.py
@@ -1,6 +1,7 @@
 import operator
 import uuid
 from typing import List, Tuple
+from unittest import mock
 
 import pytest
 import sqlalchemy as sa
@@ -16,21 +17,10 @@ from tests.integration.utils.app import override_dependencies
 
 
 @pytest.fixture
-async def admin_user(db: AsyncSession):
-    return await UserDatabase(db).create(
-        {
-            "email": "admin@example.com",
-            "hashed_password": "",
-            "is_superuser": True,
-        }
-    )
-
-
-@pytest.fixture
 async def test_user(db: AsyncSession):
     return await UserDatabase(db).create(
         {
-            "email": "admin@example.com",
+            "email": "test@example.com",
             "hashed_password": "",
         }
     )
@@ -114,7 +104,10 @@ def _check_test_user_permissions_response(response: Response):
 
 
 async def test_add_user_role(
-    client: AsyncClient, db: AsyncSession, test_user: models.User
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: models.User,
+    check_permission_spy: mock.Mock,
 ):
     role_id = await create_role(db, "test-role")
 
@@ -132,6 +125,10 @@ async def test_add_user_role(
         )
     )
     assert role_exists
+
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.USER, Action.UPDATE
+    )
 
 
 async def test_add_user_role_user_not_exist(
@@ -169,7 +166,10 @@ async def test_add_user_role_duplicate(
 
 
 async def test_remove_user_role(
-    client: AsyncClient, db: AsyncSession, test_user: models.User
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: models.User,
+    check_permission_spy: mock.Mock,
 ):
     role_id = await create_role(db, "test-role")
     await add_user_role(db, test_user.id, role_id)
@@ -178,6 +178,10 @@ async def test_remove_user_role(
         f"/api/users/{test_user.id}/roles/{role_id}"
     )
     assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.USER, Action.UPDATE
+    )
 
 
 async def test_remove_user_role_user_not_exist(
@@ -193,7 +197,7 @@ async def test_remove_user_role_user_not_exist(
 
 
 async def test_remove_user_role_role_not_exist(
-    client: AsyncClient, db: AsyncSession, test_user: models.User
+    client: AsyncClient, test_user: models.User
 ):
     invalid_role_id = "42424242-4242-4242-4242-424242424242"
 
@@ -205,35 +209,59 @@ async def test_remove_user_role_role_not_exist(
 
 # Test list roles
 async def test_list_me_roles(
-    app: FastAPI, client: AsyncClient, db: AsyncSession, test_user: models.User
+    app: FastAPI,
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: models.User,
+    check_permission_spy: mock.Mock,
 ):
     role_ids = await _prepare_test_user_roles(db, test_user.id)
     with override_dependencies(app, {current_active_user: lambda: test_user}):
         response = await client.get("/api/users/me/roles")
     _check_test_user_roles_response(response, role_ids)
+    # Only the user themselves is allowed to read their roles
+    check_permission_spy.assert_not_called()
 
 
 async def test_list_user_roles(
-    client: AsyncClient, db: AsyncSession, test_user: models.User
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: models.User,
+    check_permission_spy: mock.Mock,
 ):
     role_ids = await _prepare_test_user_roles(db, test_user.id)
     response = await client.get(f"/api/users/{test_user.id}/roles")
     _check_test_user_roles_response(response, role_ids)
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.USER, Action.READ
+    )
 
 
 # Test list permissions
 async def test_list_me_permissions(
-    app: FastAPI, client: AsyncClient, db: AsyncSession, test_user: models.User
+    app: FastAPI,
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: models.User,
+    check_permission_spy: mock.Mock,
 ):
     await _prepare_test_user_roles(db, test_user.id)
     with override_dependencies(app, {current_active_user: lambda: test_user}):
         response = await client.get("/api/users/me/permissions")
     _check_test_user_permissions_response(response)
+    # Only the user themselves is allowed to read their roles
+    check_permission_spy.assert_not_called()
 
 
 async def test_list_user_permissions(
-    client: AsyncClient, db: AsyncSession, test_user: models.User
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: models.User,
+    check_permission_spy: mock.Mock,
 ):
     await _prepare_test_user_roles(db, test_user.id)
     response = await client.get(f"/api/users/{test_user.id}/permissions")
     _check_test_user_permissions_response(response)
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.USER, Action.READ
+    )

--- a/tools/initial_data.yml
+++ b/tools/initial_data.yml
@@ -11,6 +11,12 @@ roles:
           - 'rulebook'
           - 'execution_env'
           - 'role'
+          - 'activation'
+          - 'activation_instance'
+          - 'audit_rule'
+          - 'job'
+          - 'task'
+          - 'user'
         actions:
           - 'create'
           - 'read'
@@ -27,6 +33,12 @@ roles:
           - 'playbook'
           - 'rulebook'
           - 'execution_env'
+          - 'activation'
+          - 'activation_instance'
+          - 'audit_rule'
+          - 'job'
+          - 'task'
+          - 'user'
         actions:
           - 'read'
           - 'update'
@@ -41,6 +53,10 @@ roles:
           - 'playbook'
           - 'rulebook'
           - 'execution_env'
+          - 'activation'
+          - 'activation_instance'
+          - 'job'
+          - 'task'
         actions:
           - 'read'
 users:


### PR DESCRIPTION
* Modify test suite to make permission checks testing easier.
* Add permission checks and update tests for existing API endpoints.
* Configure `app` fixture for API tests to authenticate as admin user.
* Move `test_create_rulebook` test case to respective tests file.
* Move `admin_user` fixture to API's `conftest.py`.
* Add `check_permission_spy` fixture to test permission checks.
* Add new resource types to sample `initial_data.yml`


Implements: https://issues.redhat.com/browse/AAP-5991

## Testing instructions

1. Load initial data (you may refer to the `initial_data.yml` file for sample permissions).

```
python scripts/initial_data.py tools/initial_data.yml
```

2. Login with any of the existing users (password: `secret`):

    - `root@example.com` 
    - `admin@example.com`
    - `manager@example.com`
    - `bob@example.com`

3. Send API requests as usual.

**Note:** The default user role will not be assigned to users unless the server is started with the `EDA_DEFAULT_USER_ROLE=default` environment variable setting.