### PR TITLE
[AAP-6144] Add endpoints for recent fired rules and hosts list

### DIFF
--- a/src/eda_server/schema/__init__.py
+++ b/src/eda_server/schema/__init__.py
@@ -11,6 +11,8 @@ from .activation import (
     RestartPolicy,
 )
 from .audit_rule import (
+    AuditChangedHost,
+    AuditFiredRule,
     AuditRule,
     AuditRuleHost,
     AuditRuleJobInstance,
@@ -66,6 +68,8 @@ __all__ = [
     "AuditRuleJobInstance",
     "AuditRuleJobInstanceEvent",
     "AuditRuleHost",
+    "AuditChangedHost",
+    "AuditFiredRule",
     "ExtraVarsCreate",
     "ExtraVarsRead",
     "ExtraVarsRef",

--- a/src/eda_server/schema/audit_rule.py
+++ b/src/eda_server/schema/audit_rule.py
@@ -40,3 +40,18 @@ class AuditRuleHost(BaseModel):
     id: int
     name: Optional[StrictStr]
     status: Optional[StrictStr]
+
+
+class AuditFiredRule(BaseModel):
+    name: StrictStr
+    job: StrictStr
+    status: Optional[StrictStr]
+    ruleset: StrictStr
+    fired_date: datetime
+
+
+class AuditChangedHost(BaseModel):
+    host: StrictStr
+    rule: StrictStr
+    ruleset: StrictStr
+    fired_date: datetime


### PR DESCRIPTION
Add two APIs `/api/audit/rules_fired` and `/api/audit/hosts_changed` to list recent fired rules and hosts.

Resolves: [AAP-6144](https://issues.redhat.com/browse/AAP-6144), [AAP-6145](https://issues.redhat.com/browse/AAP-6145)