### PR TITLE
Add GET endpoint to read activation jobs - UPDATED

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,6 @@ jobs:
         image: 'postgres:13'
         env:
           POSTGRES_PASSWORD: secret
-          EDA_DEPLOYMENT_TYPE: local
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,4 +43,4 @@ jobs:
         run: pytest
         env:
           EDA_DATABASE_URL: 'postgresql+asyncpg://postgres:secret@localhost:5432/postgres'
-          EDA_DEPLOYMENT_TYPE: docker
+          EDA_DEPLOYMENT_TYPE: local

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ jobs:
         image: 'postgres:13'
         env:
           POSTGRES_PASSWORD: secret
+          EDA_DEPLOYMENT_TYPE: local
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/src/eda_server/api/activation.py
+++ b/src/eda_server/api/activation.py
@@ -435,15 +435,8 @@ async def list_activation_instance_job_instances(
             models.audit_rules.c.status,
         )
         .select_from(models.job_instances)
-        .join(
-            models.activation_instance_job_instances,
-            models.activation_instance_job_instances.c.job_instance_id
-            == models.job_instances.c.id,
-        )
-        .outerjoin(
-            models.audit_rules,
-            models.audit_rules.c.activation_instance_id == models.job_instances.c.id,
-        )
+        .join(models.activation_instance_job_instances)
+        .outerjoin(models.audit_rules)
         .where(
             models.activation_instance_job_instances.c.activation_instance_id
             == activation_instance_id
@@ -451,5 +444,5 @@ async def list_activation_instance_job_instances(
     )
 
     result = await db.execute(query)
-    print(result.all())
+
     return result.all()

--- a/src/eda_server/api/job.py
+++ b/src/eda_server/api/job.py
@@ -23,8 +23,8 @@ router = APIRouter(tags=["jobs"])
 
 
 @router.get(
-    "/api/job_instances/",
-    response_model=List[schema.JobInstanceBaseRead],
+    "/api/job_instances",
+    response_model=List[schema.JobInstanceRead],
     operation_id="list_job_instances",
 )
 async def list_job_instances(db: AsyncSession = Depends(get_db_session)):
@@ -34,8 +34,8 @@ async def list_job_instances(db: AsyncSession = Depends(get_db_session)):
 
 
 @router.post(
-    "/api/job_instance/",
-    response_model=schema.JobInstanceRead,
+    "/api/job_instance",
+    response_model=schema.JobInstanceBaseRead,
     operation_id="create_job_instance",
 )
 async def create_job_instance(
@@ -93,7 +93,7 @@ async def create_job_instance(
 
 @router.get(
     "/api/job_instance/{job_instance_id}",
-    response_model=schema.JobInstanceBaseRead,
+    response_model=schema.JobInstanceRead,
     operation_id="read_job_instance",
 )
 async def read_job_instance(

--- a/src/eda_server/api/job.py
+++ b/src/eda_server/api/job.py
@@ -28,7 +28,18 @@ router = APIRouter(tags=["jobs"])
     operation_id="list_job_instances",
 )
 async def list_job_instances(db: AsyncSession = Depends(get_db_session)):
-    query = sa.select(models.job_instances)
+    query = (
+        sa.select(
+            models.job_instances,
+            models.audit_rules.c.fired_date,
+            models.audit_rules.c.status,
+        )
+        .select_from(models.job_instances)
+        .outerjoin(
+            models.audit_rules,
+            models.audit_rules.c.job_instance_id == models.job_instances.c.id,
+        )
+    )
     result = await db.execute(query)
     return result.all()
 
@@ -99,9 +110,18 @@ async def create_job_instance(
 async def read_job_instance(
     job_instance_id: int, db: AsyncSession = Depends(get_db_session)
 ):
-    query = sa.select(models.job_instances).where(
-        models.job_instances.c.id == job_instance_id
-    )
+    query = (
+        sa.select(
+            models.job_instances,
+            models.audit_rules.c.fired_date,
+            models.audit_rules.c.status,
+        )
+        .select_from(models.job_instances)
+        .outerjoin(
+            models.audit_rules,
+            models.audit_rules.c.job_instance_id == models.job_instances.c.id,
+        )
+    ).where(models.job_instances.c.id == job_instance_id)
     result = await db.execute(query)
     return result.first()
 

--- a/src/eda_server/schema/job.py
+++ b/src/eda_server/schema/job.py
@@ -23,8 +23,8 @@ class JobInstanceRead(BaseModel):
     ruleset: Optional[StrictStr]
     rule: Optional[StrictStr]
     hosts: Optional[StrictStr]
-    status: StrictStr
-    fired_date: datetime
+    status: Optional[StrictStr]
+    fired_date: Optional[datetime]
 
 
 class JobInstanceEventsRead(BaseModel):

--- a/src/eda_server/schema/job.py
+++ b/src/eda_server/schema/job.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Optional
 
 from pydantic import BaseModel, StrictStr
@@ -10,15 +11,20 @@ class JobInstanceCreate(BaseModel):
     extra_var_id: int
 
 
-class JobInstanceBaseRead(BaseModel):
-    id: int
+class JobInstanceBaseRead(JobInstanceCreate):
     uuid: StrictStr
 
 
-class JobInstanceRead(JobInstanceBaseRead):
-    playbook_id: int
-    inventory_id: int
-    extra_var_id: int
+class JobInstanceRead(BaseModel):
+    id: int
+    uuid: StrictStr
+    action: Optional[StrictStr]
+    name: StrictStr
+    ruleset: Optional[StrictStr]
+    rule: Optional[StrictStr]
+    hosts: Optional[StrictStr]
+    status: StrictStr
+    fired_date: datetime
 
 
 class JobInstanceEventsRead(BaseModel):

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -370,8 +370,7 @@ async def test_list_activation_instance_job_instances(
         "rulebook_id": foreign_keys["rulebook_id"],
         "inventory_id": foreign_keys["inventory_id"],
         "extra_var_id": foreign_keys["extra_var_id"],
-        "working_directory": "/tmp",
-        "execution_environment": "quay.io/bthomass/eda-project",
+        "working_directory": "./",
     }
 
     response = await client.post(

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -1,3 +1,6 @@
+import logging
+import time
+
 import sqlalchemy as sa
 from fastapi import status as status_codes
 from httpx import AsyncClient
@@ -7,6 +10,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from eda_server.db import models
 from eda_server.db.models.activation import RestartPolicy
 from eda_server.db.utils.lostream import PGLargeObject
+
+logger = logging.getLogger("eda_server")
 
 TEST_ACTIVATION = {
     "name": "test-activation",
@@ -364,25 +369,8 @@ async def test_delete_activation_not_found(client: AsyncClient):
 async def test_list_activation_instance_job_instances(
     client: AsyncClient, db: AsyncSession
 ):
-    foreign_keys = await _create_activation_dependent_objects(client, db)
-    test_activation_instance = {
-        "name": "test",
-        "rulebook_id": foreign_keys["rulebook_id"],
-        "inventory_id": foreign_keys["inventory_id"],
-        "extra_var_id": foreign_keys["extra_var_id"],
-        "working_directory": "./",
-    }
-
-    response = await client.post(
-        "/api/activation_instance",
-        json=test_activation_instance,
-    )
-    assert response.status_code == status_codes.HTTP_200_OK
-    activation_instance = response.json()
-    assert "id" in activation_instance
-
     response = await client.get(
-        f"/api/activation_instance_job_instances/{activation_instance['id']}",
+        f"/api/activation_instance_job_instances/1",
     )
     assert response.status_code == status_codes.HTTP_200_OK
     activation_instance_job_instances = response.json()

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -371,6 +371,7 @@ async def test_list_activation_instance_job_instances(
         "inventory_id": foreign_keys["inventory_id"],
         "extra_var_id": foreign_keys["extra_var_id"],
         "working_directory": "/tmp",
+        "execution_environment": "quay.io/aizquier/eda-server",
     }
 
     response = await client.post(

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -371,7 +371,6 @@ async def test_list_activation_instance_job_instances(
         "inventory_id": foreign_keys["inventory_id"],
         "extra_var_id": foreign_keys["extra_var_id"],
         "working_directory": "/tmp",
-        "execution_environment": "quay.io/aizquier/ansible-rulebook",
     }
 
     response = await client.post(

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -371,7 +371,7 @@ async def test_list_activation_instance_job_instances(
         "inventory_id": foreign_keys["inventory_id"],
         "extra_var_id": foreign_keys["extra_var_id"],
         "working_directory": "/tmp",
-        "execution_environment": "quay.io/aizquier/eda-server",
+        "execution_environment": "quay.io/bthomass/eda-project",
     }
 
     response = await client.post(

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -371,6 +371,7 @@ async def test_list_activation_instance_job_instances(
         "inventory_id": foreign_keys["inventory_id"],
         "extra_var_id": foreign_keys["extra_var_id"],
         "working_directory": "/tmp",
+        "execution_environment": "quay.io/aizquier/ansible-rulebook",
     }
 
     response = await client.post(

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -1,6 +1,3 @@
-import logging
-import time
-
 import sqlalchemy as sa
 from fastapi import status as status_codes
 from httpx import AsyncClient
@@ -10,8 +7,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from eda_server.db import models
 from eda_server.db.models.activation import RestartPolicy
 from eda_server.db.utils.lostream import PGLargeObject
-
-logger = logging.getLogger("eda_server")
 
 TEST_ACTIVATION = {
     "name": "test-activation",
@@ -370,7 +365,7 @@ async def test_list_activation_instance_job_instances(
     client: AsyncClient, db: AsyncSession
 ):
     response = await client.get(
-        f"/api/activation_instance_job_instances/1",
+        "/api/activation_instance_job_instances/1",
     )
     assert response.status_code == status_codes.HTTP_200_OK
     activation_instance_job_instances = response.json()


### PR DESCRIPTION
Add a new API endpoint to retrieve jobs based on activation id.

Testing:
1. Create an activation instance by sending POST to `http://localhost:8080/api/activation_instance` with the following body
```
{
  "name": "test2",
  "rulebook_id": 7,
  "inventory_id": 1,
  "extra_var_id": 1,
  "working_directory": "/tmp"
}
```
2. A new job should be triggered on activation instance; verify that it exists by sending GET request to `http://localhost:8080/api/activation_instance_job_instances/<activation_instance_id>`. Replace `activation_instance_id` with the ID of activation you created above. This should return a response similar to the following:
```
[
    {
        "id": 1,
        "uuid": "4757bd3b-5dcb-4241-a0b0-1aef99736597",
        "action": "run_playbook",
        "name": "ansible.eda.hello",
        "ruleset": "Hello Events",
        "rule": "Say Hello",
        "hosts": "all",
        "status": "successful",
        "fired_date": "2022-11-10T13:37:37.594191+00:00"
    }
]
```

Resolves: AAP-6201