### PR TITLE
Fix for dev:services:cleanup task

### DIFF
--- a/scripts/eda_dev.sh
+++ b/scripts/eda_dev.sh
@@ -169,14 +169,17 @@ stop-events-services() {
 }
 
 clean-events-services() {
+  local _volume_name="eda-server_postgres_data"
+
   log-info "Cleaning up EDA Services (postgres)"
   if docker images --format '{{.Repository}}' postgres| grep postgres > /dev/null 2>&1; then
     log-debug "docker rmi -f postgres:13"
     docker rmi -f postgres:13 > /dev/null 2>&1
   fi
-  if docker volume inspect -f '{{.Name}}' eda_server_postgres_data| grep eda_server_postgres_data > /dev/null 2>&1; then
-    log-debug "docker volume rm eda_server_postgres_data"
-    docker volume rm eda_server_postgres_data > /dev/null 2>&1
+
+  if docker volume inspect -f '{{.Name}}' "${_volume_name}"| grep "${_volume_name}"> /dev/null 2>&1; then
+    log-debug "docker volume rm $_volume_name"
+    docker volume rm "${_volume_name}" > /dev/null 2>&1
   fi
 }
 


### PR DESCRIPTION
Changes to follow the name change on the docker volume for postgress

Without this fix if you run the following 

```
> task dev:all:start
> docker volume ls
DRIVER    VOLUME NAME
local     eda-server_postgres_data
```
Now run the clean target:
```
> task dev:all:stop
> task dev:services:clean

> docker volume ls
DRIVER    VOLUME NAME
local     eda-server_postgres_data
```

With this fix from this branch we now remove the volume
```
> task dev:all:start
> docker volume ls
DRIVER    VOLUME NAME
local     eda-server_postgres_data
```
Now run the clean target:
```
> task dev:all:stop
> task dev:services:clean

> docker volume ls
DRIVER    VOLUME NAME
```