### PR TITLE
Remove enum from Execution Environment on Activations

### DIFF
--- a/src/eda_server/api/activation.py
+++ b/src/eda_server/api/activation.py
@@ -14,7 +14,6 @@ from eda_server import schema
 from eda_server.config import Settings, get_settings
 from eda_server.db import models
 from eda_server.db.dependency import get_db_session, get_db_session_factory
-from eda_server.db.models.activation import ExecutionEnvironment
 from eda_server.db.utils.lostream import PGLargeObject, decode_bytes_buff
 from eda_server.managers import updatemanager
 from eda_server.messages import ActivationErrorMessage
@@ -36,18 +35,6 @@ async def create_activation(
     activation: schema.ActivationCreate,
     db: AsyncSession = Depends(get_db_session),
 ):
-    if (
-        activation.execution_environment == ExecutionEnvironment.LOCAL
-        and not activation.working_directory
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=(
-                "If Execution Environment is 'local', "
-                "Working Directory is required."
-            ),
-        )
-
     query = sa.insert(models.activations).values(
         name=activation.name,
         description=activation.description,

--- a/src/eda_server/db/migrations/versions/202211041756_4db6bb101259_remove_enum_from_execution_environment.py
+++ b/src/eda_server/db/migrations/versions/202211041756_4db6bb101259_remove_enum_from_execution_environment.py
@@ -1,7 +1,7 @@
 """Remove enum from execution_environment.
 
 Revision ID: 4db6bb101259
-Revises: f592f6ef1e3a
+Revises: c703cd56f6b0
 Create Date: 2022-11-04 17:56:23.742473+00:00
 
 """
@@ -11,7 +11,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = "4db6bb101259"
-down_revision = "f592f6ef1e3a"
+down_revision = "c703cd56f6b0"
 branch_labels = None
 depends_on = None
 

--- a/src/eda_server/db/migrations/versions/202211041756_4db6bb101259_remove_enum_from_execution_environment.py
+++ b/src/eda_server/db/migrations/versions/202211041756_4db6bb101259_remove_enum_from_execution_environment.py
@@ -1,7 +1,7 @@
 """Remove enum from execution_environment.
 
 Revision ID: 4db6bb101259
-Revises: c703cd56f6b0
+Revises: f592f6ef1e3a
 Create Date: 2022-11-04 17:56:23.742473+00:00
 
 """
@@ -11,7 +11,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = "4db6bb101259"
-down_revision = "c703cd56f6b0"
+down_revision = "f592f6ef1e3a"
 branch_labels = None
 depends_on = None
 

--- a/src/eda_server/db/migrations/versions/202211041756_4db6bb101259_remove_enum_from_execution_environment.py
+++ b/src/eda_server/db/migrations/versions/202211041756_4db6bb101259_remove_enum_from_execution_environment.py
@@ -1,0 +1,50 @@
+"""Remove enum from execution_environment.
+
+Revision ID: 4db6bb101259
+Revises: c703cd56f6b0
+Create Date: 2022-11-04 17:56:23.742473+00:00
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "4db6bb101259"
+down_revision = "c703cd56f6b0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "activation",
+        "execution_environment",
+        existing_type=postgresql.ENUM(
+            "docker",
+            "podman",
+            "k8s",
+            "local",
+            name="execution_environment_enum",
+        ),
+        type_=sa.String(),
+        nullable=True,
+        server_default=None,
+    )
+    op.execute(sa.text('DROP TYPE "execution_environment_enum"'))
+
+
+def downgrade() -> None:
+    execution_environment = sa.Enum(
+        "docker", "podman", "k8s", "local", name="execution_environment_enum"
+    )
+    execution_environment.create(op.get_bind(), checkfirst=True)
+    op.alter_column(
+        "activation",
+        "execution_environment",
+        existing_type=sa.String(),
+        type_=execution_environment,
+        postgresql_using="execution_environment::execution_environment_enum",
+        server_default=sa.text("'docker'::execution_environment_enum"),
+        nullable=False,
+    )

--- a/src/eda_server/db/models/activation.py
+++ b/src/eda_server/db/models/activation.py
@@ -19,13 +19,6 @@ class RestartPolicy(str, Enum):
     NEVER = "never"
 
 
-class ExecutionEnvironment(str, Enum):
-    DOCKER = "docker"
-    PODMAN = "podman"
-    K8S = "k8s"
-    LOCAL = "local"
-
-
 activations = sa.Table(
     "activation",
     metadata,
@@ -38,17 +31,7 @@ activations = sa.Table(
     sa.Column("name", sa.String, nullable=False),
     sa.Column("description", sa.String),
     sa.Column("working_directory", sa.String),
-    sa.Column(
-        "execution_environment",
-        sa.Enum(
-            ExecutionEnvironment,
-            name="execution_environment_enum",
-            values_callable=lambda x: [e.value for e in x],
-        ),
-        default=ExecutionEnvironment.DOCKER,
-        server_default=ExecutionEnvironment.DOCKER.value,
-        nullable=False,
-    ),
+    sa.Column("execution_environment", sa.String),
     sa.Column(
         "rulebook_id",
         sa.ForeignKey("rulebook.id", ondelete="CASCADE"),

--- a/src/eda_server/schema/activation.py
+++ b/src/eda_server/schema/activation.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from pydantic import BaseModel, Field, StrictStr
 
-from eda_server.db.models.activation import ExecutionEnvironment, RestartPolicy
+from eda_server.db.models.activation import RestartPolicy
 
 from .extra_vars import ExtraVarsRef
 from .inventory import InventoryRef
@@ -19,7 +19,7 @@ class ActivationCreate(BaseModel):
     restart_policy: RestartPolicy = RestartPolicy.ON_FAILURE
     is_enabled: bool = True
     extra_var_id: int = Field(None, nullable=True)
-    execution_environment: ExecutionEnvironment = ExecutionEnvironment.DOCKER
+    execution_environment: StrictStr = "quay.io/aizquier/ansible-rulebook"
     working_directory: StrictStr = ""
     project_id: Optional[int]
 
@@ -35,7 +35,7 @@ class ActivationRead(BaseModel):
     status: StrictStr  # TODO: will need to add enum
     is_enabled: bool
     working_directory: StrictStr
-    execution_environment: ExecutionEnvironment
+    execution_environment: StrictStr
     rulebook: RulebookRef
     inventory: InventoryRef
     extra_var: ExtraVarsRef = Field(None, nullable=True)
@@ -58,7 +58,7 @@ class ActivationInstanceCreate(BaseModel):
     inventory_id: int
     extra_var_id: int
     working_directory: StrictStr
-    execution_environment: StrictStr
+    execution_environment: StrictStr = "quay.io/aizquier/ansible-rulebook"
     project_id: Optional[int]
 
 

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -5,7 +5,7 @@ from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from eda_server.db import models
-from eda_server.db.models.activation import ExecutionEnvironment, RestartPolicy
+from eda_server.db.models.activation import RestartPolicy
 from eda_server.db.utils.lostream import PGLargeObject
 
 TEST_ACTIVATION = {
@@ -18,7 +18,7 @@ TEST_ACTIVATION = {
     "restart_policy": RestartPolicy.ON_FAILURE.value,
     "is_enabled": True,
     "working_directory": "/tmp",
-    "execution_environment": ExecutionEnvironment.DOCKER.value,
+    "execution_environment": "quay.io/aizquier/ansible-rulebook",
     "project_id": 1,
 }
 


### PR DESCRIPTION
Background info: [AAP-6887](https://issues.redhat.com/browse/AAP-6887)

**Testing:**
Send a POST request to `http://localhost:9000/api/activations` with the following body:
```
{
    "name": "test",
    "rulebook_id": "1",
    "inventory_id": "1",
    "extra_var_id": "1",
    "project_id": "1"
}
```
should get similar to the following response, where `execution_environment` has a default value set on the schema side:
```
{
    "name": "test",
    "description": "",
    "status": "",
    "rulebook_id": 1,
    "inventory_id": 1,
    "restart_policy": "on-failure",
    "is_enabled": true,
    "extra_var_id": 1,
    "execution_environment": "quay.io/aizquier/ansible-rulebook",
    "working_directory": "",
    "project_id": 1,
    "id": 1
}
```

Resolves: AAP-6887