### PR TITLE
Fix the error of a transaction is already begun during creating projects 

### DIFF
--- a/src/eda_server/api/project.py
+++ b/src/eda_server/api/project.py
@@ -51,18 +51,15 @@ async def list_projects(db: AsyncSession = Depends(get_db_session)):
 async def create_project(
     data: schema.ProjectCreate, db: AsyncSession = Depends(get_db_session)
 ):
-    # Close a transaction before the project is cloned.
-    async with db.begin():
-        await project_by_name_exists_or_404(db, data.name)
+    await project_by_name_exists_or_404(db, data.name)
 
-    async with db.begin():
-        try:
-            project = await import_project(db, data)
-        except GitCommandFailed:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail="Cannot clone repository.",
-            )
+    try:
+        project = await import_project(db, data)
+    except GitCommandFailed:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Cannot clone repository.",
+        )
 
     return project
 

--- a/src/eda_server/project.py
+++ b/src/eda_server/project.py
@@ -117,6 +117,8 @@ async def import_project(db: AsyncSession, data: ProjectCreate):
             description=data.description,
         )
         await sync_project(db, project.id, project.large_data_id, repo_dir)
+        await db.commit()
+
         return project
 
 


### PR DESCRIPTION
Remove the extra `db.begin()` and add the missing `db.commit()` in creating project.

```
[8709] 2022-11-07 12:11:02,550 ERROR    Exception in ASGI application
Traceback (most recent call last):
  File "/Users/hsong/.pyenv/versions/3.10.4/lib/python3.10/site-packages/uvicorn/protocols/http/h11_impl.py", line 407, in run_asgi
...
  File "/Users/hsong/.pyenv/versions/3.10.4/lib/python3.10/site-packages/fastapi/routing.py", line 160, in run_endpoint_function
    return await dependant.call(**values)
  File "/Users/hsong/work/repos/eda-server/src/eda_server/api/project.py", line 66, in create_project
    async with db.begin():
  File "/Users/hsong/.pyenv/versions/3.10.4/lib/python3.10/site-packages/sqlalchemy/ext/asyncio/base.py", line 66, in __aenter__
    return await self.start(is_ctxmanager=True)
  File "/Users/hsong/.pyenv/versions/3.10.4/lib/python3.10/site-packages/sqlalchemy/ext/asyncio/session.py", line 702, in start
    await greenlet_spawn(
  File "/Users/hsong/.pyenv/versions/3.10.4/lib/python3.10/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 115, in greenlet_spawn
    result = context.switch(*args, **kwargs)
  File "<string>", line 2, in begin
  File "/Users/hsong/.pyenv/versions/3.10.4/lib/python3.10/site-packages/sqlalchemy/util/deprecations.py", line 309, in warned
    return fn(*args, **kwargs)
  File "/Users/hsong/.pyenv/versions/3.10.4/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 1331, in begin
    raise sa_exc.InvalidRequestError(
sqlalchemy.exc.InvalidRequestError: A transaction is already begun on this Session.
```