### PR TITLE
Changes to handle bash version 3.x and above

### DIFF
--- a/scripts/common/utils.sh
+++ b/scripts/common/utils.sh
@@ -8,7 +8,7 @@ check_vars() {
     local _var_names=("$@")
 
     for var_name in "${_var_names[@]}"; do
-        if  [[ -v $var_name ]]; then
+        if  [[ -z "$var_name" ]]; then
           log-debug "${var_name}=${!var_name}"
         else
           log-err "Environment variable $var_name is not set! Unable to continue."

--- a/scripts/version_check.sh
+++ b/scripts/version_check.sh
@@ -20,7 +20,7 @@ help() {
 }
 
 CMD=${1:-help}
-GOLDEN_VERSION="${2:-5}"
+GOLDEN_VERSION="${2:-3}"
 
 check_version() {
   local _current_version="${1}"


### PR DESCRIPTION
[AAP-6939](https://issues.redhat.com/browse/AAP-6939)

We now require bash version 3.x and above, instead of bash 5.x and above