### PR TITLE
Fix for Ruleset delete cascade failure

### DIFF
--- a/src/eda_server/db/migrations/versions/202211091951_a6c32c91ee3f_add_cascade_on_del_activation_instance.py
+++ b/src/eda_server/db/migrations/versions/202211091951_a6c32c91ee3f_add_cascade_on_del_activation_instance.py
@@ -1,0 +1,104 @@
+"""add_cascade_on_del_activation_instance.
+
+Revision ID: a6c32c91ee3f
+Revises: 4db6bb101259
+Create Date: 2022-11-09 19:51:08.408140+00:00
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a6c32c91ee3f"
+down_revision = "4db6bb101259"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "fk_audit_rule_job_instance_id", "audit_rule", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "fk_audit_rule_ruleset_id", "audit_rule", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "fk_audit_rule_rule_id", "audit_rule", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "fk_audit_rule_activation_instance_id",
+        "audit_rule",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        op.f("fk_audit_rule_job_instance_id"),
+        "audit_rule",
+        "job_instance",
+        ["job_instance_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        op.f("fk_audit_rule_activation_instance_id"),
+        "audit_rule",
+        "activation_instance",
+        ["activation_instance_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        op.f("fk_audit_rule_ruleset_id"),
+        "audit_rule",
+        "ruleset",
+        ["ruleset_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        op.f("fk_audit_rule_rule_id"),
+        "audit_rule",
+        "rule",
+        ["rule_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("fk_audit_rule_rule_id"), "audit_rule", type_="foreignkey"
+    )
+    op.drop_constraint(
+        op.f("fk_audit_rule_ruleset_id"), "audit_rule", type_="foreignkey"
+    )
+    op.drop_constraint(
+        op.f("fk_audit_rule_activation_instance_id"),
+        "audit_rule",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        op.f("fk_audit_rule_job_instance_id"), "audit_rule", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "fk_audit_rule_activation_instance_id",
+        "audit_rule",
+        "activation_instance",
+        ["activation_instance_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        "fk_audit_rule_rule_id", "audit_rule", "rule", ["rule_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "fk_audit_rule_ruleset_id",
+        "audit_rule",
+        "ruleset",
+        ["ruleset_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        "fk_audit_rule_job_instance_id",
+        "audit_rule",
+        "job_instance",
+        ["job_instance_id"],
+        ["id"],
+    )

--- a/src/eda_server/db/models/rulebook.py
+++ b/src/eda_server/db/models/rulebook.py
@@ -118,21 +118,21 @@ audit_rules = sa.Table(
     ),
     sa.Column(
         "rule_id",
-        sa.ForeignKey("rule.id"),
+        sa.ForeignKey("rule.id", ondelete="CASCADE"),
         nullable=False,
     ),
     sa.Column(
         "ruleset_id",
-        sa.ForeignKey("ruleset.id"),
+        sa.ForeignKey("ruleset.id", ondelete="CASCADE"),
         nullable=False,
     ),
     sa.Column(
         "activation_instance_id",
-        sa.ForeignKey("activation_instance.id"),
+        sa.ForeignKey("activation_instance.id", ondelete="CASCADE"),
         nullable=False,
     ),
     sa.Column(
         "job_instance_id",
-        sa.ForeignKey("job_instance.id"),
+        sa.ForeignKey("job_instance.id", ondelete="CASCADE"),
     ),
 )


### PR DESCRIPTION
[AAP-7006](https://issues.redhat.com/browse/AAP-7006)

This fixes an issue where the delete of the project will fail when deleting resources.(see above issue for more info)



Testing:
Setup for local env
export EDA_DEPLOYMENT_TYPE=local

1. start eda and setup user
`task dev:all:start`
`task dev:user:add`

2 login url
`http://localhost:8080/eda/`

3. create a project
![Screen Shot 2022-11-09 at 3 33 37 PM](https://user-images.githubusercontent.com/57504257/200936429-2a0cdb96-4b27-49a1-8dfc-55b30e946338.png)

4. create an Rulebook Activation
![Screen Shot 2022-11-09 at 3 34 32 PM](https://user-images.githubusercontent.com/57504257/200936496-1de837a9-f7f3-41b1-b7eb-c650ca90005d.png)

Create more then one if you like

5.  Now delete them eitehr one at a time or all at once