### PR TITLE
Adding concurrency group fallback for UI PR test workflow

### DIFF
--- a/.github/workflows/ui-pr-test.yml
+++ b/.github/workflows/ui-pr-test.yml
@@ -13,7 +13,7 @@ jobs:
       run:
         working-directory: ./ui
     concurrency:
-      group: ${{ github.head_ref }}
+      group: ${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
@ddonahue007 noticed that some of the UI PR workflows were failing: https://github.com/ansible/eda-server/actions/runs/3437757005

According to [the docs](https://github.com/ansible/eda-server/actions/runs/3437757005) adding a fallback value should resolve this issue.