### PR TITLE
Rulebook Description Bug Fix

### DIFF
--- a/src/eda_server/api/rulebook.py
+++ b/src/eda_server/api/rulebook.py
@@ -263,7 +263,7 @@ async def read_rulebook(
         sa.select(
             rulebook.c.id,
             rulebook.c.name,
-            rulebook.c.description,
+            sa.func.coalesce(rulebook.c.description, "").label("description"),
             rulebook.c.created_at,
             rulebook.c.modified_at,
             sa.func.coalesce(rulebook_ruleset_count.c.ruleset_count, 0).label(

--- a/src/eda_server/schema/rulebook.py
+++ b/src/eda_server/schema/rulebook.py
@@ -13,7 +13,7 @@ class RulebookCreate(BaseModel):
 class RulebookRead(BaseModel):
     id: int
     name: StrictStr
-    description: Optional[StrictStr] = ""
+    description: StrictStr
     ruleset_count: int
     fire_count: int
     created_at: datetime


### PR DESCRIPTION
Jira Ticket: [AAP-5229](https://issues.redhat.com/browse/AAP-5229)
-This should be a fix for the comment left on this ticket that rulebooks returns null rather than an empty string.

### Testing Instructions ###
1. Create a project 
2. Create a rulebook activation be sure to leave description parameter blank.
3. Hit a [GET]http://localhost:9000/api/rulebooks/1 should return the following body
```
{
    "id": 1,
    "name": "test_url_check_rules.yml",
    "description": "",
    "ruleset_count": 1,
    "fire_count": 0,
    "created_at": "2022-11-10T16:52:23.543162+00:00",
    "modified_at": "2022-11-10T16:52:23.543162+00:00"
}
```