### PR TITLE
Add EDA_DEPLOYMENT_TYPE env var for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,3 +43,4 @@ jobs:
         run: pytest
         env:
           EDA_DATABASE_URL: 'postgresql+asyncpg://postgres:secret@localhost:5432/postgres'
+          EDA_DEPLOYMENT_TYPE: docker


### PR DESCRIPTION
Tests are failing when attempting to create activation_instance in this [PR](https://github.com/ansible/eda-server/pull/237), although the tests pass locally. It is highly likely related to a missing environment variable EDA_DEPLOYMENT_TYPE.