### PR TITLE
Add error handling for activation creation

### DIFF
--- a/src/eda_server/api/activation.py
+++ b/src/eda_server/api/activation.py
@@ -65,10 +65,10 @@ async def create_activation(
     try:
         result = await db.execute(query)
     except sa.exc.IntegrityError as e:
-        errorInfo = e.orig.args[0].split("\n")
+        error_info = e.orig.args[0].split("\n")
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=str(errorInfo[1]),
+            detail=str(error_info[1]),
         )
     await db.commit()
     (id_,) = result.inserted_primary_key
@@ -283,10 +283,10 @@ async def create_activation_instance(
     try:
         result = await db.execute(query)
     except sa.exc.IntegrityError as e:
-        errorInfo = e.orig.args[0].split("\n")
+        error_info = e.orig.args[0].split("\n")
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=str(errorInfo[1]),
+            detail=str(error_info[1]),
         )
     await db.commit()
     id_, large_data_id = result.first()

--- a/src/eda_server/api/activation.py
+++ b/src/eda_server/api/activation.py
@@ -59,7 +59,6 @@ async def dependent_object_exists_or_exception(db: AsyncSession, activation):
     for dep_object, object_id in zip(
         activation_dependent_objects, dep_object_ids
     ):
-        await db.rollback()
         object_exists = await db.scalar(
             sa.select(sa.exists().where(dep_object[0].c.id == object_id))
         )
@@ -97,6 +96,7 @@ async def create_activation(
     try:
         result = await db.execute(query)
     except sa.exc.IntegrityError:
+        await db.rollback()
         await dependent_object_exists_or_exception(db, activation)
 
     await db.commit()
@@ -311,6 +311,7 @@ async def create_activation_instance(
     try:
         result = await db.execute(query)
     except sa.exc.IntegrityError:
+        await db.rollback()
         await dependent_object_exists_or_exception(db, a)
     await db.commit()
     id_, large_data_id = result.first()

--- a/src/eda_server/api/activation.py
+++ b/src/eda_server/api/activation.py
@@ -52,24 +52,18 @@ def activation_unprocessable_entity_exception(e):
     dependent_objects = ["rulebook", "inventory", "extra_var", "project"]
     for object in dependent_objects:
         if object in error_detail:
-            return JSONResponse(
+            raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                content={
-                    "message": "Error occurred while creating an activation.",
-                    "detail": (
-                        f"{object.capitalize()} with ID={object_id} does not "
-                        "exist."
-                    ),
-                },
+                detail=(
+                    f"{object.capitalize()} with ID={object_id} does not"
+                    " exist."
+                ),
             )
 
 
 @router.post(
     "/api/activations",
     response_model=schema.ActivationBaseRead,
-    responses={
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {"model": ActivationErrorMessage}
-    },
     operation_id="create_activation",
 )
 async def create_activation(
@@ -91,7 +85,7 @@ async def create_activation(
     try:
         result = await db.execute(query)
     except sa.exc.IntegrityError as e:
-        return activation_unprocessable_entity_exception(e)
+        activation_unprocessable_entity_exception(e)
     await db.commit()
     (id_,) = result.inserted_primary_key
 
@@ -276,9 +270,6 @@ async def read_output(proc, activation_instance_id, db_session_factory):
         status.HTTP_500_INTERNAL_SERVER_ERROR: {
             "model": ActivationErrorMessage
         },
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {
-            "model": ActivationErrorMessage
-        },
     },
     operation_id="create_activation_instance",
 )
@@ -308,7 +299,7 @@ async def create_activation_instance(
     try:
         result = await db.execute(query)
     except sa.exc.IntegrityError as e:
-        return activation_unprocessable_entity_exception(e)
+        activation_unprocessable_entity_exception(e)
     await db.commit()
     id_, large_data_id = result.first()
 

--- a/src/eda_server/api/activation.py
+++ b/src/eda_server/api/activation.py
@@ -16,7 +16,6 @@
 
 import json
 import logging
-import re
 from typing import List
 
 import aiodocker.exceptions
@@ -42,16 +41,14 @@ __all__ = ("router",)
 router = APIRouter(tags=["activations"])
 
 
-async def dependent_object_exists_or_exception(
-    db: AsyncSession, activation
-):
-    ACTIVATION_DEPENDENT_OBJECTS = [
+async def dependent_object_exists_or_exception(db: AsyncSession, activation):
+    activation_dependent_objects = [
         (models.rulebooks, "rulebook"),
         (models.inventories, "inventory"),
         (models.extra_vars, "extra_var"),
         (models.projects, "project"),
     ]
-    
+
     dep_object_ids = [
         activation.rulebook_id,
         activation.inventory_id,
@@ -59,7 +56,9 @@ async def dependent_object_exists_or_exception(
         activation.project_id,
     ]
 
-    for dep_object, object_id in zip(ACTIVATION_DEPENDENT_OBJECTS, dep_object_ids):
+    for dep_object, object_id in zip(
+        activation_dependent_objects, dep_object_ids
+    ):
         dependent_object = (
             await db.execute(
                 sa.select(dep_object[0]).where(dep_object[0].c.id == object_id)
@@ -68,7 +67,10 @@ async def dependent_object_exists_or_exception(
         if dependent_object is None:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=f"{dep_object[1].capitalize()} with ID={object_id} does not exist.",
+                detail=(
+                    f"{dep_object[1].capitalize()} with ID={object_id} does"
+                    " not exist."
+                ),
             )
 
 

--- a/src/eda_server/api/activation.py
+++ b/src/eda_server/api/activation.py
@@ -64,10 +64,11 @@ async def create_activation(
     )
     try:
         result = await db.execute(query)
-    except sa.exc.IntegrityError:
+    except sa.exc.IntegrityError as e:
+        errorInfo = e.orig.args[0].split("\n")
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Unprocessable Entity.",
+            detail=str(errorInfo[1]),
         )
     await db.commit()
     (id_,) = result.inserted_primary_key
@@ -279,7 +280,14 @@ async def create_activation_instance(
             models.activation_instances.c.large_data_id,
         )
     )
-    result = await db.execute(query)
+    try:
+        result = await db.execute(query)
+    except sa.exc.IntegrityError as e:
+        errorInfo = e.orig.args[0].split("\n")
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(errorInfo[1]),
+        )
     await db.commit()
     id_, large_data_id = result.first()
 

--- a/src/eda_server/api/activation.py
+++ b/src/eda_server/api/activation.py
@@ -269,7 +269,7 @@ async def read_output(proc, activation_instance_id, db_session_factory):
     responses={
         status.HTTP_500_INTERNAL_SERVER_ERROR: {
             "model": ActivationErrorMessage
-        },
+        }
     },
     operation_id="create_activation_instance",
 )

--- a/src/eda_server/api/activation.py
+++ b/src/eda_server/api/activation.py
@@ -43,8 +43,12 @@ router = APIRouter(tags=["activations"])
 
 
 def activation_unprocessable_entity_exception(e):
-    error_detail = e.orig.args[0].split("\n")[1]
-    object_id = re.findall(r"\d+", error_detail)[0]
+    try:
+        error_detail = e.orig.args[0].split("\n")[1]
+        object_id = re.findall(r"\d+", error_detail)[0]
+    except IndexError as ie:
+        logger.error(f"activation_unprocessable_entity_exception: {str(ie)}")
+        raise ie
     dependent_objects = ["rulebook", "inventory", "extra_var", "project"]
     for object in dependent_objects:
         if object in error_detail:
@@ -53,7 +57,7 @@ def activation_unprocessable_entity_exception(e):
                 content={
                     "message": "Error occurred while creating an activation.",
                     "detail": (
-                        f"{object.capitalize()} with ID={object_id} does not"
+                        f"{object.capitalize()} with ID={object_id} does not "
                         "exist."
                     ),
                 },

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -89,10 +89,23 @@ async def _create_activation_dependent_objects(db: AsyncSession):
         )
     ).inserted_primary_key
 
+    (project_id,) = (
+        await bsql.insert_object(
+            db,
+            models.projects,
+            values={
+                "url": "https://github.com/ansible/event-driven-ansible",
+                "name": "test",
+                "description": "test",
+            },
+        )
+    ).inserted_primary_key
+
     foreign_keys = {
         "extra_var_id": extra_var_id,
         "inventory_id": inventory_id,
         "rulebook_id": rulebook_id,
+        "project_id": project_id,
     }
 
     return foreign_keys
@@ -130,6 +143,7 @@ async def test_create_activation(client: AsyncClient, db: AsyncSession):
     my_test_activation["rulebook_id"] = fks["rulebook_id"]
     my_test_activation["extra_var_id"] = fks["extra_var_id"]
     my_test_activation["inventory_id"] = fks["inventory_id"]
+    my_test_activation["project_id"] = fks["project_id"]
 
     response = await client.post(
         "/api/activations",


### PR DESCRIPTION
Add error handling for activation creation when related objects don't exist.

Testing:
1. Send POST request to both `http://localhost:9000/api/activations` and `http://localhost:9000/api/activation_instance` with the following request body, where an ID is passed for `rulebook_id` which doesn't exist:
```
{
  "name": "test",
  "rulebook_id": 100,
  "inventory_id": 1,
  "extra_var_id": 1,
  "working_directory": "/tmp"
}
```
2. Verify the request above returns a response similar to the following:
```
{
    "detail": "Rulebook with ID=100 does not exist."
}
```
3. You can try the same process for `inventory` and `extra_var` where the ID's don't exist, which should return similar error message. 

Resolves: AAP-6098