### PR TITLE
Fix for debug message

### DIFF
--- a/scripts/common/logging.sh
+++ b/scripts/common/logging.sh
@@ -9,9 +9,6 @@ TS=$(tput setaf 2)
 TAG=$(tput setaf 10)
 RESET=$(tput sgr0)
 
-# emoji
-ERR_X='\U274C'
-
 # timestamp
 TIMESTAMP=$(date "+%Y-%m-%d %H:%M:%S")
 
@@ -32,7 +29,7 @@ log-warn() {
 }
 
 log-err() {
-    log "ERROR" "${ERR} ${ERR_X} $@"
+    log "ERROR" "${ERR} $@"
 }
 
 log-debug() {


### PR DESCRIPTION
[AAP-7099](https://issues.redhat.com/browse/AAP-7099) - Fix for error message prefix

Remove unicode(red ball emoji `\U274C`) from error message prefix

```
2022-11-14 11:11:47 [ERROR	]  \U274C Some error message...
```