### PR TITLE
[AAP-5991] Add API permission checks

### DIFF
--- a/src/eda_server/api/audit_rule.py
+++ b/src/eda_server/api/audit_rule.py
@@ -21,8 +21,10 @@ from sqlalchemy import desc
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from eda_server import schema
+from eda_server.auth import requires_permission
 from eda_server.db import models
 from eda_server.db.dependency import get_db_session
+from eda_server.types import Action, ResourceType
 
 router = APIRouter(tags=["audit_rules"])
 
@@ -31,6 +33,9 @@ router = APIRouter(tags=["audit_rules"])
     "/api/audit/rule/{rule_id}/details",
     response_model=schema.AuditRule,
     operation_id="read_audit_rule_details",
+    dependencies=[
+        Depends(requires_permission(ResourceType.AUDIT_RULE, Action.READ)),
+    ],
 )
 async def read_audit_rule_details(
     rule_id: int, db: AsyncSession = Depends(get_db_session)
@@ -82,6 +87,9 @@ async def read_audit_rule_details(
     "/api/audit/rule/{rule_id}/jobs",
     response_model=List[schema.AuditRuleJobInstance],
     operation_id="list_audit_rule_jobs",
+    dependencies=[
+        Depends(requires_permission(ResourceType.AUDIT_RULE, Action.READ)),
+    ],
 )
 async def list_audit_rule_jobs(
     rule_id: int, db: AsyncSession = Depends(get_db_session)
@@ -115,6 +123,9 @@ async def list_audit_rule_jobs(
     "/api/audit/rule/{rule_id}/hosts",
     response_model=List[schema.AuditRuleHost],
     operation_id="list_audit_rule_hosts",
+    dependencies=[
+        Depends(requires_permission(ResourceType.AUDIT_RULE, Action.READ)),
+    ],
 )
 async def list_audit_rule_hosts(
     rule_id: int, db: AsyncSession = Depends(get_db_session)
@@ -160,6 +171,9 @@ async def list_audit_rule_hosts(
     "/api/audit/rule/{rule_id}/events",
     response_model=List[schema.AuditRuleJobInstanceEvent],
     operation_id="list_audit_rule_events",
+    dependencies=[
+        Depends(requires_permission(ResourceType.AUDIT_RULE, Action.READ)),
+    ],
 )
 async def list_audit_rule_events(
     rule_id: int, db: AsyncSession = Depends(get_db_session)

--- a/src/eda_server/api/job.py
+++ b/src/eda_server/api/job.py
@@ -25,10 +25,12 @@ from fastapi.exceptions import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from eda_server import schema
+from eda_server.auth import requires_permission
 from eda_server.db import models
 from eda_server.db.dependency import get_db_session, get_db_session_factory
 from eda_server.managers import taskmanager
 from eda_server.ruleset import run_job, write_job_events
+from eda_server.types import Action, ResourceType
 
 logger = logging.getLogger("eda_server")
 
@@ -41,6 +43,7 @@ router = APIRouter(tags=["jobs"])
     "/api/job_instances",
     response_model=List[schema.JobInstanceRead],
     operation_id="list_job_instances",
+    dependencies=[Depends(requires_permission(ResourceType.JOB, Action.READ))],
 )
 async def list_job_instances(db: AsyncSession = Depends(get_db_session)):
     query = (
@@ -63,6 +66,9 @@ async def list_job_instances(db: AsyncSession = Depends(get_db_session)):
     "/api/job_instance",
     response_model=schema.JobInstanceBaseRead,
     operation_id="create_job_instance",
+    dependencies=[
+        Depends(requires_permission(ResourceType.JOB, Action.CREATE))
+    ],
 )
 async def create_job_instance(
     j: schema.JobInstanceCreate,
@@ -121,6 +127,7 @@ async def create_job_instance(
     "/api/job_instance/{job_instance_id}",
     response_model=schema.JobInstanceRead,
     operation_id="read_job_instance",
+    dependencies=[Depends(requires_permission(ResourceType.JOB, Action.READ))],
 )
 async def read_job_instance(
     job_instance_id: int, db: AsyncSession = Depends(get_db_session)
@@ -145,6 +152,9 @@ async def read_job_instance(
     "/api/job_instance/{job_instance_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     operation_id="delete_job_instance",
+    dependencies=[
+        Depends(requires_permission(ResourceType.JOB, Action.DELETE))
+    ],
 )
 async def delete_job_instance(
     job_instance_id: int, db: AsyncSession = Depends(get_db_session)
@@ -162,6 +172,7 @@ async def delete_job_instance(
 @router.get(
     "/api/job_instance_events/{job_instance_id}",
     operation_id="read_job_instance_events",
+    dependencies=[Depends(requires_permission(ResourceType.JOB, Action.READ))],
 )
 async def read_job_instance_events(
     job_instance_id: int, db: AsyncSession = Depends(get_db_session)

--- a/src/eda_server/api/rulebook.py
+++ b/src/eda_server/api/rulebook.py
@@ -20,11 +20,13 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from eda_server import schema
+from eda_server.auth import requires_permission
 from eda_server.db.dependency import get_db_session
 
 # Rule, Ruleset, Rulebook query builder, enums, etc
 from eda_server.db.sql import rulebook as rsql
 from eda_server.project import insert_rulebook_related_data
+from eda_server.types import Action, ResourceType
 
 router = APIRouter(tags=["rulebooks"])
 
@@ -142,6 +144,9 @@ async def build_detail_object_totals(
     "/api/rules",
     response_model=List[schema.RuleList],
     operation_id="list_rules",
+    dependencies=[
+        Depends(requires_permission(ResourceType.RULEBOOK, Action.READ)),
+    ],
 )
 async def list_rules(db: AsyncSession = Depends(get_db_session)):
     rules = await rsql.list_rules(db)
@@ -168,6 +173,9 @@ async def list_rules(db: AsyncSession = Depends(get_db_session)):
     "/api/rules/{rule_id}",
     response_model=schema.RuleDetail,
     operation_id="read_rule",
+    dependencies=[
+        Depends(requires_permission(ResourceType.RULEBOOK, Action.READ)),
+    ],
 )
 async def read_rule(rule_id: int, db: AsyncSession = Depends(get_db_session)):
     rule = await rsql.get_rule(db, rule_id)
@@ -194,6 +202,9 @@ async def read_rule(rule_id: int, db: AsyncSession = Depends(get_db_session)):
     "/api/rulesets",
     response_model=List[schema.RulesetList],
     operation_id="list_rulesets",
+    dependencies=[
+        Depends(requires_permission(ResourceType.RULEBOOK, Action.READ)),
+    ],
 )
 async def list_rulesets(db: AsyncSession = Depends(get_db_session)):
     rulesets = await rsql.list_rulesets(db)
@@ -223,6 +234,9 @@ async def list_rulesets(db: AsyncSession = Depends(get_db_session)):
     "/api/rulesets/{ruleset_id}",
     response_model=schema.RulesetDetail,
     operation_id="read_ruleset",
+    dependencies=[
+        Depends(requires_permission(ResourceType.RULEBOOK, Action.READ)),
+    ],
 )
 async def read_ruleset(
     ruleset_id: int, db: AsyncSession = Depends(get_db_session)
@@ -271,6 +285,9 @@ async def list_ruleset_rules(
 @router.post(
     "/api/rulebooks",
     operation_id="create_rulebook",
+    dependencies=[
+        Depends(requires_permission(ResourceType.RULEBOOK, Action.CREATE)),
+    ],
 )
 async def create_rulebook(
     rulebook: schema.RulebookCreate, db: AsyncSession = Depends(get_db_session)
@@ -307,6 +324,9 @@ async def create_rulebook(
     "/api/rulebooks",
     operation_id="list_rulebooks",
     response_model=List[schema.RulebookList],
+    dependencies=[
+        Depends(requires_permission(ResourceType.RULEBOOK, Action.READ)),
+    ],
 )
 async def list_rulebooks(db: AsyncSession = Depends(get_db_session)):
     rulebooks = await rsql.list_rulebooks(db)
@@ -317,6 +337,9 @@ async def list_rulebooks(db: AsyncSession = Depends(get_db_session)):
     "/api/rulebooks/{rulebook_id}",
     operation_id="read_rulebook",
     response_model=schema.RulebookRead,
+    dependencies=[
+        Depends(requires_permission(ResourceType.RULEBOOK, Action.READ)),
+    ],
 )
 async def read_rulebook(
     rulebook_id: int, db: AsyncSession = Depends(get_db_session)
@@ -331,7 +354,11 @@ async def read_rulebook(
 
 
 @router.get(
-    "/api/rulebook_json/{rulebook_id}", operation_id="read_rulebook_json"
+    "/api/rulebook_json/{rulebook_id}",
+    operation_id="read_rulebook_json",
+    dependencies=[
+        Depends(requires_permission(ResourceType.RULEBOOK, Action.READ)),
+    ],
 )
 async def read_rulebook_json(
     rulebook_id: int, db: AsyncSession = Depends(get_db_session)
@@ -351,6 +378,9 @@ async def read_rulebook_json(
     "/api/rulebooks/{rulebook_id}/rulesets",
     operation_id="list_rulebook_rulesets",
     response_model=List[schema.RulesetList],
+    dependencies=[
+        Depends(requires_permission(ResourceType.RULEBOOK, Action.READ)),
+    ],
 )
 async def list_rulebook_rulesets(
     rulebook_id: int, db: AsyncSession = Depends(get_db_session)
@@ -377,5 +407,3 @@ async def list_rulebook_rulesets(
         response.append(resp_obj)
 
     return response
-
-    return rulebook_rulesets.all()

--- a/src/eda_server/api/task.py
+++ b/src/eda_server/api/task.py
@@ -12,14 +12,22 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from eda_server.auth import requires_permission
 from eda_server.managers import taskmanager
+from eda_server.types import Action, ResourceType
 
 router = APIRouter(prefix="/api/tasks", tags=["tasks"])
 
 
-@router.get("", operation_id="list_tasks")
+@router.get(
+    "",
+    operation_id="list_tasks",
+    dependencies=[
+        Depends(requires_permission(ResourceType.TASK, Action.READ))
+    ],
+)
 async def list_tasks():
     tasks = [
         {

--- a/src/eda_server/api/user.py
+++ b/src/eda_server/api/user.py
@@ -21,8 +21,10 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from eda_server import auth, schema
+from eda_server.auth import requires_permission
 from eda_server.db import models
 from eda_server.db.dependency import get_db_session
+from eda_server.types import Action, ResourceType
 from eda_server.users import current_active_user, fastapi_users
 
 router = APIRouter(prefix="/api/users", tags=["users"])
@@ -79,6 +81,9 @@ async def list_me_roles(
     "/{user_id}/roles",
     operation_id="list_user_roles",
     response_model=List[schema.RoleRead],
+    dependencies=[
+        Depends(requires_permission(ResourceType.USER, Action.READ))
+    ],
 )
 async def list_user_roles(
     user_id: uuid.UUID,
@@ -93,6 +98,9 @@ async def list_user_roles(
     "/{user_id}/roles/{role_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     operation_id="add_user_role",
+    dependencies=[
+        Depends(requires_permission(ResourceType.USER, Action.UPDATE))
+    ],
 )
 async def add_user_role(
     user_id: uuid.UUID,
@@ -115,6 +123,9 @@ async def add_user_role(
     "/{user_id}/roles/{role_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     operation_id="remove_user_role",
+    dependencies=[
+        Depends(requires_permission(ResourceType.USER, Action.UPDATE))
+    ],
 )
 async def remove_user_role(
     user_id: uuid.UUID,
@@ -146,6 +157,9 @@ async def list_me_permissions(
     "/{user_id}/permissions",
     operation_id="list_user_permissions",
     response_model=List[str],
+    dependencies=[
+        Depends(requires_permission(ResourceType.USER, Action.READ))
+    ],
 )
 async def list_user_permissions(
     user_id: uuid.UUID,

--- a/src/eda_server/auth.py
+++ b/src/eda_server/auth.py
@@ -31,6 +31,18 @@ async def check_permission(
     resource_type: ResourceType,
     action: Action,
 ) -> bool:
+    """
+    Check user access permission.
+
+    Check that specified user has a permission to perform a specified action
+    against the specified resource type.
+
+    :param db: SQLAlchemy session.
+    :param user: User instance.
+    :param resource_type: Resource type.
+    :param action: Resource action.
+    :return: ``True`` if user permission is granted, ``False`` otherwise.
+    """
     if user.is_superuser:
         return True
 
@@ -56,12 +68,10 @@ def requires_permission(resource_type: ResourceType, action: Action):
         user: models.User = Depends(current_active_user),
         db: AsyncSession = Depends(get_db_session),
     ):
-        if not await check_permission(
-            db,
-            user,
-            resource_type,
-            action,
-        ):
+        has_permission = await check_permission(
+            db, user, resource_type, action
+        )
+        if not has_permission:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
 
     return requires_permission_dependency

--- a/src/eda_server/db/migrations/versions/202210261523_f592f6ef1e3a_new_rbac_enum_values.py
+++ b/src/eda_server/db/migrations/versions/202210261523_f592f6ef1e3a_new_rbac_enum_values.py
@@ -1,0 +1,37 @@
+"""New RBAC enum values.
+
+Revision ID: f592f6ef1e3a
+Revises: c703cd56f6b0
+Create Date: 2022-10-26 15:23:06.016126+00:00
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f592f6ef1e3a"
+down_revision = "ce5cc33ecdb6"
+branch_labels = None
+depends_on = None
+
+
+RESOURCE_TYPES = [
+    "activation",
+    "activation_instance",
+    "audit_rule",
+    "job",
+    "user",
+    "task",
+]
+ADD_RESOURCE_TYPE_QUERY = """\
+ALTER TYPE "resource_type_enum" ADD VALUE IF NOT EXISTS '{value}'
+"""
+
+
+def upgrade() -> None:
+    for value in RESOURCE_TYPES:
+        op.execute(sa.text(ADD_RESOURCE_TYPE_QUERY.format(value=value)))
+
+
+def downgrade() -> None:
+    pass

--- a/src/eda_server/types.py
+++ b/src/eda_server/types.py
@@ -16,6 +16,12 @@ from enum import Enum
 
 
 class ResourceType(Enum):
+    ACTIVATION = "activation"
+    ACTIVATION_INSTANCE = "activation_instance"
+    AUDIT_RULE = "audit_rule"
+    JOB = "job"
+    TASK = "task"
+    USER = "user"
     PROJECT = "project"
     INVENTORY = "inventory"
     EXTRA_VAR = "extra_var"

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -1,0 +1,42 @@
+from unittest import mock
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from eda_server.auth import check_permission
+from eda_server.db import models
+from eda_server.users import UserDatabase, current_active_user
+from tests.integration.utils.app import override_dependencies
+
+
+@pytest_asyncio.fixture
+async def admin_user(db: AsyncSession):
+    user = await UserDatabase(db).create(
+        {
+            "email": "admin@example.com",
+            "hashed_password": "",
+            "is_superuser": True,
+        }
+    )
+    # NOTE(cutwater): Commit transaction implicitly opened by
+    #   UserDatabase as a side effect. Need better API for creating users.
+    await db.commit()
+    return user
+
+
+@pytest.fixture
+def app(app: FastAPI, admin_user: models.User):
+    dependencies = {
+        current_active_user: lambda: admin_user,
+    }
+    with override_dependencies(app, dependencies):
+        yield app
+
+
+@pytest.fixture
+def check_permission_spy():
+    m = mock.AsyncMock(wraps=check_permission)
+    with mock.patch("eda_server.auth.check_permission", m):
+        yield m

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from unittest import mock
+
 import sqlalchemy as sa
 from fastapi import status as status_codes
 from httpx import AsyncClient
@@ -22,6 +24,7 @@ from eda_server.db import models
 from eda_server.db.models.activation import RestartPolicy
 from eda_server.db.sql import base as bsql
 from eda_server.db.utils.lostream import PGLargeObject
+from eda_server.types import Action, ResourceType
 
 TEST_ACTIVATION = {
     "name": "test-activation",
@@ -123,8 +126,11 @@ async def _create_activation(db: AsyncSession, foreign_keys: dict):
     return activation_id
 
 
-async def test_create_activation(client: AsyncClient, db: AsyncSession):
+async def test_create_activation(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     fks = await _create_activation_dependent_objects(db)
+    await db.commit()
 
     my_test_activation = TEST_ACTIVATION.copy()
     my_test_activation["rulebook_id"] = fks["rulebook_id"]
@@ -145,9 +151,13 @@ async def test_create_activation(client: AsyncClient, db: AsyncSession):
     assert activation["name"] == TEST_ACTIVATION["name"]
     assert activation["is_enabled"] == TEST_ACTIVATION["is_enabled"]
 
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.ACTIVATION, Action.CREATE
+    )
+
 
 async def test_delete_activation_instance(
-    client: AsyncClient, db: AsyncSession
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
 ):
     foreign_keys = await _create_activation_dependent_objects(db)
 
@@ -162,10 +172,13 @@ async def test_delete_activation_instance(
         )
     ).inserted_primary_key
 
+    # REVIEW(cutwater): This assert statement tests the test case itself
     num_activation_instances = await db.scalar(
         sa.select(func.count()).select_from(models.activation_instances)
     )
     assert num_activation_instances == 1
+
+    await db.commit()
 
     response = await client.delete(f"/api/activation_instance/{inserted_id}")
     assert response.status_code == status_codes.HTTP_204_NO_CONTENT
@@ -175,10 +188,12 @@ async def test_delete_activation_instance(
     )
     assert num_activation_instances == 0
 
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.ACTIVATION_INSTANCE, Action.DELETE
+    )
 
-async def test_ins_del_activation_instance_manages_log_lob(
-    client: AsyncClient, db: AsyncSession
-):
+
+async def test_ins_del_activation_instance_manages_log_lob(db: AsyncSession):
     foreign_keys = await _create_activation_dependent_objects(db)
     activation_id = await _create_activation(db, foreign_keys)
 
@@ -217,14 +232,13 @@ async def test_ins_del_activation_instance_manages_log_lob(
     exists, _ = await PGLargeObject.verify_large_object(db, large_data_id)
     assert not exists
 
+    # REVIEW(cutwater): This query does nothing
     query = sa.delete(models.activations).where(
         models.activations.c.id == activation_id
     )
 
 
-async def test_create_activation_bad_entity(
-    client: AsyncClient, db: AsyncSession
-):
+async def test_create_activation_bad_entity(client: AsyncClient):
     response = await client.post(
         "/api/activations",
         json=TEST_ACTIVATION,
@@ -237,9 +251,12 @@ async def test_delete_activation_instance_not_found(client: AsyncClient):
     assert response.status_code == status_codes.HTTP_404_NOT_FOUND
 
 
-async def test_read_activation(client: AsyncClient, db: AsyncSession):
+async def test_read_activation(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     foreign_keys = await _create_activation_dependent_objects(db)
     activation_id = await _create_activation(db, foreign_keys)
+    await db.commit()
 
     response = await client.get(
         f"/api/activations/{activation_id}",
@@ -272,15 +289,22 @@ async def test_read_activation(client: AsyncClient, db: AsyncSession):
         "name": "vars.yml",
     }
 
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.ACTIVATION, Action.READ
+    )
+
 
 async def test_read_activation_not_found(client: AsyncClient):
     response = await client.get("/api/activations/1")
     assert response.status_code == status_codes.HTTP_404_NOT_FOUND
 
 
-async def test_read_activations(client: AsyncClient, db: AsyncSession):
+async def test_list_activations(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     foreign_keys = await _create_activation_dependent_objects(db)
     activation_id = await _create_activation(db, foreign_keys)
+    await db.commit()
 
     response = await client.get(
         "/api/activations",
@@ -295,10 +319,12 @@ async def test_read_activations(client: AsyncClient, db: AsyncSession):
     assert activation["name"] == TEST_ACTIVATION["name"]
     assert activation["description"] == TEST_ACTIVATION["description"]
 
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.ACTIVATION, Action.READ
+    )
 
-async def test_read_activations_empty_response(
-    client: AsyncClient, db: AsyncSession
-):
+
+async def test_list_activations_empty_response(client: AsyncClient):
     response = await client.get(
         "/api/activations",
     )
@@ -307,9 +333,12 @@ async def test_read_activations_empty_response(
     assert activations == []
 
 
-async def test_update_activation(client: AsyncClient, db: AsyncSession):
+async def test_update_activation(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     foreign_keys = await _create_activation_dependent_objects(db)
     activation_id = await _create_activation(db, foreign_keys)
+    await db.commit()
 
     new_activation = {
         "name": "new demo",
@@ -328,10 +357,12 @@ async def test_update_activation(client: AsyncClient, db: AsyncSession):
     assert activation["description"] == new_activation["description"]
     assert activation["is_enabled"] == new_activation["is_enabled"]
 
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.ACTIVATION, Action.UPDATE
+    )
 
-async def test_update_activation_bad_entity(
-    client: AsyncClient, db: AsyncSession
-):
+
+async def test_update_activation_bad_entity(client: AsyncClient):
     new_activation = {
         "name": 1,
         "description": "demo activation",
@@ -358,14 +389,18 @@ async def test_update_activation_not_found(client: AsyncClient):
     assert response.status_code == status_codes.HTTP_404_NOT_FOUND
 
 
-async def test_delete_activation(client: AsyncClient, db: AsyncSession):
+async def test_delete_activation(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     foreign_keys = await _create_activation_dependent_objects(db)
     activation_id = await _create_activation(db, foreign_keys)
 
+    # REVIEW(cutwater): This assert statement tests the test case itself
     num_activations = await db.scalar(
         sa.select(func.count()).select_from(models.activations)
     )
     assert num_activations == 1
+    await db.commit()
 
     response = await client.delete(f"/api/activations/{activation_id}")
     assert response.status_code == status_codes.HTTP_204_NO_CONTENT
@@ -374,6 +409,10 @@ async def test_delete_activation(client: AsyncClient, db: AsyncSession):
         sa.select(func.count()).select_from(models.activation_instances)
     )
     assert num_activations == 0
+
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.ACTIVATION, Action.DELETE
+    )
 
 
 async def test_delete_activation_not_found(client: AsyncClient):

--- a/tests/integration/api/test_audit_rule.py
+++ b/tests/integration/api/test_audit_rule.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import datetime
+from unittest import mock
 
 import sqlalchemy as sa
 from fastapi import status as status_codes
@@ -20,6 +21,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from eda_server.db import models
+from eda_server.types import Action, ResourceType
 
 TEST_AUDIT_RULE = {
     "name": "test-audit-rule",
@@ -80,9 +82,7 @@ RULE_NAMES = {
 }
 
 
-async def _create_activation_dependent_objects(
-    client: AsyncClient, db: AsyncSession
-):
+async def _create_activation_dependent_objects(db: AsyncSession):
     (extra_var_id,) = (
         await db.execute(
             sa.insert(models.extra_vars).values(
@@ -183,9 +183,7 @@ async def _create_activation_dependent_objects(
     return foreign_keys
 
 
-async def _create_audit_rule(
-    client: AsyncClient, db: AsyncSession, foreign_keys
-):
+async def _create_audit_rule(db: AsyncSession, foreign_keys):
 
     (audit_rule_id,) = (
         await db.execute(
@@ -205,12 +203,16 @@ async def _create_audit_rule(
     return audit_rule_id
 
 
-async def test_read_audit_rule_jobs(client: AsyncClient, db: AsyncSession):
-    foreign_keys = await _create_activation_dependent_objects(client, db)
-    audit_rule_id = await _create_audit_rule(client, db, foreign_keys)
+async def test_read_audit_rule_jobs(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
+    foreign_keys = await _create_activation_dependent_objects(db)
+    audit_rule_id = await _create_audit_rule(db, foreign_keys)
 
+    # REVIEW(cutwater): This assert statement tests the test case itself
     audit_rules = (await db.execute(sa.select(models.audit_rules))).all()
     assert len(audit_rules) == 1
+    await db.commit()
 
     response = await client.get(
         f"/api/audit/rule/{audit_rule_id}/jobs",
@@ -222,13 +224,22 @@ async def test_read_audit_rule_jobs(client: AsyncClient, db: AsyncSession):
     job = audit_jobs[0]
     assert job["id"] == foreign_keys["job_instance_id"]
     assert job["status"] == TEST_AUDIT_RULE["status"]
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.AUDIT_RULE, Action.READ
+    )
 
 
-async def test_read_audit_details(client: AsyncClient, db: AsyncSession):
-    foreign_keys = await _create_activation_dependent_objects(client, db)
-    audit_rule_id = await _create_audit_rule(client, db, foreign_keys)
+async def test_read_audit_details(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
+    foreign_keys = await _create_activation_dependent_objects(db)
+    audit_rule_id = await _create_audit_rule(db, foreign_keys)
+
+    # REVIEW(cutwater): This assert statement tests the test case itself
     audit_rules = (await db.execute(sa.select(models.audit_rules))).all()
     assert len(audit_rules) == 1
+
+    await db.commit()
 
     response = await client.get(
         f"/api/audit/rule/{audit_rule_id}/details",
@@ -247,13 +258,22 @@ async def test_read_audit_details(client: AsyncClient, db: AsyncSession):
         "name": RULE_NAMES["ruleset_name"],
     }
     assert audit_rule["definition"] == TEST_AUDIT_RULE["definition"]
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.AUDIT_RULE, Action.READ
+    )
 
 
-async def test_read_audit_rule_events(client: AsyncClient, db: AsyncSession):
-    foreign_keys = await _create_activation_dependent_objects(client, db)
-    audit_rule_id = await _create_audit_rule(client, db, foreign_keys)
+async def test_read_audit_rule_events(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
+    foreign_keys = await _create_activation_dependent_objects(db)
+    audit_rule_id = await _create_audit_rule(db, foreign_keys)
+
+    # REVIEW(cutwater): This assert statement tests the test case itself
     audit_rules = (await db.execute(sa.select(models.audit_rules))).all()
     assert len(audit_rules) == 1
+
+    await db.commit()
 
     response = await client.get(
         f"/api/audit/rule/{audit_rule_id}/events",
@@ -269,13 +289,22 @@ async def test_read_audit_rule_events(client: AsyncClient, db: AsyncSession):
         job_event["increment_counter"] == TEST_AUDIT_RULE_JOB_EVENT["counter"]
     )
     assert job_event["name"] == TEST_AUDIT_RULE["name"]
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.AUDIT_RULE, Action.READ
+    )
 
 
-async def test_read_audit_rule_hosts(client: AsyncClient, db: AsyncSession):
-    foreign_keys = await _create_activation_dependent_objects(client, db)
-    audit_rule_id = await _create_audit_rule(client, db, foreign_keys)
+async def test_read_audit_rule_hosts(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
+    foreign_keys = await _create_activation_dependent_objects(db)
+    audit_rule_id = await _create_audit_rule(db, foreign_keys)
+
+    # REVIEW(cutwater): This assert statement tests the test case itself
     audit_rules = (await db.execute(sa.select(models.audit_rules))).all()
     assert len(audit_rules) == 1
+
+    await db.commit()
 
     response = await client.get(
         f"/api/audit/rule/{audit_rule_id}/hosts",
@@ -288,15 +317,21 @@ async def test_read_audit_rule_hosts(client: AsyncClient, db: AsyncSession):
     assert host["id"] == foreign_keys["job_instance_host_id"]
     assert host["name"] == TEST_AUDIT_RULE_JOB_HOST["host"]
     assert host["status"] == TEST_AUDIT_RULE_JOB_HOST["status"]
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.AUDIT_RULE, Action.READ
+    )
 
 
 async def test_list_audit_rules_fired(client: AsyncClient, db: AsyncSession):
-    foreign_keys = await _create_activation_dependent_objects(client, db)
-    await _create_audit_rule(client, db, foreign_keys)
-    await _create_audit_rule(client, db, foreign_keys)
+    foreign_keys = await _create_activation_dependent_objects(db)
+    await _create_audit_rule(db, foreign_keys)
+    await _create_audit_rule(db, foreign_keys)
 
+    # REVIEW(cutwater): This assert statement tests the test case itself
     audit_rules = (await db.execute(sa.select(models.audit_rules))).all()
     assert len(audit_rules) == 2
+
+    await db.commit()
 
     response = await client.get("/api/audit/rules_fired")
     fired_rules = response.json()
@@ -313,9 +348,9 @@ async def test_list_audit_rules_fired(client: AsyncClient, db: AsyncSession):
 
 
 async def test_list_audit_hosts_changed(client: AsyncClient, db: AsyncSession):
-    foreign_keys = await _create_activation_dependent_objects(client, db)
-    await _create_audit_rule(client, db, foreign_keys)
-    await _create_audit_rule(client, db, foreign_keys)
+    foreign_keys = await _create_activation_dependent_objects(db)
+    await _create_audit_rule(db, foreign_keys)
+    await _create_audit_rule(db, foreign_keys)
 
     audit_rules = (await db.execute(sa.select(models.audit_rules))).all()
     assert len(audit_rules) == 2
@@ -345,7 +380,7 @@ async def test_empty_responses(client: AsyncClient, db: AsyncSession):
     assert fired_hosts_response.json() == []
 
 
-async def test_audit_rule_404(client: AsyncClient, db: AsyncSession):
+async def test_audit_rule_404(client: AsyncClient):
     audit_rule_id = 100
     details_response = await client.get(
         f"/api/audit/rule/{audit_rule_id}/details",

--- a/tests/integration/api/test_job.py
+++ b/tests/integration/api/test_job.py
@@ -12,12 +12,15 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from unittest import mock
+
 import sqlalchemy as sa
 from fastapi import status as status_codes
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from eda_server.db import models
+from eda_server.types import Action, ResourceType
 
 TEST_EXTRA_VAR = """
 ---
@@ -48,7 +51,9 @@ TEST_RULEBOOK = """
 TEST_PLAYBOOK = TEST_RULEBOOK
 
 
-async def test_create_delete_job(client: AsyncClient, db: AsyncSession):
+async def test_create_delete_job(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     query = sa.insert(models.job_instances).values(
         uuid="f4c87c90-254e-11ed-861d-0242ac120002",
     )
@@ -60,11 +65,17 @@ async def test_create_delete_job(client: AsyncClient, db: AsyncSession):
     job_to_delete = (await db.execute(sa.select(models.job_instances))).first()
     job_id = job_to_delete.id
 
+    await db.commit()
+
     response = await client.delete(f"/api/job_instance/{job_id}")
     assert response.status_code == status_codes.HTTP_204_NO_CONTENT
 
     jobs = (await db.execute(sa.select(models.job_instances))).all()
     assert len(jobs) == (jobs_len - 1)
+
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.JOB, Action.DELETE
+    )
 
 
 async def test_delete_job_not_found(client: AsyncClient):

--- a/tests/integration/api/test_playbook.py
+++ b/tests/integration/api/test_playbook.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+# TODO(cutwater): Add unit tests for API endpoints
 from fastapi import status as status_codes
 from httpx import AsyncClient
 

--- a/tests/integration/api/test_role.py
+++ b/tests/integration/api/test_role.py
@@ -13,39 +13,22 @@
 #  limitations under the License.
 
 import operator
+from unittest import mock
 
 import pytest
-import pytest_asyncio
 import sqlalchemy as sa
-from fastapi import FastAPI, status
+from fastapi import status
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from eda_server.auth import add_role_permissions, create_role
 from eda_server.db import models
 from eda_server.types import Action, ResourceType
-from eda_server.users import UserDatabase, current_active_user
-from tests.integration.utils.app import override_dependencies
 
 
-@pytest_asyncio.fixture
-async def admin_user(db: AsyncSession):
-    return await UserDatabase(db).create(
-        {
-            "email": "admin@example.com",
-            "hashed_password": "",
-            "is_superuser": True,
-        }
-    )
-
-
-@pytest.fixture
-def app(app: FastAPI, admin_user: models.User):
-    with override_dependencies(app, {current_active_user: lambda: admin_user}):
-        yield app
-
-
-async def test_create_role(client: AsyncClient, db: AsyncSession):
+async def test_create_role(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     response = await client.post(
         "/api/roles",
         json={"name": "test-role-01", "description": "A test role 01."},
@@ -64,10 +47,16 @@ async def test_create_role(client: AsyncClient, db: AsyncSession):
 
     assert role["name"] == "test-role-01"
     assert role["description"] == "A test role 01."
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.ROLE, Action.CREATE
+    )
 
 
-async def test_show_role(client: AsyncClient, db: AsyncSession):
+async def test_show_role(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     role_id = await create_role(db, "test-role-02")
+    await db.commit()
 
     response = await client.get(f"/api/roles/{role_id}")
     assert response.status_code == status.HTTP_200_OK
@@ -76,9 +65,14 @@ async def test_show_role(client: AsyncClient, db: AsyncSession):
         "name": "test-role-02",
         "description": "",
     }
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.ROLE, Action.READ
+    )
 
 
-async def test_role_invalid_id(client: AsyncClient):
+async def test_role_invalid_id(
+    client: AsyncClient, check_permission_spy: mock.Mock
+):
     response = await client.get("/api/roles/42")
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert response.json() == {
@@ -99,16 +93,23 @@ async def test_show_role_not_exist(client: AsyncClient):
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-async def test_delete_role(client: AsyncClient, db: AsyncSession):
+async def test_delete_role(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     role_id = await create_role(db, "test-role-03")
+    await db.commit()
 
     response = await client.delete(f"/api/roles/{role_id}")
     assert response.status_code == status.HTTP_204_NO_CONTENT
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.ROLE, Action.DELETE
+    )
 
     role_exists = await db.scalar(
         sa.select(sa.exists().where(models.roles.c.id == role_id))
     )
     assert not role_exists
+    await db.commit()
 
     # Check that subsequent DELETE request returns 404
     response = await client.delete(f"/api/roles/{role_id}")
@@ -122,7 +123,9 @@ async def test_delete_role_not_exist(client: AsyncClient):
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-async def test_list_role_permissions(client: AsyncClient, db: AsyncSession):
+async def test_list_role_permissions(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     role_id = await create_role(db, "test-role-04")
     await add_role_permissions(
         db,
@@ -133,6 +136,7 @@ async def test_list_role_permissions(client: AsyncClient, db: AsyncSession):
             (ResourceType.EXECUTION_ENV, Action.READ),
         ],
     )
+    await db.commit()
 
     response = await client.get(f"/api/roles/{role_id}/permissions")
     assert response.status_code == status.HTTP_200_OK
@@ -148,10 +152,16 @@ async def test_list_role_permissions(client: AsyncClient, db: AsyncSession):
     data.sort(key=operator.itemgetter("resource_type"))
     for item, expected in zip(data, expected_items):
         assert item["resource_type"], item["action"] == expected
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.ROLE, Action.READ
+    )
 
 
-async def test_add_role_permissions(client: AsyncClient, db: AsyncSession):
+async def test_add_role_permissions(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     role_id = await create_role(db, "test-role-05")
+    await db.commit()
 
     response = await client.post(
         f"/api/roles/{role_id}/permissions",
@@ -167,6 +177,10 @@ async def test_add_role_permissions(client: AsyncClient, db: AsyncSession):
     assert data["resource_type"] == "project"
     assert data["action"] == "read"
 
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.ROLE, Action.UPDATE
+    )
+
 
 @pytest.mark.parametrize(
     "data",
@@ -181,24 +195,32 @@ async def test_add_role_permissions_invalid(
     client: AsyncClient, db: AsyncSession, data
 ):
     role_id = await create_role(db, "test-role-06")
+    await db.commit()
+
     response = await client.post(
         f"/api/roles/{role_id}/permissions", json=data
     )
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
-async def test_delete_role_permissions(client: AsyncClient, db: AsyncSession):
+async def test_delete_role_permissions(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
     role_id = await create_role(db, "test-role-07")
     permission_ids = await add_role_permissions(
         db,
         role_id,
         [(ResourceType.PROJECT, Action.READ)],
     )
+    await db.commit()
 
     response = await client.delete(
         f"/api/roles/{role_id}/permissions/{permission_ids[0]}"
     )
     assert response.status_code == status.HTTP_204_NO_CONTENT
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.ROLE, Action.UPDATE
+    )
 
     # Check that subsequent DELETE request returns 404
     response = await client.delete(

--- a/tools/initial_data.yml
+++ b/tools/initial_data.yml
@@ -11,6 +11,12 @@ roles:
           - 'rulebook'
           - 'execution_env'
           - 'role'
+          - 'activation'
+          - 'activation_instance'
+          - 'audit_rule'
+          - 'job'
+          - 'task'
+          - 'user'
         actions:
           - 'create'
           - 'read'
@@ -27,6 +33,12 @@ roles:
           - 'playbook'
           - 'rulebook'
           - 'execution_env'
+          - 'activation'
+          - 'activation_instance'
+          - 'audit_rule'
+          - 'job'
+          - 'task'
+          - 'user'
         actions:
           - 'read'
           - 'update'
@@ -41,6 +53,10 @@ roles:
           - 'playbook'
           - 'rulebook'
           - 'execution_env'
+          - 'activation'
+          - 'activation_instance'
+          - 'job'
+          - 'task'
         actions:
           - 'read'
 users:


### PR DESCRIPTION
* Modify test suite to make permission checks testing easier.
* Add permission checks and update tests for existing API endpoints.
* Configure `app` fixture for API tests to authenticate as admin user.
* Move `test_create_rulebook` test case to respective tests file.
* Move `admin_user` fixture to API's `conftest.py`.
* Add `check_permission_spy` fixture to test permission checks.
* Add new resource types to sample `initial_data.yml`