### PR TITLE
Fix read ruleset function name to match operator ID.

### DIFF
--- a/src/eda_server/api/rulebook.py
+++ b/src/eda_server/api/rulebook.py
@@ -210,7 +210,7 @@ async def list_rulesets(db: AsyncSession = Depends(get_db_session)):
     response_model=schema.RulesetDetail,
     operation_id="read_ruleset",
 )
-async def get_ruleset(
+async def read_ruleset(
     ruleset_id: int, db: AsyncSession = Depends(get_db_session)
 ):
     ruleset = await rsql.get_ruleset(db, ruleset_id)


### PR DESCRIPTION
Jira Ticket: [AAP-7125](https://issues.redhat.com/browse/AAP-7125)

Quick fix on a very minor bug. The standard is to match the function name and operator ID and for retrieving and individual DB row entry we are use the `read_object` format.

Test in the Docs:
1.  Bring up the docs http://localhost:9000/api/docs#
2. check `/api/rulesets/{ruleset_id}` to make sure next to it the description is Read Ruleset