### PR TITLE
[AAP-7174] Database defined default user roles

### DIFF
--- a/scripts/adduser.py
+++ b/scripts/adduser.py
@@ -54,7 +54,7 @@ async def create_user(
     password: str,
     is_superuser: bool = False,
 ):
-    user_db = get_user_db(config, db)
+    user_db = get_user_db(db)
     user_manager = get_user_manager(config, user_db)
 
     try:

--- a/src/eda_server/api/role.py
+++ b/src/eda_server/api/role.py
@@ -61,17 +61,13 @@ async def list_roles(db: AsyncSession = Depends(get_db_session)):
 async def create_role(
     data: schema.RoleCreate, db: AsyncSession = Depends(get_db_session)
 ):
-    query = sa.insert(models.roles).values(
-        name=data.name, description=data.description
-    )
+    query = sa.insert(models.roles).values(data.dict())
     try:
         (role_id,) = (await db.execute(query)).inserted_primary_key
     except sa.exc.IntegrityError:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT)
     await db.commit()
-    return schema.RoleRead(
-        id=role_id, name=data.name, description=data.description
-    )
+    return schema.RoleRead(id=role_id, **data.dict())
 
 
 @router.get(

--- a/src/eda_server/config/__init__.py
+++ b/src/eda_server/config/__init__.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 from importlib import resources
-from typing import Optional
 
 import yaml
 from fastapi.requests import Request
@@ -36,8 +35,6 @@ class Settings(BaseSettings):
 
     deployment_type: str = "docker"
     server_name: str = "localhost"
-
-    default_user_role: Optional[str] = None
 
     class Config:
         env_prefix = "EDA_"

--- a/src/eda_server/db/migrations/versions/202211171209_202cf90fc4b0_add_role_is_default.py
+++ b/src/eda_server/db/migrations/versions/202211171209_202cf90fc4b0_add_role_is_default.py
@@ -1,0 +1,45 @@
+#  Copyright 2022 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Add is_default column to roles table.
+
+Revision ID: 202cf90fc4b0
+Revises: f592f6ef1e3a
+Create Date: 2022-11-17 12:09:13.258802+00:00
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "202cf90fc4b0"
+down_revision = "f592f6ef1e3a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "role",
+        sa.Column(
+            "is_default",
+            sa.Boolean(),
+            server_default=sa.false(),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("role", "is_default")

--- a/src/eda_server/db/models/auth.py
+++ b/src/eda_server/db/models/auth.py
@@ -58,6 +58,13 @@ roles = sa.Table(
         server_default="",
         nullable=False,
     ),
+    sa.Column(
+        "is_default",
+        sa.Boolean,
+        default=False,
+        server_default=sa.false(),
+        nullable=True,
+    ),
 )
 
 user_roles = sa.Table(

--- a/src/eda_server/schema/role.py
+++ b/src/eda_server/schema/role.py
@@ -14,7 +14,7 @@
 
 import uuid
 
-from pydantic import BaseModel
+from pydantic import BaseModel, StrictBool
 
 from eda_server.types import Action, ResourceType
 
@@ -23,11 +23,13 @@ class RoleRead(BaseModel):
     id: uuid.UUID
     name: str
     description: str
+    is_default: StrictBool
 
 
 class RoleCreate(BaseModel):
     name: str
     description: str = ""
+    is_default: StrictBool = False
 
 
 class RolePermissionRead(BaseModel):

--- a/tests/integration/api/test_user.py
+++ b/tests/integration/api/test_user.py
@@ -93,11 +93,13 @@ def _check_test_user_roles_response(
             "id": str(role_ids[0]),
             "name": "test-role__0",
             "description": "",
+            "is_default": False,
         },
         {
             "id": str(role_ids[1]),
             "name": "test-role__1",
             "description": "",
+            "is_default": False,
         },
     ]
 

--- a/tools/initial_data.yml
+++ b/tools/initial_data.yml
@@ -45,6 +45,7 @@ roles:
 
   - name: 'default'
     description: 'Default role, that is applied to all users'
+    is_default: true
     permissions:
       - resources:
           - 'project'


### PR DESCRIPTION
Drop configuration parameter `EDA_DEFAULT_USER_ROLE` in favor of database defined default user roles.
The `roles` database tables now has new `is_default` field. When `is_default` set to `True`, a role is automatically assigned to a user at user creation or registration.

Implements: https://issues.redhat.com/browse/AAP-7174

## Testing instructions

1. Create an empty database

2. Execute:
    ```
    python scripts/load_data.py tools/initial_data.yml
    ```

3. Login as root:
    ```
    TOKEN=$(http -f POST http://localhost:9000/api/auth/bearer/login username=root@example.com password=secret | jq -r .access_token)
    ```

3. Check roles, a new `is_default` field must be included in response.

    ```
    http -A bearer -a "$TOKEN" http://localhost:9000/api/roles
    [
        {
            "description": "Has full access to all resources",
            "id": "4ca9cd32-e11e-4634-875e-4acf7a5682e1",
            "is_default": false,
            "name": "admin"
        },
        ...
    ```

4. Check your roles, you should see default role in the list of roles.
    ````
    http -A bearer -a "$TOKEN" http://localhost:9000/api/users/me/roles
    [
        {
            "description": "Default role, that is applied to all users",
            "id": "12e9b549-e1eb-40cb-b84b-f289614439af",
            "is_default": true,
            "name": "default"
        }
    ]
    ````

5. Login as any other user, repeat steps 3 and 4.