### PR TITLE
[AAP-7221] Add more details in audit list

### DIFF
--- a/src/eda_server/api/audit_rule.py
+++ b/src/eda_server/api/audit_rule.py
@@ -222,6 +222,9 @@ async def list_audit_rule_events(
     "/api/audit/rules_fired",
     response_model=List[schema.AuditFiredRule],
     operation_id="list_audit_rules_fired",
+    dependencies=[
+        Depends(requires_permission(ResourceType.AUDIT_RULE, Action.READ)),
+    ],
 )
 async def list_audit_rules_fired(db: AsyncSession = Depends(get_db_session)):
     query = (
@@ -260,14 +263,20 @@ async def list_audit_rules_fired(db: AsyncSession = Depends(get_db_session)):
     for row in rows:
         response.append(
             {
-                "id": row["rule_id"],
-                "name": row["rule_name"],
-                "job_id": row["job_id"],
-                "job": row["job_name"],
+                "job": {
+                    "id": row["job_id"],
+                    "name": row["job_name"],
+                },
                 "status": row["status"],
-                "ruleset_id": row["ruleset_id"],
-                "ruleset": row["ruleset_name"],
                 "fired_date": row["fired_date"],
+                "rule": {
+                    "id": row["rule_id"],
+                    "name": row["rule_name"],
+                },
+                "ruleset": {
+                    "id": row["ruleset_id"],
+                    "name": row["ruleset_name"],
+                },
             }
         )
 
@@ -278,6 +287,9 @@ async def list_audit_rules_fired(db: AsyncSession = Depends(get_db_session)):
     "/api/audit/hosts_changed",
     response_model=List[schema.AuditChangedHost],
     operation_id="list_audit_hosts_changed",
+    dependencies=[
+        Depends(requires_permission(ResourceType.AUDIT_RULE, Action.READ)),
+    ],
 )
 async def list_audit_hosts_changed(db: AsyncSession = Depends(get_db_session)):
     query = (
@@ -315,11 +327,15 @@ async def list_audit_hosts_changed(db: AsyncSession = Depends(get_db_session)):
         response.append(
             {
                 "host": row["host"],
-                "rule_id": row["rule_id"],
-                "rule": row["rule_name"],
-                "ruleset_id": row["ruleset_id"],
-                "ruleset": row["ruleset_name"],
                 "fired_date": row["fired_date"],
+                "rule": {
+                    "id": row["rule_id"],
+                    "name": row["rule_name"],
+                },
+                "ruleset": {
+                    "id": row["ruleset_id"],
+                    "name": row["ruleset_name"],
+                },
             }
         )
 

--- a/src/eda_server/api/audit_rule.py
+++ b/src/eda_server/api/audit_rule.py
@@ -226,9 +226,12 @@ async def list_audit_rule_events(
 async def list_audit_rules_fired(db: AsyncSession = Depends(get_db_session)):
     query = (
         sa.select(
+            models.audit_rules.c.rule_id.label("rule_id"),
             models.audit_rules.c.name.label("rule_name"),
+            models.audit_rules.c.job_instance_id.label("job_id"),
             models.job_instance_hosts.c.task.label("job_name"),
             models.audit_rules.c.status.label("status"),
+            models.rulesets.c.id.label("ruleset_id"),
             models.rulesets.c.name.label("ruleset_name"),
             models.audit_rules.c.fired_date.label("fired_date"),
         )
@@ -257,9 +260,12 @@ async def list_audit_rules_fired(db: AsyncSession = Depends(get_db_session)):
     for row in rows:
         response.append(
             {
+                "id": row["rule_id"],
                 "name": row["rule_name"],
+                "job_id": row["job_id"],
                 "job": row["job_name"],
                 "status": row["status"],
+                "ruleset_id": row["ruleset_id"],
                 "ruleset": row["ruleset_name"],
                 "fired_date": row["fired_date"],
             }
@@ -277,7 +283,9 @@ async def list_audit_hosts_changed(db: AsyncSession = Depends(get_db_session)):
     query = (
         sa.select(
             models.job_instance_hosts.c.host.label("host"),
+            models.audit_rules.c.rule_id.label("rule_id"),
             models.audit_rules.c.name.label("rule_name"),
+            models.rulesets.c.id.label("ruleset_id"),
             models.rulesets.c.name.label("ruleset_name"),
             models.audit_rules.c.fired_date.label("fired_date"),
         )
@@ -307,7 +315,9 @@ async def list_audit_hosts_changed(db: AsyncSession = Depends(get_db_session)):
         response.append(
             {
                 "host": row["host"],
+                "rule_id": row["rule_id"],
                 "rule": row["rule_name"],
+                "ruleset_id": row["ruleset_id"],
                 "ruleset": row["ruleset_name"],
                 "fired_date": row["fired_date"],
             }

--- a/src/eda_server/schema/__init__.py
+++ b/src/eda_server/schema/__init__.py
@@ -44,6 +44,7 @@ from .job import (
     JobInstanceCreate,
     JobInstanceEventsRead,
     JobInstanceRead,
+    JobRef,
 )
 from .message import ProducerMessage, ProducerResponse
 from .playbook import PlaybookRead, PlaybookRef
@@ -110,6 +111,7 @@ __all__ = [
     "JobInstanceBaseRead",
     "JobInstanceRead",
     "JobInstanceEventsRead",
+    "JobRef",
     "ProducerMessage",
     "ProducerResponse",
     "PlaybookRef",

--- a/src/eda_server/schema/audit_rule.py
+++ b/src/eda_server/schema/audit_rule.py
@@ -57,15 +57,20 @@ class AuditRuleHost(BaseModel):
 
 
 class AuditFiredRule(BaseModel):
+    id: int
     name: StrictStr
+    job_id: int
     job: StrictStr
     status: Optional[StrictStr]
+    ruleset_id: int
     ruleset: StrictStr
     fired_date: datetime
 
 
 class AuditChangedHost(BaseModel):
     host: StrictStr
+    rule_id: int
     rule: StrictStr
+    ruleset_id: int
     ruleset: StrictStr
     fired_date: datetime

--- a/src/eda_server/schema/audit_rule.py
+++ b/src/eda_server/schema/audit_rule.py
@@ -17,7 +17,8 @@ from typing import Optional
 
 from pydantic import BaseModel, StrictStr
 
-from .rulebook import RuleRulesetRef
+from .job import JobRef
+from .rulebook import RuleRef, RuleRulesetRef
 
 
 class AuditRuleActivationRef(BaseModel):
@@ -57,20 +58,15 @@ class AuditRuleHost(BaseModel):
 
 
 class AuditFiredRule(BaseModel):
-    id: int
-    name: StrictStr
-    job_id: int
-    job: StrictStr
+    job: JobRef
+    rule: RuleRef
+    ruleset: RuleRulesetRef
     status: Optional[StrictStr]
-    ruleset_id: int
-    ruleset: StrictStr
-    fired_date: datetime
+    fired_date: Optional[datetime]
 
 
 class AuditChangedHost(BaseModel):
     host: StrictStr
-    rule_id: int
-    rule: StrictStr
-    ruleset_id: int
-    ruleset: StrictStr
-    fired_date: datetime
+    rule: RuleRef
+    ruleset: RuleRulesetRef
+    fired_date: Optional[datetime]

--- a/src/eda_server/schema/job.py
+++ b/src/eda_server/schema/job.py
@@ -29,6 +29,11 @@ class JobInstanceBaseRead(JobInstanceCreate):
     uuid: StrictStr
 
 
+class JobRef(BaseModel):
+    id: int
+    name: Optional[str]
+
+
 class JobInstanceRead(BaseModel):
     id: int
     uuid: StrictStr


### PR DESCRIPTION
Add more details `rule_id`, `job_id` and `ruleset_id` to endpoints `/api/audit/rules_fired` and `/api/audit/hosts_changed`.

The expect output of `/api/audit/rules_fired` looks like:
```
[
  {
    "rule": {
      "id": 2,
      "name": "Say Hello",
    },
    "job": {
      "id": 1,
      "name": "debug",
    },
    "ruleset": {
      "id": 2,
      "name": "Hello Events",
    },
    "status": "successful",
    "fired_date": "2022-11-17T14:54:37.813339+00:00"
  }
]
```
The expect output of `/api/audit/hosts_changed` looks like:
```
[
  {
    "host": "localhost",
    "rule": {
      "id": 2,
      "name": "Say Hello",
    },
    "ruleset": {
      "id": 2,
      "name": "Hello Events",
    },
    "fired_date": "2022-11-17T14:54:37.813339+00:00"
  }
]
```

Resolves: [AAP-7221](https://issues.redhat.com/browse/AAP-7221)