### PR TITLE
Update extravar and playbook urls

### DIFF
--- a/ui/src/app/API/Extravar.ts
+++ b/ui/src/app/API/Extravar.ts
@@ -1,7 +1,7 @@
 import { getAxiosInstance } from '@app/API/baseApi';
 import { AxiosResponse } from 'axios';
 
-const extravarsEndpoint = '/api/extra_vars';
+const extravarsEndpoint = '/api/extra_vars/';
 const extravarEndpoint = '/api/extra_var';
 
 export const listExtraVars = (): Promise<AxiosResponse> => getAxiosInstance().get(extravarsEndpoint);

--- a/ui/src/app/API/Playbook.ts
+++ b/ui/src/app/API/Playbook.ts
@@ -2,7 +2,7 @@ import { defaultSettings } from '@app/shared/pagination';
 import { AxiosResponse } from 'axios';
 import { getAxiosInstance } from '@app/API/baseApi';
 
-const playbooksEndpoint = '/api/playbooks';
+const playbooksEndpoint = '/api/playbooks/';
 
 export const listPlaybooks = (pagination = defaultSettings): Promise<AxiosResponse> =>
   getAxiosInstance().get(playbooksEndpoint);

--- a/ui/src/test/NewActivation/NewActivation.test.tsx
+++ b/ui/src/test/NewActivation/NewActivation.test.tsx
@@ -31,7 +31,7 @@ describe('NewActivation', () => {
       { id: '2', name: 'RuleBook 2' },
       { id: '3', name: 'RuleBook 3' },
     ]);
-    mockApi.onGet(`/api/extra_vars`).replyOnce(200, [
+    mockApi.onGet(`/api/extra_vars/`).replyOnce(200, [
       { id: '1', name: 'Var 1' },
       { id: '2', name: 'Var 2' },
     ]);

--- a/ui/src/test/NewJob/NewJob.test.tsx
+++ b/ui/src/test/NewJob/NewJob.test.tsx
@@ -26,7 +26,7 @@ describe('NewJob', () => {
   });
 
   it('should render the New Job form', async () => {
-    mockApi.onGet(`/api/extra_vars`).replyOnce(200, [
+    mockApi.onGet(`/api/extra_vars/`).replyOnce(200, [
       { id: '1', name: 'Var 1' },
       { id: '2', name: 'Var 2' },
     ]);
@@ -34,7 +34,7 @@ describe('NewJob', () => {
       { id: '1', name: 'Inventory 1' },
       { id: '2', name: 'Inventory 2' },
     ]);
-    mockApi.onGet(`/api/playbooks`).replyOnce(200, [
+    mockApi.onGet(`/api/playbooks/`).replyOnce(200, [
       { id: '1', name: 'Playbook 1' },
       { id: '2', name: 'Playbook 2' },
       { id: '3', name: 'Playbook 3' },


### PR DESCRIPTION
Fixed the playbook and extravars get urls

 - Fixes the list of playbook and extravars in the New Activation and New Job forms following the RBAC PR