### PR TITLE
Add Sync Project Endpoint

### DIFF
--- a/src/eda_server/api/project.py
+++ b/src/eda_server/api/project.py
@@ -110,8 +110,19 @@ async def sync_project(
             status_code=status.HTTP_404_NOT_FOUND, detail="Project Not Found."
         )
 
-    await sync_existing_project(db, project)
+    try:
+        await sync_existing_project(db, project)
+    except GitCommandFailed:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Cannot clone repository.",
+        )
     await db.commit()
+
+    return Response(
+        status_code=status.HTTP_200_OK,
+        content="Project has been syned successfully!",
+    )
 
 
 @router.get(

--- a/src/eda_server/api/rulebook.py
+++ b/src/eda_server/api/rulebook.py
@@ -25,7 +25,6 @@ from eda_server.db.dependency import get_db_session
 
 # Rule, Ruleset, Rulebook query builder, enums, etc
 from eda_server.db.sql import rulebook as rsql
-from eda_server.project import insert_rulebook_related_data
 from eda_server.types import Action, ResourceType
 
 router = APIRouter(tags=["rulebooks"])
@@ -314,7 +313,7 @@ async def create_rulebook(
             )
 
     rulebook_data = yaml.safe_load(new_rulebook.rulesets)
-    await insert_rulebook_related_data(db, new_rulebook.id, rulebook_data)
+    await rsql.insert_rulebook_related_data(db, new_rulebook.id, rulebook_data)
     await db.commit()
 
     return new_rulebook

--- a/src/eda_server/db/sql/extra_var/__init__.py
+++ b/src/eda_server/db/sql/extra_var/__init__.py
@@ -1,0 +1,42 @@
+#  Copyright 2022 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from eda_server.db import models
+
+
+async def import_extra_var_file(
+    db: AsyncSession, filename: str, file_content: str, project_id: int
+):
+    await db.execute(
+        sa.insert(models.extra_vars).values(
+            name=filename,
+            extra_var=file_content,
+            project_id=project_id,
+        )
+    )
+
+
+async def update_extra_var(
+    db: AsyncSession, file_content: str, extra_var_id: int
+):
+    await db.execute(
+        sa.update(models.extra_vars)
+        .where(models.extra_vars.c.id == extra_var_id)
+        .values(
+            extra_var=file_content,
+        )
+    )

--- a/src/eda_server/db/sql/inventory/__init__.py
+++ b/src/eda_server/db/sql/inventory/__init__.py
@@ -1,0 +1,48 @@
+#  Copyright 2022 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from eda_server.db import models
+from eda_server.types import InventorySource
+
+logger = logging.getLogger("eda_server")
+
+
+async def import_inventory_file(
+    db: AsyncSession, filename: str, file_content: str, project_id: int
+):
+    await db.execute(
+        sa.insert(models.inventories).values(
+            name=filename,
+            inventory=file_content,
+            project_id=project_id,
+            inventory_source=InventorySource.PROJECT,
+        )
+    )
+
+
+async def update_inventory(
+    db: AsyncSession, file_content: str, inventory_id: int
+):
+    await db.execute(
+        sa.update(models.inventories)
+        .where(models.inventories.c.id == inventory_id)
+        .values(
+            inventory=file_content,
+        )
+    )

--- a/src/eda_server/db/sql/playbook/__init__.py
+++ b/src/eda_server/db/sql/playbook/__init__.py
@@ -1,0 +1,42 @@
+#  Copyright 2022 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from eda_server.db import models
+
+
+async def import_playbook_file(
+    db: AsyncSession, filename: str, file_content: str, project_id: int
+):
+    await db.execute(
+        sa.insert(models.playbooks).values(
+            name=filename,
+            playbook=file_content,
+            project_id=project_id,
+        )
+    )
+
+
+async def update_playbook(
+    db: AsyncSession, file_content: str, playbook_id: int
+):
+    await db.execute(
+        sa.update(models.playbooks)
+        .where(models.playbooks.c.id == playbook_id)
+        .values(
+            playbook=file_content,
+        )
+    )

--- a/tests/integration/api/test_project.py
+++ b/tests/integration/api/test_project.py
@@ -130,16 +130,23 @@ async def test_delete_project_not_found(client: AsyncClient):
 
 @mock.patch("tempfile.TemporaryDirectory")
 @mock.patch("eda_server.project.clone_project")
-@mock.patch("eda_server.project.sync_project")
+@mock.patch("eda_server.project.find_project_files")
+@mock.patch("eda_server.project.import_project_files")
+@mock.patch("eda_server.project.tar_project")
 async def test_create_project(
-    sync_project: mock.Mock,
+    tar_project: mock.Mock,
+    import_project_files: mock.Mock,
+    find_project_files: mock.Mock,
     clone_project: mock.Mock,
     tempfile: mock.Mock(),
     client: AsyncClient,
     db: AsyncSession,
     check_permission_spy: mock.Mock,
 ):
-    tempfile.return_value.__enter__.return_value = "/tmp/test-create-project"
+    project_files = {"rulebook": [("rulebook", "test-rules.yml")]}
+    repo_dir = "/tmp/test-create-project"
+    tempfile.return_value.__enter__.return_value = repo_dir
+    find_project_files.return_value = project_files
     found_hash = hashlib.sha1(b"test").hexdigest()
     clone_project.return_value = found_hash
 
@@ -160,11 +167,68 @@ async def test_create_project(
     assert project["url"] == TEST_PROJECT["url"]
 
     clone_project.assert_called_once_with(TEST_PROJECT["url"], mock.ANY)
-    sync_project.assert_called_once_with(
-        db, project["id"], project["large_data_id"], "/tmp/test-create-project"
-    )
+    import_project_files.assert_called_once_with(db, mock.ANY, project["id"])
+    find_project_files.assert_called_once_with(repo_dir)
+    tar_project.assert_called_once_with(db, project["large_data_id"], repo_dir)
     check_permission_spy.assert_called_once_with(
         mock.ANY, mock.ANY, ResourceType.PROJECT, Action.CREATE
+    )
+
+
+@mock.patch("tempfile.TemporaryDirectory")
+@mock.patch("eda_server.project.clone_project")
+@mock.patch("eda_server.project.find_project_files")
+@mock.patch("eda_server.project.retrieve_existing_project_files")
+@mock.patch("eda_server.project.import_project_file")
+async def test_sync_project(
+    import_project_file: mock.Mock,
+    retrieve_existing_project_files: mock.Mock,
+    find_project_files: mock.Mock,
+    clone_project: mock.Mock,
+    tempfile: mock.Mock(),
+    client: AsyncClient,
+    db: AsyncSession,
+    check_permission_spy: mock.Mock,
+):
+    old_hash = hashlib.sha1(b"test").hexdigest()
+    query = sa.insert(models.projects).values(
+        git_hash=old_hash,
+        url=TEST_PROJECT["url"],
+        name=TEST_PROJECT["name"],
+        description=TEST_PROJECT["description"],
+    )
+    (project_id,) = (await db.execute(query)).inserted_primary_key
+    await db.commit()
+
+    file_type = "rulebook"
+    new_files = [("rulebook", "test-rules.yml")]
+    project_files = {file_type: new_files}
+    repo_dir = "/tmp/test-sync-project"
+
+    tempfile.return_value.__enter__.return_value = repo_dir
+    find_project_files.return_value = project_files
+    new_hash = hashlib.sha1(b"test2").hexdigest()
+    clone_project.return_value = new_hash
+
+    response = await client.post(f"/api/projects/{project_id}")
+    assert response.status_code == status_codes.HTTP_200_OK
+
+    (_hash,) = (
+        await db.execute(
+            sa.select(models.projects.c.git_hash).where(
+                models.projects.c.id == project_id
+            )
+        )
+    ).one_or_none()
+    assert _hash == new_hash
+
+    find_project_files.assert_called_once_with(repo_dir)
+    retrieve_existing_project_files.assert_called_once_with(db, project_id)
+    import_project_file.assert_called_once_with(
+        db, new_files[0], file_type, project_id
+    )
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.PROJECT, Action.UPDATE
     )
 
 

--- a/tests/integration/db/sql/rulebook/test_rulebook.py
+++ b/tests/integration/db/sql/rulebook/test_rulebook.py
@@ -22,7 +22,6 @@ import yaml
 from dateutil.parser import parse as dtparse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from eda_server import project as bl_prj
 from eda_server.db import models
 from eda_server.db.sql import base as bsql, rulebook as rsql
 from eda_server.types import InventorySource
@@ -229,7 +228,7 @@ async def test_get_rulesets_base_no_data(db: AsyncSession):
 
 async def test_expand_ruleset_sources(db: AsyncSession):
     rulesets_data = yaml.safe_load(TEST_RULESET_SIMPLE)
-    res = bl_prj.expand_ruleset_sources(rulesets_data)
+    res = rsql.expand_ruleset_sources(rulesets_data)
     rs_name = "Test simple"
     assert rs_name in res
     assert len(res[rs_name]) == 2
@@ -247,9 +246,7 @@ async def test_process_ruleset_sources(db: AsyncSession):
     rulebooks = await insert_rulebooks(db, project)
     assert len(rulebooks) == 2
     rulebook_data = yaml.safe_load(rulebooks[1].rulesets)
-    await bl_prj.insert_rulebook_related_data(
-        db, rulebooks[1].id, rulebook_data
-    )
+    await rsql.insert_rulebook_related_data(db, rulebooks[1].id, rulebook_data)
     ruleset = await bsql.get_object(
         db,
         models.rulesets,


### PR DESCRIPTION
## Description 

Adds an API endpoint to sync an existing project.

- refactor importing project files code
- add sync project endpoint `api/projects/<project_id>`

Currently syncs an existing project based on two factors:
1. If the content of an existing file has changed, the [code](https://github.com/ansible/eda-server/blob/0cea343e310d68d8651fd55c957daf8b7c74c524/src/eda_server/project.py#L488) updates the respective DB entry. 
2. If there is a new file created, the [code](https://github.com/ansible/eda-server/blob/0cea343e310d68d8651fd55c957daf8b7c74c524/src/eda_server/project.py#L492) imports the file into its respective table (rulebook, inventory, etc.)
3. TO BE IMPLEMENTED: If the existing file's name has changed but the content is the same.

## Testing

Testing this PR mainly involves importing a Github project and syncing new changes from the project. Feel free to use the following [test project](https://github.com/Dostonbek1/test-project-for-eda).
1. Fork [this Github project](https://github.com/Dostonbek1/test-project-for-eda)
2. Create an EDA project by calling POST on `http://localhost:9000/api/projects` with the following request body:
```
{
    "url": "<link to your forked project repo>",
    "name": "Test Project",
    "description": "Test project"
}
```
3. Check the DB tables (project, rulebook, inventory, etc.) to make sure the project files have been imported.
4. Push new changes to your forked repo; could be a new rulebook, extra_var, etc. files or change the contents of the existing files.
5. Send a POST request on `http://localhost:9000/api/projects/<project_id>`.
6. Verify the above request is successful.
7. Check DB and verify all changes from the project have been synced including the `git_hash` of the project.

Resolves: AAP-5704