### PR TITLE
Remove obsolete docker build arg

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,7 +1,6 @@
 # Build eda-server
 FROM registry.access.redhat.com/ubi8/python-39
 ARG USER_ID=${USER_ID:-1001}
-ARG DEVEL_EDA_LIBRARY=1
 WORKDIR $HOME
 
 USER 0

--- a/tools/docker/docker-compose.yml
+++ b/tools/docker/docker-compose.yml
@@ -20,7 +20,6 @@ services:
       context: ../../
       dockerfile: tools/docker/Dockerfile
       args:
-        DEVEL_EDA_LIBRARY: ${DEVEL_EDA_LIBRARY:-1}
         USER_ID: ${EDA_USER_ID:-1001}
     command:
       [


### PR DESCRIPTION
In commit f43d718 the conditional check to install ansible-rulebook directly from the repo was removed, making the DEVEL_EDA_LIBRARY arg obsolete. This commit removes the remnants of DEVEL_EDA_LIBRARY.