### PR TITLE
Handles null source config

### DIFF
--- a/src/eda_server/db/sql/rulebook/__init__.py
+++ b/src/eda_server/db/sql/rulebook/__init__.py
@@ -665,7 +665,7 @@ def expand_ruleset_sources(rulebook_data: dict) -> dict:
         for ruleset_data in rulebook_data:
             xp_sources = []
             expanded_ruleset_sources[ruleset_data["name"]] = xp_sources
-            for source in ruleset_data.get("sources", []):
+            for source in ruleset_data.get("sources", []) or []:
                 xp_src = {"name": "<unnamed>"}
                 for src_key, src_val in source.items():
                     if src_key == "name":

--- a/src/eda_server/schema/rulebook.py
+++ b/src/eda_server/schema/rulebook.py
@@ -91,7 +91,7 @@ class RulesetSourceRef(BaseModel):
     name: str
     type: str
     source: str
-    config: dict
+    config: Optional[dict]
 
 
 class RulesetSource(BaseModel):


### PR DESCRIPTION
## Jira Ticket

[AAP-7694](https://issues.redhat.com/browse/AAP-7694)

## Description

* Better handle when source is missing or source is missing config info (empty dict)
* Handle missing source config on serializing output
* Adds tests

## Testing

1. Create project with the following rulebook:
    ```yaml
    ---
    - name: Local Test Runner Git Hook Rules
      hosts: all
      sources:
        - ansible.eda.webhook:
      rules:
        - name: run tests 1
          condition: event.payload.src_path == "{{src_path}}"
          action:
            run_playbook:
              name: ansible.eda.run_pytest
              var_root: payload
              post_events: true
        - name: print output
          condition: event.output is defined
            action:
              print_event:
                var_root: output
    ```
2. Navigate down from project -> rulebook -> ruleset
3. The original bug result would 500
4. There should be no server error and a result for the ruleset detail should return


