### PR TITLE
AAP 8180 pg copy support

### DIFF
--- a/src/aap_eda/core/models/base.py
+++ b/src/aap_eda/core/models/base.py
@@ -158,8 +158,11 @@ class ModelCopyWriter(DictCopyWriter):
         self,
         copyfile: TextIO,
         model: models.Model,
+        *,
+        pk_in_data=False,
     ):
         self.model = model
+        self.pk_in_data = pk_in_data
         # Sets fieldnames, fieldtypes
         self._resolve_fields()
         super().__init__(copyfile, self.fieldnames)
@@ -169,6 +172,8 @@ class ModelCopyWriter(DictCopyWriter):
         self.fieldtypes = {}
 
         for field in self.model._meta.concrete_fields:
+            if field.primary_key and not self.pk_in_data:
+                continue
             self.fieldnames.append(field.name)
             self.fieldtypes[field.name] = type(field)
 

--- a/tests/integration/core/test_db_mixin.py
+++ b/tests/integration/core/test_db_mixin.py
@@ -128,13 +128,21 @@ def test_adapt_copy_types_dict(test_record):
 
 
 @pytest.mark.django_db
+def test_model_writer_pk_switch(eek_model):
+    writer = base.ModelCopyWriter(StringIO(), eek_model)
+    assert eek_model._meta.pk.name not in writer.fieldnames
+    writer = base.ModelCopyWriter(StringIO(), eek_model, pk_in_data=True)
+    assert eek_model._meta.pk.name in writer.fieldnames
+
+
+@pytest.mark.django_db
 def test_adapt_copy_types_model(eek_model):
     eek = eek_model(
         label="test_model_adapt",
         data={"quatloos": 300},
         lista=[1, 2, 3],
     )
-    writer = base.ModelCopyWriter(StringIO(), eek_model)
+    writer = base.ModelCopyWriter(StringIO(), eek_model, pk_in_data=True)
     rec = writer._model_to_dict(eek)
     assert type(rec["id"]) == base.Copyfy
     assert type(rec["label"]) == base.Copyfy


### PR DESCRIPTION
## Jira Ticket

[AAP-8180](https://issues.redhat.com/browse/AAP-8180)

## Description

Adds a `DictCopyWriter` class and a `ModelCopyWriter` class that will provide the write-to-copy-file interface. These will adapt python types to copy-output representations.

## Usage

```python
# Example of bulk loading projects
# Setup
from datetime import datetime, timezone
import os
import time
from random import seed, randrange

from django.db import connection
from aap_eda.core.models import base, Project

connection.connect()
seed(time.time())

def get_project_data(records):
    for i in range(records):
        proj_num = randrange(100, 100000)
        created_ts = datetime.now(tz=timezone.utc)
        yield {
            "git_hash": "",
            "url": "",
            "name": f"project-{proj_num}", 
            "description": f"test project {proj_num}",
            "created_at": created_ts,
            "modified_at": created_ts,
        }
# END Setup

# Example 1: COPY Project instances using .writerow()
with open("project_copy.dat", "wt+") as proj_copy_file:
    cp_writer = base.ModelCopyWriter(proj_copy_file, Project)
    for project_data in get_project_data(10):
        cp_writer.writerow(Project(**project_data))
    proj_copy_file.seek(0)
    base.copy_to_table(
        connection,
        Project._meta.db_table,
        cp_writer.fieldnames,
        proj_copy_file,
    )

os.unlink("project_copy.dat")
# END Example 1

# Example 2: COPY dict instances using .writerows()
with open("project_copy2.dat", "wt") as proj_copy_file:
    cp_writer = base.DictCopyWriter(
        proj_copy_file, 
        [f.name for f in Project._meta.concrete_fields if not f.primary_key]
    )
    cp_writer.writerows(get_project_data(10))

base.copy_to_table(
    connection,
    Project._meta.db_table,
    cp_writer.fieldnames,
    open("project_copy2.dat", "rt"),
)

os.unlink("project_copy2.dat")
# END Example 2
```

## Testing

1. Execute `python ./src/aap_eda/manage.py shell`
2. Copy the **Setup** section and the **Example 1** section into the shell.
3. Connect to the local database using `psql` (Don't exit the python shell)
4. In `psql` execute 
    ```sql
    select * from core_project;
    ```
    You should see 10 records in the output like:
    ```
     id | git_hash | url |     name      |    description     |          created_at           |          modified_at          | large_data_id 
    ----+----------+-----+---------------+--------------------+-------------------------------+-------------------------------+---------------
      2 |          |     | project-46109 | test project 46109 | 2023-01-23 23:49:52.071062+00 | 2023-01-23 23:49:52.071062+00 |              
      3 |          |     | project-53729 | test project 53729 | 2023-01-23 23:49:52.071583+00 | 2023-01-23 23:49:52.071583+00 |              
      4 |          |     | project-4538  | test project 4538  | 2023-01-23 23:49:52.071793+00 | 2023-01-23 23:49:52.071793+00 |              
      5 |          |     | project-52398 | test project 52398 | 2023-01-23 23:49:52.072009+00 | 2023-01-23 23:49:52.072009+00 |              
    ...
    ```
5. Switch back to the python shell.
6. Copy the **Example 2** code into the shell.
7. In `psql` execute 
    ```sql
    select * from core_project;
    ```
    You should now see a total of 20 records in the output like:
    ```
     id | git_hash | url |     name      |    description     |          created_at           |          modified_at          | large_data_id 
    ----+----------+-----+---------------+--------------------+-------------------------------+-------------------------------+---------------
    ...
      4 |          |     | project-4538  | test project 4538  | 2023-01-23 23:49:52.071793+00 | 2023-01-23 23:49:52.071793+00 |              
      5 |          |     | project-52398 | test project 52398 | 2023-01-23 23:49:52.072009+00 | 2023-01-23 23:49:52.072009+00 |              
      6 |          |     | project-46228 | test project 46228 | 2023-01-23 23:49:52.07219+00  | 2023-01-23 23:49:52.07219+00  |              
      7 |          |     | project-8242  | test project 8242  | 2023-01-23 23:49:52.072347+00 | 2023-01-23 23:49:52.072347+00 |              
      8 |          |     | project-15423 | test project 15423 | 2023-01-23 23:49:52.072536+00 | 2023-01-23 23:49:52.072536+00 |              
    ...
    ```
