### PR TITLE
Update poetry-lock hook in pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,4 @@ repos:
     hooks:
       - id: poetry-check
       - id: poetry-lock
+        args: ["--check"]


### PR DESCRIPTION
By default `poetry lock` attempts to update all dependencies in the lock file, which causes unintended changes in the `poetry.lock` file. This change changes `poetry-lock` pre-commit hook to only check if the `poetry.lock` file is consistent.

In case of conflict, a developer must manually call either `poetry update`, `poetry lock` or `poetry lock --no-update` to resolve it.