### PR TITLE
[AAP-8993] Add the ability to run a single test mod or single test via task

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -52,8 +52,6 @@ tasks:
           $ task test -- tests/integration/api/test_activation.py
         Run a single test from a module
           $ task test -- tests/integration/api/test_activation.py::test_retrieve_activation
-       Exclude a single test 
-          $ task test -- tests/integration/api/test_activation.py -k test_retrieve_activation
     cmds:
       - '{{.PYTEST_CMD}} {{.CLI_ARGS}}'
 


### PR DESCRIPTION
[AAP-8993](https://issues.redhat.com/browse/AAP-8993)

```
      Example(s):
        Run a single test module
          $ task test -- tests/integration/api/test_activation.py
        Run a single test from a module
          $ task test -- tests/integration/api/test_activation.py::test_retrieve_activation