### PR TITLE
Fix incorrect client class used in API tests

### DIFF
--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -1,0 +1,26 @@
+#  Copyright 2023 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+from rest_framework.test import APIClient
+
+
+@pytest.fixture
+def client() -> APIClient:
+    """Override pytest-django client fixture.
+
+    Return an instance of ``rest_framework.test.APIClient`` class
+    instead of base ``django.test.Client`` class.
+    """
+    return APIClient()

--- a/tests/integration/api/test_self.py
+++ b/tests/integration/api/test_self.py
@@ -1,0 +1,19 @@
+#  Copyright 2023 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from rest_framework.test import APIClient
+
+
+def test_client_fixture(client: APIClient):
+    assert isinstance(client, APIClient)


### PR DESCRIPTION
While the annotation used everywhere in the tests states that the `rest_framework.test.APIClient` is expected, in reality tests were using the `django.test.Client` class.

This creates a problem of incorrect content type being passed to API handlers. For instance `client.put` sends the `application/octet-stream` content type.