### PR TITLE
[AAP-9256] update for minikube task

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -219,12 +219,12 @@ tasks:
         vars:
           CLI_ARGS: port-forward-api {{.CLI_ARGS}}
 
-  minikube:logs:api:
-    desc: "Get eda-api server pod logs"
+  minikube:logs:eda:
+    desc: "Stream logs for EDA application"
     cmds:
       - task: minikube
         vars:
-          CLI_ARGS: eda-api-logs {{.CLI_ARGS}}
+          CLI_ARGS: eda-logs {{.CLI_ARGS}}
 
   minikube:all:
     desc: "clean, build, deploy"

--- a/scripts/eda_kube.sh
+++ b/scripts/eda_kube.sh
@@ -38,7 +38,7 @@ usage() {
     log-info "\t clean                        remove deployment directory and all EDA resource from minikube"
     log-info "\t port-forward-api             forward local port to EDA API (default: 8000)"
     log-info "\t port-forward-ui              forward local port to EDA UI (default: 8080)"
-    log-info "\t eda-api-logs                 get eda-api pod logs"
+    log-info "\t eda-logs                     stream logs for all container in eda application"
     log-info "\t help                         show usage"
 }
 
@@ -190,11 +190,9 @@ port-forward-api() {
   port-forward "${_svc_name}" "${_local_port}" "${_svc_port}"
 }
 
-get-eda-api-logs() {
-  local _pod_name=$(kubectl get pod -l comp=api -o jsonpath="{.items[0].metadata.name}")
-
-  log-debug "kubectl logs ${_pod_name} -f"
-  kubectl logs "${_pod_name}" -f
+get-eda-logs() {
+  log-debug "kubectl logs -n ${NAMESPACE} -l app=eda -f"
+  kubectl logs -n "${NAMESPACE}" -l app=eda -f
 }
 
 #
@@ -206,7 +204,7 @@ case ${CMD} in
   "deploy") deploy "${VERSION}" ;;
   "port-forward-api") port-forward-api 8000 ;;
   "port-forward-ui") port-forward-ui 8080 ;;
-  "eda-api-logs") get-eda-api-logs ;;
+  "eda-logs") get-eda-logs ;;
   "help") usage ;;
    *) usage ;;
 esac


### PR DESCRIPTION
[AAP-9256](https://issues.redhat.com/browse/AAP-9256)

Example:
```
> task minikube:logs:eda
task: [minikube] scripts/eda_kube.sh eda-logs 
2023-02-13 15:48:14 [DEBUG	]  kubectl logs -n aap-eda -l app=eda -f
2023-02-13 20:26:12,254 INFO     HTTP GET /static/rest_framework/js/jquery-3.5.1.min.js 200 [0.01, 127.0.0.1:44138]
2023-02-13 20:26:12,255 INFO     HTTP GET /static/rest_framework/js/csrf.js 200 [0.01, 127.0.0.1:44116]
2023-02-13 20:26:12,257 INFO     HTTP GET /static/rest_framework/css/bootstrap-tweaks.css 200 [0.01, 127.0.0.1:44160]
2023-02-13 20:26:12,258 INFO     HTTP GET /static/rest_framework/js/ajax-form.js 200 [0.01, 127.0.0.1:44148]
2023-02-13 20:26:12,260 INFO     HTTP GET /static/rest_framework/css/default.css 200 [0.00, 127.0.0.1:44164]
server stopped

PostgreSQL init process complete; ready for start up.

2023-02-13 20:06:45.716 UTC [1] LOG:  starting PostgreSQL 13.10 (Debian 13.10-1.pgdg110+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
2023-02-13 20:06:45.716 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2023-02-13 20:06:45.716 UTC [1] LOG:  listening on IPv6 address "::", port 5432
2023-02-13 20:06:45.717 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2023-02-13 20:06:45.722 UTC [64] LOG:  database system was shut down at 2023-02-13 20:06:45 UTC
2023-02-13 20:26:12,262 INFO     HTTP GET /static/rest_framework/js/bootstrap.min.js 200 [0.01, 127.0.0.1:44130]
2023-02-13 20:26:12,264 INFO     HTTP GET /static/rest_framework/js/default.js 200 [0.00, 127.0.0.1:44138]
2023-02-13 20:26:12,265 INFO     HTTP GET /static/rest_framework/js/prettify-min.js 200 [0.00, 127.0.0.1:44116]
2023-02-13 20:06:45.726 UTC [1] LOG:  database system is ready to accept connections
    return subprocess.run(
  File "/usr/lib64/python3.9/subprocess.py", line 505, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib64/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib64/python3.9/subprocess.py", line 1696, in _execute_child
2023-02-13 20:26:12,274 INFO     HTTP GET /static/rest_framework/img/grid.png 200 [0.00, 127.0.0.1:44116]
2023-02-13 20:41:47,669 INFO     HTTP POST /api/eda/v1/projects 202 [0.02, 127.0.0.1:37478]
    and os.path.dirname(executable)
127.0.0.1 - - [13/Feb/2023:20:11:04 +0000] "GET /api/eda/v1/projects/NaN HTTP/1.1" 404 23 "http://localhost:8080/eda/projects/create" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36" "-"
127.0.0.1 - - [13/Feb/2023:20:11:09 +0000] "GET /api/eda/v1/projects/NaN HTTP/1.1" 404 23 "http://localhost:8080/eda/projects/create" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36" "-"
127.0.0.1 - - [13/Feb/2023:20:11:14 +0000] "GET /api/eda/v1/projects/NaN HTTP/1.1" 404 23 "http://localhost:8080/eda/projects/create" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36" "-"
```