### PR TITLE
Django 3.2 Compatibility: Check constraints

### DIFF
--- a/src/aap_eda/core/migrations/0002_aap_eda_model_init.py
+++ b/src/aap_eda/core/migrations/0002_aap_eda_model_init.py
@@ -508,7 +508,6 @@ class Migration(migrations.Migration):
             constraint=models.CheckConstraint(
                 check=models.Q(("name", ""), _negated=True),
                 name="ck_empty_project_name",
-                violation_error_message="Project name cannot be empty.",
             ),
         ),
         migrations.AddField(
@@ -686,7 +685,6 @@ class Migration(migrations.Migration):
             constraint=models.CheckConstraint(
                 check=models.Q(("name", ""), _negated=True),
                 name="ck_rulebook_name_not_empty",
-                violation_error_message="Rulebook name must not be empty.",
             ),
         ),
         migrations.AlterUniqueTogether(
@@ -728,7 +726,6 @@ class Migration(migrations.Migration):
                     )
                 ),
                 name="ck_resource_type_values",
-                violation_error_message="Value not defined in Resource Type Enum.",
             ),
         ),
         migrations.AddConstraint(
@@ -738,7 +735,6 @@ class Migration(migrations.Migration):
                     ("action__in", ("create", "read", "update", "delete"))
                 ),
                 name="ck_action_values",
-                violation_error_message="Value not defined in Action Enum.",
             ),
         ),
         migrations.AlterUniqueTogether(
@@ -766,7 +762,6 @@ class Migration(migrations.Migration):
                     )
                 ),
                 name="ck_inventory_source_values",
-                violation_error_message="Value not defined in Inventory Source enum.",
             ),
         ),
         migrations.AddConstraint(
@@ -774,7 +769,6 @@ class Migration(migrations.Migration):
             constraint=models.CheckConstraint(
                 check=models.Q(("name", ""), _negated=True),
                 name="ck_empty_inventory_name",
-                violation_error_message="Inventory name cannot be empty.",
             ),
         ),
         migrations.AddIndex(

--- a/src/aap_eda/core/models/auth.py
+++ b/src/aap_eda/core/models/auth.py
@@ -52,14 +52,10 @@ class RolePermission(models.Model):
             models.CheckConstraint(
                 check=models.Q(resource_type__in=ResourceType.values()),
                 name="ck_resource_type_values",
-                violation_error_message=(
-                    "Value not defined in Resource Type Enum."
-                ),
             ),
             models.CheckConstraint(
                 check=models.Q(action__in=Action.values()),
                 name="ck_action_values",
-                violation_error_message="Value not defined in Action Enum.",
             ),
         ]
         indexes = [

--- a/src/aap_eda/core/models/inventory.py
+++ b/src/aap_eda/core/models/inventory.py
@@ -26,14 +26,10 @@ class Inventory(models.Model):
             models.CheckConstraint(
                 check=models.Q(inventory_source__in=InventorySource.values()),
                 name="ck_inventory_source_values",
-                violation_error_message=(
-                    "Value not defined in Inventory Source enum."
-                ),
             ),
             models.CheckConstraint(
                 check=~models.Q(name=""),
                 name="ck_empty_inventory_name",
-                violation_error_message="Inventory name cannot be empty.",
             ),
         ]
         indexes = [

--- a/src/aap_eda/core/models/project.py
+++ b/src/aap_eda/core/models/project.py
@@ -36,7 +36,6 @@ class Project(models.Model):
             models.CheckConstraint(
                 check=~models.Q(name=""),
                 name="ck_empty_project_name",
-                violation_error_message="Project name cannot be empty.",
             )
         ]
 

--- a/src/aap_eda/core/models/rulebook.py
+++ b/src/aap_eda/core/models/rulebook.py
@@ -30,7 +30,6 @@ class Rulebook(models.Model):
             models.CheckConstraint(
                 check=~models.Q(name=""),
                 name="ck_rulebook_name_not_empty",
-                violation_error_message="Rulebook name must not be empty.",
             ),
         ]
 


### PR DESCRIPTION
Remove `violation_error_message` argument in `CheckConstraint`, since it was introduced in Django 4.1.