### PR TITLE
[AAP-9692] Add the ability to over ride docker image name

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -186,6 +186,18 @@ $ docker images
 REPOSITORY                                    TAG         IMAGE ID       CREATED        SIZE
 localhost/aap-eda                             latest      28fd94c8cf89   5 hours ago    611MB
 ```
+To override image name:(using short git hash for version here)
+
+```shell
+export EDA_IMAGE="ansible/eda-server:$(git rev-parse --short HEAD)"; task docker:build
+```
+
+```shell
+$ docker images
+
+REPOSITORY                      TAG         IMAGE ID       CREATED          SIZE
+ansible/eda-server              12146d8     51fb0c850b94   10 minutes ago   682MB
+```
 
 ### Running services
 

--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -6,7 +6,7 @@ x-environment:
 
 services:
   api:
-    image: 'localhost/aap-eda'
+    image: "${EDA_IMAGE:-localhost/aap-eda}"
     build:
       context: ../../
       dockerfile: tools/docker/Dockerfile


### PR DESCRIPTION
[AAP-9692](https://issues.redhat.com/browse/AAP-9692)

```
> export EDA_IMAGE="ansible/eda-server:$(git rev-parse --short HEAD)"; task docker:build
> docker images
REPOSITORY                    TAG      IMAGE ID        CREATED          SIZE
ansible/eda-server           12146d8   51fb0c850b94   44 minutes ago   682MB
```

```
> export EDA_IMAGE="ansible/eda-server:"; task docker:build
> docker images
REPOSITORY                    TAG      IMAGE ID        CREATED          SIZE
ansible/eda-server           latest   51fb0c850b94   44 minutes ago    682MB
```