### PR TITLE
Set root group permissions on needed directories for ocp deployments

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -30,4 +30,22 @@ RUN poetry install -E all --no-root
 COPY . ${WORKDIR}
 RUN poetry install -E all --only-root
 
+
+# Pre-create things we need to access
+USER 0
+RUN for dir in \
+      /app \
+      /app/venv \
+      /app/venv/bin ; \
+    do mkdir -m 0775 -p $dir ; chmod g+rwx $dir ; chgrp root $dir ; done && \
+    for file in \
+      /etc/subuid \
+      /etc/subgid \
+      /etc/group \
+      /etc/passwd ; \
+    do touch $file ; chmod g+rw $file ; chgrp root $file ; done
+
+USER "$USER_ID"
+
+
 CMD ["aap-eda-manage", "runserver", "0.0.0.0:8000"]


### PR DESCRIPTION
When creating a pod in Openshift, a random uid and gid are set. As a result, any logic that relies solely on the user UID being 1001 will not work.

To enable the aap-eda-manage command to be run in the eda-server container when deployed on Openshift, we add root group permissions on the /app/env directory.

This follows the pattern used in the awx-operator here:
* https://github.com/ansible/awx/blob/devel/tools/ansible/roles/dockerfile/templates/Dockerfile.j2#L225-L244