### PR TITLE
Fix workdir variable in Dockerfile

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -4,7 +4,7 @@ ARG USER_ID=${USER_ID:-1001}
 RUN useradd --uid "$USER_ID" --gid 0 --home-dir /app --create-home eda
 
 RUN DNF=dnf \
-    INSTALL_PACKAGES="python3 python3-devel python3-pip libpq-devel gcc git" \
+    INSTALL_PACKAGES="python3 python3-devel python3-pip libpq-devel gcc git-core" \
     && $DNF -y install $INSTALL_PACKAGES \
     && $DNF -y clean all \
     && rm -rf /var/cache/dnf
@@ -17,17 +17,18 @@ ENV POETRY_VERSION='1.3.1' \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     POETRY_NO_INTERACTION=1 \
     VIRTUAL_ENV=/app/venv \
+    SOURCES_DIR=/app/src \
     PATH="/app/venv/bin:/app/.local/bin:$PATH"
 
 RUN python3 -m pip install --user "poetry==${POETRY_VERSION}" \
     && python3 -m venv "$VIRTUAL_ENV" \
     && poetry config virtualenvs.create false
 
-WORKDIR /app/src
+WORKDIR $SOURCES_DIR
 
-COPY pyproject.toml poetry.lock ${WORKDIR}/
+COPY pyproject.toml poetry.lock $SOURCES_DIR/
 RUN poetry install -E all --no-root
-COPY . ${WORKDIR}/
+COPY . $SOURCES_DIR/
 RUN poetry install -E all --only-root
 
 CMD ["aap-eda-manage", "runserver", "0.0.0.0:8000"]


### PR DESCRIPTION
During the image build process, the environment variable `WORKDIR` equals to `/` regardless of `WORKDIR /app/src` build instruction.