### PR TITLE
[AAP-9892] Add ability to access Django shell via task

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -174,12 +174,19 @@ tasks:
         vars:
           CLI_ARGS: exec postgres psql -U postgres eda
 
-  docker:shell:
-    desc: "Run the management shell"
+  docker:shell:api:
+      desc: "Run the management shell in api container"
+      cmds:
+        - task: docker
+          vars:
+            CLI_ARGS: exec -it api aap-eda-manage shell
+
+  docker:shell:worker:
+    desc: "Run the management shell in worker container"
     cmds:
       - task: docker
         vars:
-          CLI_ARGS: run --rm api aap-eda-manage shell
+          CLI_ARGS: exec -it worker aap-eda-manage shell
 
   minikube:
     desc: "Run eda_kube.sh with specified CLI arguments."


### PR DESCRIPTION
[AAP-9892](https://issues.redhat.com/browse/AAP-9892)

Examples of new tasks:
```
 > task docker:shell:api
task: [docker] docker-compose -p eda -f tools/docker/docker-compose-dev.yaml exec -it api aap-eda-manage shell
Python 3.9.14 (main, Jan  9 2023, 00:00:00) 
[GCC 11.3.1 20220421 (Red Hat 11.3.1-2)] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> 
```

```
> task docker:shell:worker
task: [docker] docker-compose -p eda -f tools/docker/docker-compose-dev.yaml exec -it worker aap-eda-manage shell
Python 3.9.14 (main, Jan  9 2023, 00:00:00) 
[GCC 11.3.1 20220421 (Red Hat 11.3.1-2)] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> 
```