### PR TITLE
[AAP-9898] Add task for Postgres port forward when running in minikube config

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -233,6 +233,13 @@ tasks:
         vars:
           CLI_ARGS: port-forward-api {{.CLI_ARGS}}
 
+  minikube:fp:pg:
+    desc: "Forward local port to postgres instance port in minikube"
+    cmds:
+      - task: minikube
+        vars:
+          CLI_ARGS: port-forward-pg {{.CLI_ARGS}}
+
   minikube:logs:eda:
     desc: "Stream logs for EDA application"
     cmds:

--- a/scripts/eda_kube.sh
+++ b/scripts/eda_kube.sh
@@ -38,6 +38,7 @@ usage() {
     log-info "\t clean                        remove deployment directory and all EDA resource from minikube"
     log-info "\t port-forward-api             forward local port to EDA API (default: 8000)"
     log-info "\t port-forward-ui              forward local port to EDA UI (default: 8080)"
+    log-info "\t port-forward-pg              forward local port to Postgres (default: 5432)"
     log-info "\t eda-logs                     stream logs for all container in eda application"
     log-info "\t help                         show usage"
 }
@@ -190,6 +191,16 @@ port-forward-api() {
   port-forward "${_svc_name}" "${_local_port}" "${_svc_port}"
 }
 
+port-forward-pg() {
+  local _local_port=${1}
+  local _svc_name=eda-postgres
+  local _svc_port=5432
+
+  log-debug "port-forward ${_svc_name} ${_local_port} ${_svc_port}"
+  port-forward "${_svc_name}" "${_local_port}" "${_svc_port}"
+}
+
+
 get-eda-logs() {
   log-debug "kubectl logs -n ${NAMESPACE} -l app=eda -f"
   kubectl logs -n "${NAMESPACE}" -l app=eda -f
@@ -204,6 +215,7 @@ case ${CMD} in
   "deploy") deploy "${VERSION}" ;;
   "port-forward-api") port-forward-api 8000 ;;
   "port-forward-ui") port-forward-ui 8080 ;;
+  "port-forward-pg") port-forward-pg 5432 ;;
   "eda-logs") get-eda-logs ;;
   "help") usage ;;
    *) usage ;;


### PR DESCRIPTION
[AAP-9898](https://issues.redhat.com/browse/AAP-9898)

```
> task minikube:fp:pg
task: [minikube] scripts/eda_kube.sh port-forward-pg 
2023-03-06 10:51:20 [INFO	]  kubectl port-forward svc/eda-postgres 5432:5432
Forwarding from 127.0.0.1:5432 -> 5432
Forwarding from [::1]:5432 -> 5432
```