### PR TITLE
Add two instances of the worker for docker-compose

### DIFF
--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -31,6 +31,8 @@ services:
       - '../../:/app/src:z'
 
   worker:
+    deploy:
+      replicas: 2
     image: 'localhost/aap-eda'
     environment: *common-env
     command:

--- a/tools/docker/docker-compose-stage.yaml
+++ b/tools/docker/docker-compose-stage.yaml
@@ -32,6 +32,8 @@ services:
       retries: 10
 
   worker:
+    deploy:
+      replicas: 2
     image: 'localhost/aap-eda'
     environment: *common-env
     command:


### PR DESCRIPTION
Adds multiple instances of the worker. I think this is a healthy practice that enable parallelism and allows to find possible errors.