### PR TITLE
[AAP-9951] Add filter description doc strings

### DIFF
--- a/src/aap_eda/api/filters/project.py
+++ b/src/aap_eda/api/filters/project.py
@@ -20,7 +20,7 @@ from aap_eda.core import models
 class ProjectFilter(django_filters.FilterSet):
     name = django_filters.CharFilter(
         field_name="name",
-        lookup_expr="startswith",
+        lookup_expr="istartswith",
         label="Filter by project name.",
     )
     url = django_filters.CharFilter(


### PR DESCRIPTION
Jira Ticket: [AAP-9951](https://issues.redhat.com/browse/AAP-9951)

Purpose: The API docs endpoints were missing descriptions for the project filters


Testing instructions:
1.) insure that there are descriptions for both name and url query params in the [api docs](http://127.0.0.1:8000/api/eda/v1/docs#/projects/projects_list) 