### PR TITLE
[AAP-10041] Install ansible-rulebook in docker image

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,14 +1,15 @@
-FROM registry.access.redhat.com/ubi9/ubi
-ARG USER_ID=${USER_ID:-1001}
+FROM registry.access.redhat.com/ubi9/ubi:latest
 
+ARG USER_ID=${USER_ID:-1001}
 RUN useradd --uid "$USER_ID" --gid 0 --home-dir /app --create-home eda \
-    && mkdir -p /var/lib/eda/ \
-    && chown "${USER_ID}:0" /var/lib/eda \
-    && chmod g+w /var/lib/eda
+    && mkdir -p /app/.local /var/lib/eda/ \
+    && chown -R "${USER_ID}:0" /app/.local /var/lib/eda \
+    && chmod 0775 /app /var/lib/eda
 
 RUN DNF=dnf \
-    INSTALL_PACKAGES="python3 python3-devel python3-pip libpq-devel gcc git-core" \
-    && $DNF -y install $INSTALL_PACKAGES \
+    INSTALL_PACKAGES=(python3 python3-devel python3-pip libpq-devel  \
+                      gcc git-core java-17-openjdk-headless) \
+    && $DNF -y install "${INSTALL_PACKAGES[@]}" \
     && $DNF -y clean all \
     && rm -rf /var/cache/dnf
 
@@ -21,16 +22,27 @@ ENV POETRY_VERSION='1.4.0' \
     POETRY_NO_INTERACTION=1 \
     VIRTUAL_ENV=/app/venv \
     SOURCES_DIR=/app/src \
-    PATH="/app/venv/bin:/app/.local/bin:$PATH"
+    PATH="/app/.local/bin:$PATH"
 
+# Install poetry, create virtual environment
 RUN python3 -m pip install --user "poetry==${POETRY_VERSION}" \
     && python3 -m venv "$VIRTUAL_ENV" \
     && poetry config virtualenvs.create false
 
+# Install ansible
+ARG EDA_COLLECTION=${EDA_COLLECTION:-ansible.eda}
+RUN python3 -m pip install --user ansible \
+    && ansible-galaxy collection install "$EDA_COLLECTION"
+
+# Install ansible-rulebook
+ARG ANSIBLE_RULEBOOK=${ANSIBLE_RULEBOOK:-ansible-rulebook}
+RUN python3 -m pip install --user "$ANSIBLE_RULEBOOK"
+
 WORKDIR $SOURCES_DIR
 
+ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 COPY pyproject.toml poetry.lock $SOURCES_DIR/
-RUN poetry install -E all --no-root
+RUN poetry install -E all --no-root --no-cache
 COPY . $SOURCES_DIR/
 RUN poetry install -E all --only-root
 


### PR DESCRIPTION
At the container build, the `ansible-rulebook` distribution
package is installed. The latest version available on PyPI
is installed by default.

It can be customized by specifying `ANSIBLE_RULEBOOK_URL`
build argument.

Example:

    ANSIBLE_RULEBOOK_URL=git+https://github.com/ansible/ansible-rulebook


Resolves: https://issues.redhat.com/browse/AAP-10041