### PR TITLE
Fix logic for user script

### DIFF
--- a/scripts/create_superuser.sh
+++ b/scripts/create_superuser.sh
@@ -26,23 +26,22 @@ usage() {
 }
 
 create_user() {
-    log-debug "poetry run /usr/bin/env src/aap_eda/manage.py createsuperuser --noinput"
-    local _result
-    _result=$(poetry run /usr/bin/env src/aap_eda/manage.py createsuperuser --noinput 2>&1 || true)
-    
-    if [[ "${_result}" =~ "username is already taken" ]]; then
-        log-info "username ${DJANGO_SUPERUSER_USERNAME} is already taken"
-        exit 0
-    elif [[ "${_result}" =~ "Superuser created successfully" ]]; then
-        log-info "Superuser created"
-        log-info "\t User: ${DJANGO_SUPERUSER_USERNAME}"
-        log-info "\t Password: ${DJANGO_SUPERUSER_PASSWORD}"
-        log-info "\t Email: ${DJANGO_SUPERUSER_EMAIL}"
-        exit 0
-    else
-        log-err "${_result}"
-        exit 1
-    fi
+  log-debug "poetry run /usr/bin/env src/aap_eda/manage.py createsuperuser --noinput"
+  local _result=$(poetry run /usr/bin/env src/aap_eda/manage.py createsuperuser --noinput 2>&1)
+
+  if [[ "${_result}" =~ "Superuser created successfully" ]]; then
+    log-info "Superuser created"
+    log-debug "\t User: ${DJANGO_SUPERUSER_USERNAME}"
+    log-debug "\t Password: ${DJANGO_SUPERUSER_PASSWORD}"
+    log-debug "\t Email: ${DJANGO_SUPERUSER_EMAIL}"
+
+  elif [[ "${_result}" =~ "username is already taken" ]]; then
+    log-warn "username ${DJANGO_SUPERUSER_USERNAME} is already taken"
+
+  else [ -n "${_result}" ]
+    log-err "${_result}"
+    exit 1
+  fi
 }
 
 #


### PR DESCRIPTION
Quick fix for default user creation

When user is created:
```
> docker logs eda-api-1
Operations to perform:
  Apply all migrations: auth, contenttypes, core, django_rq, sessions
Running migrations:
  Applying contenttypes.0001_initial... OK
  Applying contenttypes.0002_remove_content_type_name... OK
  Applying auth.0001_initial... OK
  Applying auth.0002_alter_permission_name_max_length... OK
  Applying auth.0003_alter_user_email_max_length... OK
  Applying auth.0004_alter_user_username_opts... OK
  Applying auth.0005_alter_user_last_login_null... OK
  Applying auth.0006_require_contenttypes_0002... OK
  Applying auth.0007_alter_validators_add_error_messages... OK
  Applying auth.0008_alter_user_username_max_length... OK
  Applying auth.0009_alter_user_last_name_max_length... OK
  Applying auth.0010_alter_group_name_max_length... OK
  Applying auth.0011_update_proxy_permissions... OK
  Applying auth.0012_alter_user_first_name_max_length... OK
  Applying core.0001_initial... OK
  Applying core.0002_aap_eda_model_init... OK
  Applying core.0003_alter_rulebook_rulesets... OK
  Applying core.0004_alter_project_description... OK
  Applying core.0005_remove_activationinstance_ix_act_inst_name_and_more... OK
  Applying core.0006_alter_activation_restart_policy_and_more... OK
  Applying core.0007_remove_large_data_id... OK
  Applying core.0008_project_archive_file... OK
  Applying core.0009_rename_rule_id_auditrule_rule... OK
  Applying core.0010_auto_20230306_1329... OK
  Applying django_rq.0001_initial... OK
  Applying sessions.0001_initial... OK
2023-03-16 12:04:14 [INFO	] Superuser created
Performing system checks...

System check identified no issues (0 silenced).
March 16, 2023 - 12:04:18
Django version 3.2.18, using settings 'aap_eda.settings.development'
Starting ASGI/Daphne version 4.0.0 development server at http://0.0.0.0:8000/
Quit the server with CONTROL-C.
```

When user already exists:
```
 > docker logs eda-api-1
Operations to perform:
  Apply all migrations: auth, contenttypes, core, django_rq, sessions
Running migrations:
  No migrations to apply.
2023-03-16 12:04:49 [WARNING	] username admin is already taken
Performing system checks...
```

