### PR TITLE
[AAP-9990] Add support for AWX personal access tokens

### DIFF
--- a/src/aap_eda/api/serializers/__init__.py
+++ b/src/aap_eda/api/serializers/__init__.py
@@ -38,7 +38,7 @@ from .rulebook import (
     RulesetSerializer,
 )
 from .tasks import TaskRefSerializer, TaskSerializer
-from .user import ControllerTokenSerializer, UserSerializer
+from .user import AwxTokenSerializer, UserSerializer
 
 __all__ = (
     # auth
@@ -68,5 +68,5 @@ __all__ = (
     "ActivationInstanceLogSerializer",
     # users
     "UserSerializer",
-    "ControllerTokenSerializer",
+    "AwxTokenSerializer",
 )

--- a/src/aap_eda/api/serializers/user.py
+++ b/src/aap_eda/api/serializers/user.py
@@ -10,9 +10,9 @@ class UserSerializer(serializers.ModelSerializer):
         read_only_fields = ["username"]
 
 
-class ControllerTokenSerializer(serializers.ModelSerializer):
+class AwxTokenSerializer(serializers.ModelSerializer):
     class Meta:
-        model = models.ControllerToken
+        model = models.AwxToken
         fields = [
             "id",
             "name",

--- a/src/aap_eda/api/urls.py
+++ b/src/aap_eda/api/urls.py
@@ -33,8 +33,8 @@ router.register("tasks", views.TaskViewSet, basename="task")
 router.register("activations", views.ActivationViewSet)
 router.register("activation-instances", views.ActivationInstanceViewSet)
 router.register(
-    "users/me/controller-tokens",
-    views.CurrentUserControllerTokensViewSet,
+    "users/me/awx-tokens",
+    views.CurrentUserAwxTokensViewSet,
     basename="controller-token",
 )
 

--- a/src/aap_eda/api/views/__init__.py
+++ b/src/aap_eda/api/views/__init__.py
@@ -17,7 +17,7 @@ from .auth import SessionLoginView, SessionLogoutView
 from .project import ExtraVarViewSet, PlaybookViewSet, ProjectViewSet
 from .rulebook import RulebookViewSet, RulesetViewSet, RuleViewSet
 from .tasks import TaskViewSet
-from .user import CurrentUserControllerTokensViewSet, CurrentUserView
+from .user import CurrentUserAwxTokensViewSet, CurrentUserView
 
 __all__ = (
     # auth
@@ -37,5 +37,5 @@ __all__ = (
     "ActivationInstanceViewSet",
     # user
     "CurrentUserView",
-    "CurrentUserControllerTokensViewSet",
+    "CurrentUserAwxTokensViewSet",
 )

--- a/src/aap_eda/api/views/user.py
+++ b/src/aap_eda/api/views/user.py
@@ -49,43 +49,43 @@ class CurrentUserView(views.APIView):
 
 @extend_schema_view(
     list=extend_schema(
-        description="List current user controller tokens.",
+        description="List current user AWX tokens.",
         responses={
             status.HTTP_200_OK: OpenApiResponse(
-                serializers.ControllerTokenSerializer,
-                description="Return a list of controller tokens.",
+                serializers.AwxTokenSerializer,
+                description="Return a list of AWX tokens.",
             ),
         },
     ),
     retrieve=extend_schema(
-        description="Get current user controller token by ID.",
+        description="Get current user AWX token by ID.",
         responses={
             status.HTTP_200_OK: OpenApiResponse(
-                serializers.ControllerTokenSerializer,
-                description="Return a controller tokens.",
+                serializers.AwxTokenSerializer,
+                description="Return a AWX tokens.",
             ),
         },
     ),
     create=extend_schema(
-        description="Create a controller token for a current user.",
+        description="Create a AWX token for a current user.",
         responses={
             status.HTTP_201_CREATED: OpenApiResponse(
-                serializers.ControllerTokenSerializer,
-                description="Return the created controller token.",
+                serializers.AwxTokenSerializer,
+                description="Return the created AWX token.",
             ),
         },
     ),
     destroy=extend_schema(
-        description="Delete controller token of a current user by ID.",
+        description="Delete AWX token of a current user by ID.",
         responses={
             status.HTTP_204_NO_CONTENT: OpenApiResponse(
                 None,
-                description="The controller token has been deleted.",
+                description="The AWX token has been deleted.",
             ),
         },
     ),
 )
-class CurrentUserControllerTokensViewSet(
+class CurrentUserAwxTokensViewSet(
     mixins.CreateModelMixin,
     mixins.RetrieveModelMixin,
     mixins.DestroyModelMixin,
@@ -93,18 +93,18 @@ class CurrentUserControllerTokensViewSet(
     GenericViewSet,
 ):
     permission_classes = (permissions.IsAuthenticated,)
-    serializer_class = serializers.ControllerTokenSerializer
+    serializer_class = serializers.AwxTokenSerializer
 
     def get_queryset(self):
-        return models.ControllerToken.objects.filter(
-            user=self.request.user
-        ).order_by("id")
+        return models.AwxToken.objects.filter(user=self.request.user).order_by(
+            "id"
+        )
 
     def perform_create(self, serializer):
         try:
             serializer.save(user=self.request.user)
         except django.db.utils.IntegrityError:
-            name_exists = models.ControllerToken.objects.filter(
+            name_exists = models.AwxToken.objects.filter(
                 user=self.request.user, name=serializer.validated_data["name"]
             ).exists()
             if name_exists:

--- a/src/aap_eda/core/migrations/0011_awx_token.py
+++ b/src/aap_eda/core/migrations/0011_awx_token.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
-            name="ControllerToken",
+            name="AwxToken",
             fields=[
                 (
                     "id",

--- a/src/aap_eda/core/models/__init__.py
+++ b/src/aap_eda/core/models/__init__.py
@@ -24,7 +24,7 @@ from .job import (
 )
 from .project import ExtraVar, Playbook, Project
 from .rulebook import AuditRule, Rule, Rulebook, Ruleset
-from .user import ControllerToken, User
+from .user import AwxToken, User
 
 __all__ = [
     "ActivationInstanceJobInstance",
@@ -47,5 +47,5 @@ __all__ = [
     "Ruleset",
     "UserRole",
     "User",
-    "ControllerToken",
+    "AwxToken",
 ]

--- a/src/aap_eda/core/models/user.py
+++ b/src/aap_eda/core/models/user.py
@@ -32,7 +32,7 @@ class User(AbstractUser):
     pass
 
 
-class ControllerToken(models.Model):
+class AwxToken(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE, null=False)
     name = models.TextField(null=False, blank=False)
     description = models.TextField(null=False, blank=True, default="")


### PR DESCRIPTION
Add support for AWX personal access tokens
    
New API endpoints:
    
- `GET /users/me/controller-tokens/` - List controller tokens
- `POST /users/me/controller-tokens/` - Create a controller token
- `GET /users/me/controller-tokens/{id}/` - Retrieve a controller token
- `DELETE /users/me/controller-tokens/{id}/` - Delete a controller token


Depends-On: #110 