### PR TITLE
[AAP-10066] Add sending controller info to ansible-rulebook

### DIFF
--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -288,6 +288,4 @@ EDA_CONTROLLER_URL = settings.get("CONTROLLER_URL", "default_controller_url")
 EDA_CONTROLLER_TOKEN = settings.get(
     "CONTROLLER_TOKEN", "default_controller_token"
 )
-EDA_CONTROLLER_SSL_VERIFY = settings.get(
-    "CONTROLLER_SSL_VERIFY", "default_controller_ssl_verify"
-)
+EDA_CONTROLLER_SSL_VERIFY = settings.get("CONTROLLER_SSL_VERIFY", "yes")

--- a/src/aap_eda/wsapi/messages.py
+++ b/src/aap_eda/wsapi/messages.py
@@ -55,9 +55,22 @@ class WorkerMessage(Message):
     activation_id: int
 
 
-class DataPackage(BaseModel):
+class Rulebook(BaseModel):
     data: str
-    type: str
+    type: str = "Rulebook"
+
+
+class ExtraVars(BaseModel):
+    data: str
+    type: str = "ExtraVars"
+
+
+# ssl_verify is either yes|no, future may have cert
+class ControllerInfo(BaseModel):
+    type: str = "ControllerInfo"
+    url: str
+    token: str
+    ssl_verify: str
 
 
 class Hello(BaseModel):

--- a/tests/integration/wsapi/test_consumer.py
+++ b/tests/integration/wsapi/test_consumer.py
@@ -94,9 +94,7 @@ async def test_handle_workers():
         "Hello",
         "Rulebook",
         "ExtraVars",
-        "ControllerUrl",
-        "ControllerToken",
-        "ControllerSslVerify",
+        "ControllerInfo",
         "EndOfResponse",
     ]:
         response = await communicator.receive_json_from()


### PR DESCRIPTION
This PR contains:

- remove `Inventory` from websocket messages;
- add `ControllerInfo`, which contains `url, token` and `ssl_verify`;
- add `EndofResponse` message to mark the end of response

Depends: https://github.com/ansible/ansible-rulebook/pull/449