### PR TITLE
[AAP-9978] Add missing status field in Activation GET endpoints

### DIFF
--- a/src/aap_eda/api/serializers/__init__.py
+++ b/src/aap_eda/api/serializers/__init__.py
@@ -16,6 +16,7 @@ from .activation import (
     ActivationCreateSerializer,
     ActivationInstanceLogSerializer,
     ActivationInstanceSerializer,
+    ActivationListSerializer,
     ActivationReadSerializer,
     ActivationSerializer,
 )
@@ -75,6 +76,7 @@ __all__ = (
     "TaskSerializer",
     # activations
     "ActivationSerializer",
+    "ActivationListSerializer",
     "ActivationCreateSerializer",
     "ActivationReadSerializer",
     "ActivationInstanceSerializer",

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -21,7 +21,7 @@ from rest_framework.test import APIClient
 
 from aap_eda.api import serializers
 from aap_eda.core import models
-from aap_eda.core.enums import RestartPolicy
+from aap_eda.core.enums import ActivationStatus, RestartPolicy
 from tests.integration.constants import api_url_v1
 
 TEST_ACTIVATION = {
@@ -184,6 +184,7 @@ def test_list_activations(client: APIClient):
     for data, activation in zip(response.data["results"], activations):
         assert_activation_base_data(data, activation)
         assert_activation_related_object_fks(data, activation)
+        assert data["status"] == ActivationStatus.FAILED.value
 
 
 @pytest.mark.django_db
@@ -195,6 +196,7 @@ def test_retrieve_activation(client: APIClient):
     assert response.status_code == status.HTTP_200_OK
     data = response.data
     assert_activation_base_data(data, activation)
+    assert data["status"] == ActivationStatus.FAILED.value
     assert data["project"] == {"id": activation.project.id, **TEST_PROJECT}
     assert data["rulebook"] == {"id": activation.rulebook.id, **TEST_RULEBOOK}
     assert data["decision_environment"] == {


### PR DESCRIPTION
Add missing field 'status' in Activation read and list endpoints.

Partially resolves: AAP-9978