### PR TITLE
[AAP-10520] Fix project delete schema

### DIFF
--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -132,8 +132,9 @@ class PlaybookViewSet(
         description="Delete a project by id",
         responses={
             status.HTTP_204_NO_CONTENT: OpenApiResponse(
-                serializers.ProjectSerializer, description="Delete successful."
-            )
+                None,
+                description="Delete successful.",
+            ),
         },
     ),
 )


### PR DESCRIPTION
Project DELETE schema expects content in response, although the endpoints returns only status code without content. Fix the schema to return a response without content.

Resolves: AAP-10520