### PR TITLE
[AAP-10654] Add project hash in retrieving rulebook activation data

### DIFF
--- a/src/aap_eda/api/serializers/project.py
+++ b/src/aap_eda/api/serializers/project.py
@@ -42,7 +42,7 @@ class ProjectCreateRequestSerializer(serializers.ModelSerializer):
 class ProjectRefSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Project
-        fields = ["id", "url", "name", "description"]
+        fields = ["id", "git_hash", "url", "name", "description"]
         read_only_fields = ["id"]
 
 

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -38,6 +38,7 @@ TEST_ACTIVATION = {
 }
 
 TEST_PROJECT = {
+    "git_hash": "684f62df18ce5f8d5c428e53203b9b975426eed0",
     "name": "test-project-01",
     "url": "https://git.example.com/acme/project-01",
     "description": "test project",
@@ -69,6 +70,7 @@ collections:
 
 def create_activation_related_data():
     project_id = models.Project.objects.create(
+        git_hash=TEST_PROJECT["git_hash"],
         name=TEST_PROJECT["name"],
         url=TEST_PROJECT["url"],
         description=TEST_PROJECT["description"],


### PR DESCRIPTION
Include git_hash field in project when retrieving a rulebook activation through the API.

Resolves: AAP-10654