### PR TITLE
Add back credential username for list/retrieve endpoints

### DIFF
--- a/src/aap_eda/api/serializers/credential.py
+++ b/src/aap_eda/api/serializers/credential.py
@@ -25,7 +25,13 @@ class CredentialSerializer(serializers.ModelSerializer):
             "created_at",
             "modified_at",
         ]
-        fields = ["name", "description", "credential_type", *read_only_fields]
+        fields = [
+            "name",
+            "description",
+            "username",
+            "credential_type",
+            *read_only_fields,
+        ]
 
 
 class CredentialCreateSerializer(serializers.ModelSerializer):

--- a/tests/integration/api/test_credential.py
+++ b/tests/integration/api/test_credential.py
@@ -20,6 +20,7 @@ def test_list_credentials(client: APIClient):
     assert result == {
         "name": "credential1",
         "description": "",
+        "username": "me",
         "credential_type": CredentialType.REGISTRY.value,
         "id": obj.id,
     }
@@ -42,6 +43,7 @@ def test_create_credential(client: APIClient):
     assert result == {
         "name": "credential1",
         "description": "desc here",
+        "username": "me",
         "credential_type": CredentialType.REGISTRY.value,
         "id": id_,
     }
@@ -63,6 +65,7 @@ def test_retrieve_credential(client: APIClient):
     assert result == {
         "name": "credential1",
         "description": "",
+        "username": "me",
         "credential_type": CredentialType.REGISTRY.value,
         "id": obj.id,
     }
@@ -88,6 +91,7 @@ def test_update_credential(client: APIClient):
     assert result == {
         "name": "credential2",
         "description": "",
+        "username": "he",
         "credential_type": CredentialType.REGISTRY.value,
         "id": obj.id,
     }
@@ -110,6 +114,7 @@ def test_partial_update_credential(client: APIClient):
     assert result == {
         "name": "credential1",
         "description": "",
+        "username": "me",
         "credential_type": CredentialType.REGISTRY.value,
         "id": obj.id,
     }


### PR DESCRIPTION
Both username and secret fields were excluded from the return of list/retrieve endpoints. Add back username field because UI needs to display it.