### PR TITLE
[AAP-11203] Fix audit rule's last_fired_date and status to use right action's status and fired_at field

### DIFF
--- a/src/aap_eda/wsapi/consumers.py
+++ b/src/aap_eda/wsapi/consumers.py
@@ -195,6 +195,10 @@ class AnsibleRulebookConsumer(AsyncWebsocketConsumer):
             )
 
             logger.info(f"Audit rule [{audit_rule.name}] is created.")
+        else:
+            audit_rule.fired_at = message.run_at
+            audit_rule.status = message.status
+            audit_rule.save()
 
         audit_action = models.AuditAction.objects.filter(
             id=message.action_uuid


### PR DESCRIPTION
If a rule contains multiple actions, its audit rule's status and last_fired_date should alway use its last action's status and fired_at fields, rather than using the first one.

Resolves: [AAP-11203](https://issues.redhat.com/browse/AAP-11203)