### PR TITLE
Fix event payload with right data

### DIFF
--- a/src/aap_eda/wsapi/consumers.py
+++ b/src/aap_eda/wsapi/consumers.py
@@ -227,7 +227,7 @@ class AnsibleRulebookConsumer(AsyncWebsocketConsumer):
 
         matching_events = message.matching_events
         for event_meta in matching_events.values():
-            meta = event_meta.get("meta")
+            meta = event_meta.pop("meta")
             if meta:
                 audit_event = models.AuditEvent.objects.filter(
                     id=meta.get("uuid")
@@ -238,7 +238,7 @@ class AnsibleRulebookConsumer(AsyncWebsocketConsumer):
                         id=meta.get("uuid"),
                         source_name=meta.get("source", {}).get("name"),
                         source_type=meta.get("source", {}).get("type"),
-                        payload=meta,
+                        payload=event_meta,
                         received_at=meta.get("received_at"),
                         rule_fired_at=message.rule_run_at,
                     )

--- a/tests/integration/wsapi/test_consumer.py
+++ b/tests/integration/wsapi/test_consumer.py
@@ -249,6 +249,24 @@ async def test_handle_actions():
     assert (await get_audit_action_count()) == 1
     assert (await get_audit_event_count()) == 2
 
+    event1, event2 = await get_audit_events()
+
+    assert str(event1.id) == "523af123-2783-448f-9e2a-d33ad89b04fa"
+    assert event1.payload == {"i": 7}
+    assert event1.source_name == "my test source"
+    assert event1.source_type == "ansible.eda.range"
+
+    assert str(event2.id) == "58d7bbfe-4205-4d25-8cc1-d7e8eea06d21"
+    assert event2.payload == {"i": 3}
+
+
+@database_sync_to_async
+def get_audit_events():
+    return (
+        models.AuditEvent.objects.first(),
+        models.AuditEvent.objects.last(),
+    )
+
 
 @database_sync_to_async
 def get_audit_event_count():


### PR DESCRIPTION
Fix the event `payload` with meaningful data.

Before an audit event like:
```
{
  "id": "01f2fa48-023e-4722-950d-5ca62db88908",
  "source_name": "my test source",
  "source_type": "ansible.eda.range",
  "received_at": "2023-04-17T18:24:58.904399Z",
  "payload": {
    "uuid": "01f2fa48-023e-4722-950d-5ca62db88908",
    "source": {
      "name": "my test source",
      "type": "ansible.eda.range"
    },
    "received_at": "2023-04-17T18:24:58.904399Z"
  },
  "rule_fired_at": "2023-04-17T18:24:58.924184Z",
  "audit_actions": [
    "14977b38-ce52-4353-9ef3-f93d5ced2d8b"
  ]
}
```
After fix:
```
{
  "id": "0b9f71b0-a832-4e7a-9455-de279675f961",
  "source_name": "my test source",
  "source_type": "ansible.eda.range",
  "received_at": "2023-04-17T18:43:07.822432Z",
  "payload": {
    "i": 2
  },
  "rule_fired_at": "2023-04-17T18:43:07.823474Z",
  "audit_actions": [
    "93425852-de9e-4bc5-a35d-99c83a803675"
  ]
}
```
