### PR TITLE
Add 'url' to list of serializable project fields

### DIFF
--- a/src/aap_eda/api/serializers/project.py
+++ b/src/aap_eda/api/serializers/project.py
@@ -22,7 +22,6 @@ class ProjectSerializer(serializers.ModelSerializer):
         model = models.Project
         read_only_fields = [
             "id",
-            "url",
             "git_hash",
             "import_state",
             "import_error",
@@ -30,7 +29,7 @@ class ProjectSerializer(serializers.ModelSerializer):
             "created_at",
             "modified_at",
         ]
-        fields = ["name", "description", *read_only_fields]
+        fields = ["name", "description", "url", *read_only_fields]
 
 
 class ProjectCreateRequestSerializer(serializers.ModelSerializer):

--- a/tests/integration/api/test_project.py
+++ b/tests/integration/api/test_project.py
@@ -283,12 +283,16 @@ def test_partial_update_project(client: APIClient):
     )
     response = client.patch(
         f"{api_url_v1}/projects/{project.id}/",
-        data={"name": "test-project-01-updated"},
+        data={
+            "name": "test-project-01-updated",
+            "url": "https://git.example.com/acme/project-02",
+        },
     )
     assert response.status_code == status.HTTP_200_OK
 
     project = models.Project.objects.get(pk=project.id)
     assert project.name == "test-project-01-updated"
+    assert project.url == "https://git.example.com/acme/project-02"
 
     assert_project_data(response.json(), project)
 


### PR DESCRIPTION
This PR simply solves the issue of needing to be able to edit the url of a project but not being able to, as described in https://issues.redhat.com/browse/AAP-10790.

It is related to https://issues.redhat.com/browse/AAP-9977, since simply changing the url doesn't actually do anything right now, and I can't remember if we discussed that users would need to manually sync after changing the url or if we would auto-sync for them. If the latter is the case, this PR would need to either be updated or added on to after merge to adjust the update endpoint to auto-sync.