### PR TITLE
Fix stderr output missed in db

### DIFF
--- a/src/aap_eda/services/ruleset/ansible_rulebook.py
+++ b/src/aap_eda/services/ruleset/ansible_rulebook.py
@@ -53,7 +53,8 @@ class AnsibleRulebookService:
                 [ssh_agent, ansible_rulebook, *args],
                 check=True,
                 encoding="utf-8",
-                capture_output=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
                 cwd=self.cwd,
             )
         except subprocess.CalledProcessError as exc:

--- a/tests/unit/test_ansible_rulebook.py
+++ b/tests/unit/test_ansible_rulebook.py
@@ -47,7 +47,8 @@ def test_run_worker_mode(run_mock: mock.Mock):
         ],
         check=True,
         encoding="utf-8",
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
         cwd=None,
     )
 


### PR DESCRIPTION
When deployment_type is `local`, current `subprocess.run` params didn't catch the output from `stderr`. This PR fix it.

**Test Instruction**
1. Define a problematic rulebook, make sure it will fail `ansible-rulebook` with errors
2. Activate this rulebook
3. Its history detail page should show these errors in the `output` field

