### PR TITLE
[AAP-5433] Enable to allocate ports for source plugin in podman env

### DIFF
--- a/src/aap_eda/services/ruleset/activation_podman.py
+++ b/src/aap_eda/services/ruleset/activation_podman.py
@@ -59,6 +59,7 @@ class ActivationPodman:
         ws_ssl_verify: str,
         activation_instance_id: str,
         heartbeat: str,
+        ports: dict,
     ) -> Container:
         try:
             """Run ansible-rulebook in worker mode."""
@@ -83,10 +84,13 @@ class ActivationPodman:
                 remove=True,
                 detach=True,
                 name=f"eda-{activation_instance_id}-{uuid.uuid4()}",
+                ports=ports,
             )
 
             logger.info(
-                f"Created container: name: {container.name}, "
+                f"Created container: "
+                f"name: {container.name}, "
+                f"ports: {container.ports}, "
                 f"status: {container.status}, "
                 f"command: {args}"
             )
@@ -100,6 +104,9 @@ class ActivationPodman:
             raise
         except ImageNotFound:
             logger.exception("Image not found")
+            raise
+        except APIError:
+            logger.exception("Container run failed")
             raise
 
     def _default_podman_url(self) -> None:

--- a/tests/integration/services/test_activation_podman.py
+++ b/tests/integration/services/test_activation_podman.py
@@ -72,12 +72,14 @@ def test_activation_podman_run_worker_mode(
 
     podman = ActivationPodman(decision_environment, None)
     uuid_mock.return_value = DUMMY_UUID
+    ports = {"5000/tcp": 5000}
 
     podman.run_worker_mode(
         ws_url="ws://localhost:8000/api/eda/ws/ansible-rulebook",
         ws_ssl_verify="no",
         activation_instance_id="1",
         heartbeat="5",
+        ports=ports,
     )
 
     client_mock.containers.run.assert_called_once_with(
@@ -99,6 +101,7 @@ def test_activation_podman_run_worker_mode(
         remove=True,
         detach=True,
         name=f"eda-1-{DUMMY_UUID}",
+        ports=ports,
     )
 
 
@@ -120,3 +123,28 @@ def test_activation_podman_with_invalid_credential(
 
     with pytest.raises(exceptions.APIError, match="login attempt failed"):
         ActivationPodman(decision_environment, None)
+
+
+@pytest.mark.django_db
+@mock.patch("aap_eda.services.ruleset.activation_podman.PodmanClient")
+def test_activation_podman_with_invalid_ports(my_mock: mock.Mock, init_data):
+    def raise_error(*args, **kwargs):
+        raise exceptions.APIError(message="bind: address already in use")
+
+    credential, decision_environment = init_data
+    client_mock = mock.Mock()
+    my_mock.return_value = client_mock
+
+    client_mock.containers.run.side_effect = raise_error
+
+    podman = ActivationPodman(decision_environment, None)
+    with pytest.raises(
+        exceptions.APIError, match="bind: address already in use"
+    ):
+        podman.run_worker_mode(
+            ws_url="ws://localhost:8000/api/eda/ws/ansible-rulebook",
+            ws_ssl_verify="no",
+            activation_instance_id="1",
+            heartbeat="5",
+            ports={"5000/tcp": 5000},
+        )


### PR DESCRIPTION
The created podman container will allocate port numbers, based on the `sources` information defined in the rulebook.

The potential issues: 
1. The port numbers defined in rulebook may not available;
2. The port number may be used by other activation tasks;

Resolves: [AAP-5433](https://issues.redhat.com/browse/AAP-5433)