### PR TITLE
[AAP-11546] Add default log level to rulebook engine to have output

### DIFF
--- a/src/aap_eda/services/ruleset/activation_podman.py
+++ b/src/aap_eda/services/ruleset/activation_podman.py
@@ -16,6 +16,7 @@ import logging
 import os
 import uuid
 
+from django.conf import settings
 from podman import PodmanClient
 from podman.domain.containers import Container
 from podman.domain.images import Image
@@ -74,6 +75,7 @@ class ActivationPodman:
                 str(activation_instance_id),
                 "--heartbeat",
                 str(heartbeat),
+                settings.ANSIBLE_RULEBOOK_LOG_LEVEL,
             ]
 
             container = self.client.containers.run(

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -310,3 +310,8 @@ RULEBOOK_LIVENESS_CHECK_SECONDS = settings.get(
 RULEBOOK_LIVENESS_TIMEOUT_SECONDS = settings.get(
     "RULEBOOK_LIVENESS_TIMEOUT_SECONDS", 610
 )
+
+# ---------------------------------------------------------
+# RULEBOOK ENGINE LOG LEVEL
+# ---------------------------------------------------------
+ANSIBLE_RULEBOOK_LOG_LEVEL = settings.get("ANSIBLE_RULEBOOK_LOG_LEVEL", "-v")

--- a/tests/integration/services/test_activation_podman.py
+++ b/tests/integration/services/test_activation_podman.py
@@ -15,6 +15,7 @@ import os
 from unittest import mock
 
 import pytest
+from django.conf import settings
 from podman.errors import exceptions
 
 from aap_eda.core import models
@@ -40,6 +41,11 @@ def init_data():
     )
 
     return (credential, decision_environment)
+
+
+@pytest.fixture(autouse=True)
+def use_dummy_log_level(settings):
+    settings.ANSIBLE_RULEBOOK_LOG_LEVEL = "-vv"
 
 
 @pytest.mark.django_db
@@ -95,6 +101,7 @@ def test_activation_podman_run_worker_mode(
             "1",
             "--heartbeat",
             "5",
+            settings.ANSIBLE_RULEBOOK_LOG_LEVEL,
         ],
         stdout=True,
         stderr=True,


### PR DESCRIPTION
Add default log level to rulebook engine to get output in the normal situation.

Resolves: [AAP-11546](https://issues.redhat.com/browse/AAP-11546)