### PR TITLE
[AAP-5607] Activation filter by name

### DIFF
--- a/src/aap_eda/api/filters/__init__.py
+++ b/src/aap_eda/api/filters/__init__.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from .activation_instance import ActivationInstanceFilter
+from .activation import ActivationFilter, ActivationInstanceFilter
 from .credential import CredentialFilter
 from .decision_environment import DecisionEnvironmentFilter
 from .project import ProjectFilter
@@ -30,4 +30,5 @@ __all__ = (
     "DecisionEnvironmentFilter",
     # activation instance
     "ActivationInstanceFilter",
+    "ActivationFilter",
 )

--- a/src/aap_eda/api/filters/activation.py
+++ b/src/aap_eda/api/filters/activation.py
@@ -17,6 +17,18 @@ import django_filters
 from aap_eda.core import models
 
 
+class ActivationFilter(django_filters.FilterSet):
+    name = django_filters.CharFilter(
+        field_name="name",
+        lookup_expr="istartswith",
+        label="Filter by activation name.",
+    )
+
+    class Meta:
+        model = models.Activation
+        fields = ["name"]
+
+
 class ActivationInstanceFilter(django_filters.FilterSet):
     name = django_filters.CharFilter(
         field_name="name",

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -14,7 +14,7 @@
 from django.conf import settings
 from django.db import IntegrityError
 from django.shortcuts import get_object_or_404
-from django_filters.rest_framework import DjangoFilterBackend
+from django_filters import rest_framework as defaultfilters
 from drf_spectacular.utils import (
     OpenApiResponse,
     extend_schema,
@@ -70,6 +70,8 @@ class ActivationViewSet(
 ):
     queryset = models.Activation.objects.order_by("id")
     serializer_class = serializers.ActivationSerializer
+    filter_backends = (defaultfilters.DjangoFilterBackend,)
+    filterset_class = filters.ActivationFilter
     rbac_action = None
 
     @extend_schema(
@@ -341,7 +343,7 @@ class ActivationInstanceViewSet(
 ):
     queryset = models.ActivationInstance.objects.order_by("started_at")
     serializer_class = serializers.ActivationInstanceSerializer
-    filter_backends = (DjangoFilterBackend,)
+    filter_backends = (defaultfilters.DjangoFilterBackend,)
     filterset_class = filters.ActivationInstanceFilter
     rbac_resource_type = "activation_instance"
     rbac_action = None

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -130,6 +130,29 @@ def create_activation(fks: dict):
     return activation
 
 
+def create_multiple_activations(fks: dict):
+    activation_names = ["test-activation", "filter-test-activation"]
+    activations = []
+    for name in activation_names:
+        activation_data = {
+            "name": name,
+            "description": "test activation",
+            "is_enabled": True,
+            "decision_environment_id": fks["decision_environment_id"],
+            "project_id": fks["project_id"],
+            "rulebook_id": fks["project_id"],
+            "extra_var_id": fks["project_id"],
+            "user_id": fks["user_id"],
+            "restart_policy": RestartPolicy.ON_FAILURE.value,
+            "restart_count": 0,
+        }
+        activation = models.Activation(**activation_data)
+        activations.append(activation)
+        activation.save()
+
+    return activations
+
+
 @pytest.mark.django_db
 @mock.patch("aap_eda.tasks.ruleset.activate_rulesets")
 def test_create_activation(activate_rulesets: mock.Mock, client: APIClient):
@@ -223,6 +246,29 @@ def test_list_activations(client: APIClient):
     for data, activation in zip(response.data["results"], activations):
         assert_activation_base_data(data, activation)
         assert_activation_related_object_fks(data, activation)
+
+
+@pytest.mark.django_db
+def test_list_activations_filter_name(client: APIClient):
+    filter_name = "filter"
+    fks = create_activation_related_data()
+    activations = create_multiple_activations(fks)
+
+    response = client.get(f"{api_url_v1}/activations/?name={filter_name}")
+    assert response.status_code == status.HTTP_200_OK
+    response_data = response.data["results"]
+    assert_activation_base_data(response_data[0], activations[1])
+
+
+@pytest.mark.django_db
+def test_list_activations_filter_name_none_exist(client: APIClient):
+    filter_name = "noname"
+    fks = create_activation_related_data()
+    create_multiple_activations(fks)
+
+    response = client.get(f"{api_url_v1}/activations/?name={filter_name}")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["results"] == []
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Jira Ticket: [AAP-5607](https://issues.redhat.com/browse/AAP-5607) ###

### Purpose: ###
- We were missing backend filtering on the rulebook activations which cause a bug in the UI.

### Testing Instructions: ###
1. Load project data
2. create multiple activations `[POST] http://127.0.0.1:8000/api/eda/v1/activations/`
3. Hit the list activation endpoint: `[GET] http://127.0.0.1:8000/api/eda/v1/activations/` 
4. Filter by one of the names of the activations posted `[GET] http://127.0.0.1:8000/api/eda/v1/activations/?name={act_name}`
- The filter is what the name starts with and is not case sensitive
5. Filter by a name that does not exist `[GET] http://127.0.0.1:8000/api/eda/v1/activations/?name={fake_name}`
- The return for results should be an empty list []
6. Please ensure the docs have the parameter for filter by name in the activation endpoint. `http://127.0.0.1:8000/api/eda/v1/docs#/`