### PR TITLE
[AAP-11546] Add EDA_ANSIBLE_RULEBOOK_FLUSH_AFTER env to adjust output logs

### DIFF
--- a/src/aap_eda/services/ruleset/activate_rulesets.py
+++ b/src/aap_eda/services/ruleset/activate_rulesets.py
@@ -219,31 +219,13 @@ class ActivateRulesets:
         ):
             ports[f"{port}/tcp"] = port
 
-        container = podman.run_worker_mode(
+        podman.run_worker_mode(
             ws_url=ws_url,
             ws_ssl_verify=ssl_verify,
             activation_instance_id=activation_instance.id,
             heartbeat=str(settings.RULEBOOK_LIVENESS_CHECK_SECONDS),
             ports=ports,
         )
-
-        line_number = 0
-
-        activation_instance_logs = []
-        for line in container.logs():
-            activation_instance_log = models.ActivationInstanceLog(
-                line_number=line_number,
-                log=line.decode("utf-8"),
-                activation_instance_id=int(activation_instance.id),
-            )
-            activation_instance_logs.append(activation_instance_log)
-
-            line_number += 1
-
-        models.ActivationInstanceLog.objects.bulk_create(
-            activation_instance_logs
-        )
-        logger.info(f"{line_number} of activation instance log are created.")
 
     # TODO(hsong) implement later
     def activate_in_docker():

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -315,3 +315,4 @@ RULEBOOK_LIVENESS_TIMEOUT_SECONDS = settings.get(
 # RULEBOOK ENGINE LOG LEVEL
 # ---------------------------------------------------------
 ANSIBLE_RULEBOOK_LOG_LEVEL = settings.get("ANSIBLE_RULEBOOK_LOG_LEVEL", "-v")
+ANSIBLE_RULEBOOK_FLUSH_AFTER = settings.get("ANSIBLE_RULEBOOK_FLUSH_AFTER", 1)

--- a/tests/integration/services/test_ruleset_activate.py
+++ b/tests/integration/services/test_ruleset_activate.py
@@ -219,4 +219,3 @@ def test_rulesets_activate_with_podman(my_mock: mock.Mock, init_data):
         models.ActivationInstance.objects.first().status
         == ActivationStatus.COMPLETED.value
     )
-    assert models.ActivationInstanceLog.objects.count() == 2


### PR DESCRIPTION
Previously for Podman the logs were being written only at the end when the container has ended. The Kubernetes deployment has the opposite behavior it logs every line as they are available from the pod. Since this was a difference in behavior between the podman and k8s this PR tries to address this.

Added an environment variable **EDA_ANSIBLE_RULEBOOK_FLUSH_AFTER** to specify when the log lines from rulebook engine should be committed to the DB. 

**EDA_ANSIBLE_RULEBOOK_FLUSH_AFTER** can be:
1. EDA_ANSIBLE_RULEBOOK_FLUSH_AFTER=**end**(default value if not set): means the output is only shown after rulebook engine completes the activation,
2. EDA_ANSIBLE_RULEBOOK_FLUSH_AFTER=**10**: means the output is flushed after 10 lines,

This env var is only being handled by  podman deployment, will add to kubenetes later.

Resolves: [AAP-11546](https://issues.redhat.com/browse/AAP-11546)