### PR TITLE
[AAP-11459] Log errors for podman activation

### DIFF
--- a/src/aap_eda/services/ruleset/activation_db_logger.py
+++ b/src/aap_eda/services/ruleset/activation_db_logger.py
@@ -1,0 +1,63 @@
+#  Copyright 2023 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+from typing import Union
+
+from django.conf import settings
+
+from aap_eda.core import models
+
+logger = logging.getLogger(__name__)
+
+
+class ActivationDbLogger:
+    def __init__(self, activation_instance_id: int):
+        self.line_number = 0
+        self.activation_instance_id = activation_instance_id
+        self.activation_instance_log_buffer = []
+        if str(settings.ANSIBLE_RULEBOOK_FLUSH_AFTER) == "end":
+            self.incremental_flush = False
+            logger.info("Log flush setting: end")
+        else:
+            self.flush_after = int(settings.ANSIBLE_RULEBOOK_FLUSH_AFTER)
+            self.incremental_flush = True
+            logger.info(f"Log flush setting: {self.flush_after}")
+
+    def lines_written(self) -> int:
+        return self.line_number
+
+    def write(self, lines: Union[list[str], str]) -> None:
+        if self.incremental_flush and self.line_number % self.flush_after == 0:
+            self.flush()
+
+        if not isinstance(lines, list):
+            lines = [lines]
+
+        for line in lines:
+            self.activation_instance_log_buffer.append(
+                models.ActivationInstanceLog(
+                    line_number=self.line_number,
+                    log=line,
+                    activation_instance_id=self.activation_instance_id,
+                )
+            )
+            self.line_number += 1
+
+    def flush(self) -> None:
+        if self.activation_instance_log_buffer:
+            models.ActivationInstanceLog.objects.bulk_create(
+                self.activation_instance_log_buffer
+            )
+        self.activation_instance_log_buffer = []

--- a/tests/integration/services/test_activation_db_logger.py
+++ b/tests/integration/services/test_activation_db_logger.py
@@ -1,0 +1,74 @@
+#  Copyright 2023 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+
+from aap_eda.core import models
+from aap_eda.services.ruleset.activation_db_logger import ActivationDbLogger
+
+
+@pytest.fixture()
+def init_data():
+    user = models.User.objects.create(
+        username="tester",
+        password="secret",
+        first_name="Adam",
+        last_name="Tester",
+        email="adam@example.com",
+    )
+    activation = models.Activation.objects.create(
+        name="activation",
+        user=user,
+    )
+    activation_instance = models.ActivationInstance.objects.create(
+        name="test-instance",
+        activation=activation,
+    )
+
+    return activation_instance
+
+
+@pytest.fixture
+def use_dummy_flush_at_end(settings):
+    settings.ANSIBLE_RULEBOOK_FLUSH_AFTER = "end"
+
+
+@pytest.fixture
+def use_dummy_flush_after_2(settings):
+    settings.ANSIBLE_RULEBOOK_FLUSH_AFTER = "2"
+
+
+@pytest.mark.django_db
+def test_activation_db_logger_end(init_data, use_dummy_flush_at_end):
+    activation_instance = init_data
+    activation_db_logger = ActivationDbLogger(activation_instance.id)
+    activation_db_logger.write("Hello")
+    activation_db_logger.write(["Hello", "World"])
+    activation_db_logger.flush()
+
+    assert models.ActivationInstanceLog.objects.count() == 3
+    assert activation_db_logger.lines_written() == 3
+
+
+@pytest.mark.django_db
+def test_activation_db_logger_intermittent(init_data, use_dummy_flush_after_2):
+    activation_instance = init_data
+    activation_db_logger = ActivationDbLogger(activation_instance.id)
+    activation_db_logger.write("Hello")
+    activation_db_logger.write("World")
+    activation_db_logger.write(["Fred", "Barney"])
+    activation_db_logger.flush()
+
+    assert models.ActivationInstanceLog.objects.count() == 4
+    assert activation_db_logger.lines_written() == 4

--- a/tests/integration/services/test_ruleset_activate.py
+++ b/tests/integration/services/test_ruleset_activate.py
@@ -181,10 +181,15 @@ def test_rulesets_activate_with_errors(run_mock: mock.Mock, init_data):
 
 
 @pytest.mark.django_db
+@mock.patch("aap_eda.services.ruleset.activate_rulesets.ActivationDbLogger")
 @mock.patch("aap_eda.services.ruleset.activate_rulesets.ActivationPodman")
-def test_rulesets_activate_with_podman(my_mock: mock.Mock, init_data):
+def test_rulesets_activate_with_podman(
+    my_mock: mock.Mock, logger_mock: mock.Mock, init_data
+):
     pod_mock = mock.Mock()
     my_mock.return_value = pod_mock
+    log_mock = mock.Mock()
+    logger_mock.return_value = log_mock
 
     container_mock = mock.Mock()
     pod_mock.run_worker_mode.return_value = container_mock
@@ -206,7 +211,7 @@ def test_rulesets_activate_with_podman(my_mock: mock.Mock, init_data):
     instance = models.ActivationInstance.objects.first()
 
     my_mock.assert_called_once_with(
-        init_data.decision_environment, "unix://socket_url"
+        init_data.decision_environment, "unix://socket_url", log_mock
     )
     pod_mock.run_worker_mode.assert_called_once_with(
         ws_url="ws://localhost:8000/api/eda/ws/ansible-rulebook",


### PR DESCRIPTION
When podman activation has initial errors before the container starts we were not reporting it to the user.

1. Invalid Image
2. Invalid Credentials

We were just logging in the worker logs but nothing was being written to the database activation log.

https://issues.redhat.com/browse/AAP-11459