### PR TITLE
AAP-12005 - Add secret token for eda-qa repo

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -42,6 +42,7 @@ jobs:
           fetch-depth: 0
           repository: ansible/eda-qa
           path: ${{ env.EDA_QA_PATH }}
+          token: ${{ secrets.EDA_QA_GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
Eda-qa repo must be private, this is necessary to run the nightly test runs. 
https://issues.redhat.com/browse/AAP-12005