### PR TITLE
[AAP-11605] Websocket url validation on activation creation

### DIFF
--- a/src/aap_eda/api/exceptions.py
+++ b/src/aap_eda/api/exceptions.py
@@ -75,6 +75,16 @@ class TooManyControllerTokens(APIException):
     )
 
 
-class InvalidWebsocketURL(APIException):
+class InvalidWebsocketScheme(APIException):
     status_code = 422
-    default_detail = "Connection Error to provided websocket URL."
+    default_detail = (
+        "Connection Error: Invalid WebSocket URL scheme. "
+        "Scheme should be either 'ws' or 'wss'."
+    )
+
+
+class InvalidWebsocketHost(APIException):
+    status_code = 422
+    default_detail = (
+        "Connection Error: WebSocket URL must have a valid host address."
+    )


### PR DESCRIPTION
### Jira Ticket: [AAP-11605](https://issues.redhat.com/browse/AAP-11605) ###

### Purpose: ###
- To validate that the websocket url is valid and connecting before the creation of an activation
- also changed decision environment to not nullable since they are required for running activations

### Testing Instructions: ###
1. Add a project, decision environment, and controller token
2. Create an activation and see that it starts
3. in settings change the websocket base URL to something invalid run `task dev:init`
4. Try and create the activation again and you should get a 422