### PR TITLE
[AAP-12166] Fix project sync rulebook content issue

### DIFF
--- a/src/aap_eda/services/project/imports.py
+++ b/src/aap_eda/services/project/imports.py
@@ -157,6 +157,7 @@ class ProjectImportService:
         if rulebook.rulesets == rulebook_info.raw_content:
             return
         rulebook.rulesets = rulebook_info.raw_content
+        rulebook.save()
         rulebook.ruleset_set.clear()
         insert_rulebook_related_data(rulebook, rulebook_info.content)
         models.Activation.objects.filter(rulebook=rulebook).update(


### PR DESCRIPTION
## Description

When performing a project sync that changes the content of a rulebook the following is observed:

1. The project hash is updated correctly
2. Existing activations that use the rulebook that was modified will use the new content of the rulebook
3. New activations created after the project sync will use the old content of the rulebook

## Expected Behavior

According to the [AAP-9977](https://issues.redhat.com/browse/AAP-9977) description, 1) and 2) are expected behavior. As for 3) new activations should use the new content of the updated rulebook. 
