### PR TITLE
Register OpenAPI extension for custom session auth

### DIFF
--- a/src/aap_eda/api/openapi.py
+++ b/src/aap_eda/api/openapi.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from drf_spectacular.authentication import SessionScheme as _SessionScheme
 
 
 def preprocess_filter_api_routes(endpoints):
@@ -8,3 +9,7 @@ def preprocess_filter_api_routes(endpoints):
         for path, path_regex, method, callback in endpoints
         if path.startswith(api_path)
     ]
+
+
+class SessionScheme(_SessionScheme):
+    target_class = "aap_eda.api.authentication.SessionAuthentication"

--- a/src/aap_eda/api/serializers/user.py
+++ b/src/aap_eda/api/serializers/user.py
@@ -13,6 +13,9 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class UserDetailSerializer(serializers.ModelSerializer):
+    username = serializers.CharField(
+        help_text="The user's log in name.",
+    )
     created_at = serializers.DateTimeField(source="date_joined")
 
     roles = RoleRefSerializer(read_only=True, many=True)
@@ -61,6 +64,9 @@ class UserListSerializer(serializers.Serializer):
 
 
 class UserCreateUpdateSerializer(serializers.ModelSerializer):
+    username = serializers.CharField(
+        help_text="The user's log in name.",
+    )
     password = serializers.CharField(write_only=True)
 
     class Meta:


### PR DESCRIPTION
This patch adds a `drf-spectacular` extension to generate OpenAPI schema for the custom SessionAuthentication class that replaced DRF built in class.

This fixes numerous warnings caused by unregistered session authentication class.