### PR TITLE
Enable podman activations in stage env

### DIFF
--- a/tools/docker/docker-compose-stage.yaml
+++ b/tools/docker/docker-compose-stage.yaml
@@ -9,12 +9,19 @@ x-environment:
   - EDA_DEPLOYMENT_TYPE=${EDA_DEPLOYMENT_TYPE:-podman}
   - EDA_WEBSOCKET_BASE_URL=${EDA_WEBSOCKET_BASE_URL:-ws://host.containers.internal:8080}
   - EDA_WEBSOCKET_SSL_VERIFY=no
-  - EDA_PODMAN_SOCKET_URL=unix:///run/podman/podman.sock
+  - EDA_PODMAN_SOCKET_URL=tcp://podman:8888
   - EDA_CONTROLLER_URL=${EDA_CONTROLLER_URL:-https://awx-example.com}
   - EDA_CONTROLLER_TOKEN=${EDA_CONTROLLER_TOKEN:-some-secret-token}
   - EDA_CONTROLLER_SSL_VERIFY=${EDA_CONTROLLER_SSL_VERIFY:-no}
 
 services:
+  podman:
+    image: quay.io/containers/podman:${EDA_PODMAN_VERSION:-v4.5}
+    privileged: true
+    command: podman system service --time=0 tcp://0.0.0.0:8888
+    ports:
+      - 8888:8888
+
   eda-ui:
     image: "${EDA_UI_IMAGE:-quay.io/ansible/eda-ui:main}"
     ports:
@@ -49,7 +56,7 @@ services:
   eda-worker:
     user: "${EDA_POD_USER_ID:-0}"
     deploy:
-      replicas: 2
+      replicas: ${EDA_NUM_WORKERS:-2}
     image: "${EDA_IMAGE:-quay.io/ansible/eda-server:main}"
     environment: *common-env
     command:


### PR DESCRIPTION
Run a podman daemon as a new service to use for activations, that removes the issues related with exposing the local socket and removes the dependency on podman (it should work now on docker as well) 

Also makes the num of workers a variable. 