### PR TITLE
Change to allow us to get the Job instance result

### DIFF
--- a/src/aap_eda/services/ruleset/activation_kubernetes.py
+++ b/src/aap_eda/services/ruleset/activation_kubernetes.py
@@ -285,9 +285,12 @@ class ActivationKubernetes:
             time.sleep(10)
 
         logger.info(f"Create Job: {job_name}")
-        self.batch_api.create_namespaced_job(
-            namespace=namespace, body=job_spec, async_req=True
+        job_result = self.batch_api.create_namespaced_job(
+            namespace=namespace, body=job_spec
         )
+
+        logger.info(f"Job Info: {job_result}")
+
         w = watch.Watch()
 
         done = False


### PR DESCRIPTION
This PR is to remove the async call on the k8s Job. This will allow us to view the Job Status after setup