### PR TITLE
[AAP-12522] Remove the unneeded checking for audit rules

### DIFF
--- a/src/aap_eda/wsapi/consumers.py
+++ b/src/aap_eda/wsapi/consumers.py
@@ -217,11 +217,6 @@ class AnsibleRulebookConsumer(AsyncWebsocketConsumer):
             )
 
             logger.info(f"Audit rule [{audit_rule.name}] is created.")
-        elif audit_rule.fired_at > datetime.strptime(
-            message.rule_run_at, DATETIME_FORMAT
-        ):
-            logger.info(f"Ignore the fired audit rule {audit_rule.name}")
-            return
         else:
             audit_rule.fired_at = message.rule_run_at
             audit_rule.status = message.status


### PR DESCRIPTION
Now we changed to display all audit rules, rather than the latest one, we don't need the logic to check and ignore the previous rules.

Resolves: [AAP-12522](https://issues.redhat.com/browse/AAP-12522)