### PR TITLE
[AAP-12102] Check for "InvalidImageName" or "ImagePullBackOff" 

### DIFF
--- a/src/aap_eda/services/ruleset/activation_kubernetes.py
+++ b/src/aap_eda/services/ruleset/activation_kubernetes.py
@@ -399,7 +399,11 @@ class ActivationKubernetes:
 
     def watch_job_pod(self, job_name, namespace, activation_instance) -> None:
         w = watch.Watch()
-        pod_failed_reasons = ["InvalidImageName", "ImagePullBackOff"]
+        pod_failed_reasons = [
+            "InvalidImageName",
+            "ImagePullBackOff",
+            "ErrImagePull",
+        ]
 
         done = False
         while not done:


### PR DESCRIPTION
[AAP-12102](https://issues.redhat.com/browse/AAP-12102)

Initial local testing was done with the following DE urls

- Bad tag name: "quay.io/ansible/ansible-rulebook:bogus"
- Invalid image URL: "http://quay.io/ansible/ansible-rulebook:main"
- No access or invalid user and password
