### PR TITLE
[2.4] [Backport] [AAP-12848] Utilize activation-id and not activation-name for references

### DIFF
--- a/src/aap_eda/services/ruleset/activate_rulesets.py
+++ b/src/aap_eda/services/ruleset/activate_rulesets.py
@@ -411,7 +411,6 @@ class ActivateRulesets:
         namespace = ns_fileref.read()
         ns_fileref.close()
 
-        activation_name = activation.name
         activation_id = activation.pk
         job_name = f"activation-job-{activation_id}"
         pod_name = f"activation-pod-{activation_id}"
@@ -423,7 +422,7 @@ class ActivateRulesets:
             pull_policy=_pull_policy,
             url=ws_url,
             ssl_verify=ssl_verify,
-            activation_id=activation_instance.id,
+            activation_id=str(activation_id),
             ports=[
                 port
                 for _, port in find_ports(
@@ -450,7 +449,7 @@ class ActivateRulesets:
 
         job_spec = k8s.create_job(
             job_name=job_name,
-            activation_name=activation_name,
+            activation_id=str(activation_id),
             pod_template=pod_spec,
             ttl=30,
         )

--- a/src/aap_eda/services/ruleset/activation_kubernetes.py
+++ b/src/aap_eda/services/ruleset/activation_kubernetes.py
@@ -201,14 +201,14 @@ class ActivationKubernetes:
 
     @staticmethod
     def create_job(
-        job_name, activation_name, pod_template, backoff_limit=0, ttl=0
+        job_name, activation_id, pod_template, backoff_limit=0, ttl=0
     ) -> client.V1Job:
         metadata = client.V1ObjectMeta(
             name=job_name,
             labels={
                 "job-name": job_name,
                 "app": "eda",
-                "activation-name": activation_name,
+                "activation-id": str(activation_id),
             },
         )
 
@@ -232,7 +232,8 @@ class ActivationKubernetes:
             instance_name = activation_instance.name
             activation_job = self.batch_api.list_namespaced_job(
                 namespace=namespace,
-                label_selector=f"activation-name={instance_name}",
+                label_selector="activation-id="
+                f"{activation_instance.activation.pk}",
                 timeout_seconds=0,
             )
 


### PR DESCRIPTION
This is a cherry-pick for PR #286 