### PR TITLE
[AAP-12930] Fix, pass activation_instance.id to container config, not activation.id

### DIFF
--- a/src/aap_eda/services/ruleset/activate_rulesets.py
+++ b/src/aap_eda/services/ruleset/activate_rulesets.py
@@ -422,7 +422,7 @@ class ActivateRulesets:
             pull_policy=_pull_policy,
             url=ws_url,
             ssl_verify=ssl_verify,
-            activation_id=str(activation_id),
+            activation_instance_id=activation_instance.id,
             ports=[
                 port
                 for _, port in find_ports(

--- a/src/aap_eda/services/ruleset/activation_kubernetes.py
+++ b/src/aap_eda/services/ruleset/activation_kubernetes.py
@@ -49,7 +49,7 @@ class ActivationKubernetes:
         pull_policy,
         url,
         ssl_verify,
-        activation_id,
+        activation_instance_id,
         ports,
         heartbeat,
     ) -> client.V1Container:
@@ -60,7 +60,7 @@ class ActivationKubernetes:
             "--websocket-ssl-verify",
             ssl_verify,
             "--id",
-            str(activation_id),
+            str(activation_instance_id),
             "--heartbeat",
             str(heartbeat),
         ]


### PR DESCRIPTION
[AAP-12930](https://issues.redhat.com/browse/AAP-12930)

This PR fixes a regression that was introduced in PR: [286](https://github.com/ansible/aap-eda/pull/286).  One line to many changed.