### PR TITLE
[AAP-12989] Fixes audit rules schemas.

### DIFF
--- a/src/aap_eda/api/serializers/rulebook.py
+++ b/src/aap_eda/api/serializers/rulebook.py
@@ -266,7 +266,14 @@ class AuditRuleDetailSerializer(serializers.Serializer):
     )
 
     @extend_schema_field(
-        {"type": "dict", "example": {"id": "int", "name": "string"}}
+        {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "name": {"type": "string"},
+            },
+            "example": {"id": 0, "name": "string"},
+        }
     )
     def get_activation_instance(self, rule):
         instance = rule.activation_instance
@@ -300,7 +307,14 @@ class AuditRuleListSerializer(serializers.Serializer):
     )
 
     @extend_schema_field(
-        {"type": "dict", "example": {"id": "int", "name": "string"}}
+        {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "name": {"type": "string"},
+            },
+            "example": {"id": 0, "name": "string"},
+        }
     )
     def get_activation_instance(self, rule):
         instance = rule.activation_instance


### PR DESCRIPTION
### Jira Ticket: [AAP-12989](https://issues.redhat.com/browse/AAP-12989) ###

### Purpose: ###
- The schemas for audit rule list and audit rule detail endpoints had activation instance as a dict which is not a valid option and has been changed to an object.

### Testing Instructions: ###
1. check the [docs endpoint](http://127.0.0.1:8000/api/eda/v1/docs)
   - Ensure the `audit-rules` and `audit-rules/{id}` endpoints have correct responses
        - `audit-rules`
        <img width="414" alt="Screenshot 2023-06-07 at 10 23 06 AM" src="https://github.com/ansible/aap-eda/assets/49072851/989dfdbf-89be-4433-939e-8315966fe766">
       
        - `audit-rules/{id}`
        <img width="308" alt="Screenshot 2023-06-07 at 10 22 57 AM" src="https://github.com/ansible/aap-eda/assets/49072851/7ff9584b-2321-4377-9d07-0d3c5e3633e9">


2.  Hit the [openapi endpoint](http://localhost:8000/api/eda/v1/openapi.json)
     - Search for the keyword `AuditRuleList` and `AuditRuleDetail` to ensure the schema is correct and that activation instance is an object now
     
     ```
     "activation_instance": {
              "type": "object",
               "properties": {
                       "id": {
                             "type": "integer"
                         },
                        "name": {
                             "type": "string"
                         }
                  },
                  "example": {
                         "id": 0,
                         "name": "string"
                  },
                  "readOnly": true
          },
     ```