### PR TITLE
[AAP-13237] Fix Activation Instance Log retrieve response schema

### DIFF
--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -428,7 +428,9 @@ class ActivationInstanceViewSet(
     @extend_schema(
         description="List all logs for the Activation Instance",
         responses={
-            status.HTTP_200_OK: serializers.ActivationInstanceLogSerializer
+            status.HTTP_200_OK: serializers.ActivationInstanceLogSerializer(
+                many=True
+            )
         },
     )
     @action(detail=True, rbac_action=Action.READ)


### PR DESCRIPTION
The response schema for the `/activation-instances/{id}/logs` endpoint appears to be incorrect. The schema expects a non-paginated result like:
![image](https://github.com/ansible/aap-eda/assets/31990136/5b5e8f1e-4fda-493a-9c3f-ab227a7b5ef9)


However, the actual response is a paginated list of results:
![image](https://github.com/ansible/aap-eda/assets/31990136/0fc0bb1a-8369-411a-bf4b-3988ef7e1676)

This PR updates the schema to match the response from `/activation-instances/{id}/logs`