### PR TITLE
Add gunicorn dependency for operator deployments

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -770,6 +770,27 @@ reauth = ["pyu2f (>=0.1.5)"]
 requests = ["requests (>=2.20.0,<3.0.0dev)"]
 
 [[package]]
+name = "gunicorn"
+version = "20.1.0"
+description = "WSGI HTTP Server for UNIX"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "gunicorn-20.1.0-py3-none-any.whl", hash = "sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e"},
+    {file = "gunicorn-20.1.0.tar.gz", hash = "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"},
+]
+
+[package.dependencies]
+setuptools = ">=3.0"
+
+[package.extras]
+eventlet = ["eventlet (>=0.24.1)"]
+gevent = ["gevent (>=1.4.0)"]
+setproctitle = ["setproctitle"]
+tornado = ["tornado (>=0.2)"]
+
+[[package]]
 name = "hyperlink"
 version = "21.0.0"
 description = "A featureful, immutable, and correct URL for Python."
@@ -1876,4 +1897,4 @@ dev = ["psycopg2-binary"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9"
-content-hash = "57fc658a84c817d6b1a4229bd39e7c3d1a5cd18061be67e84576a72853d558e6"
+content-hash = "adf267637ffe2c247daca1ef4b9914dc44fbf20ad105f0bfc93bb1b213a6fdfe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ pydantic = "*"
 cryptography = "*"
 kubernetes = "*"
 podman = ">=4.5"
+gunicorn = "*"
 
 [tool.poetry.group.test.dependencies]
 pytest = "*"


### PR DESCRIPTION
Using the `django runserver` command to start the api deployment is not recommended for production environments.  We should use gunicorn, but it is not currently available in the eda-server container.  

This PR introduces the gunicorn dependency.

The following PR makes the changes to start using gunicorn to start services in the API container:
* https://github.com/ansible/eda-server-operator/pull/97

I did not change the entrypoint for the minikube deployment because I figured it might be preferable from a dev perspective there.  During development, Django's runserver can be convenient because it automatically reloads the code when changes are detected, making the development process smoother. In contrast, Gunicorn requires manual restarts to reflect code changes.