### PR TITLE
[AAP-10387] Fix ExtraVar create endpoint request serializer

### DIFF
--- a/src/aap_eda/api/serializers/__init__.py
+++ b/src/aap_eda/api/serializers/__init__.py
@@ -38,6 +38,7 @@ from .decision_environment import (
     DecisionEnvironmentSerializer,
 )
 from .project import (
+    ExtraVarCreateSerializer,
     ExtraVarRefSerializer,
     ExtraVarSerializer,
     PlaybookSerializer,
@@ -75,6 +76,7 @@ __all__ = (
     "LoginSerializer",
     # project
     "ExtraVarSerializer",
+    "ExtraVarCreateSerializer",
     "ExtraVarRefSerializer",
     "PlaybookSerializer",
     "ProjectSerializer",

--- a/src/aap_eda/api/serializers/project.py
+++ b/src/aap_eda/api/serializers/project.py
@@ -101,6 +101,17 @@ class ExtraVarSerializer(serializers.ModelSerializer):
         read_only_fields = ["id"]
 
 
+class ExtraVarCreateSerializer(serializers.ModelSerializer):
+    extra_var = serializers.CharField(
+        required=True,
+        help_text="Content of the extra_var",
+    )
+
+    class Meta:
+        model = models.ExtraVar
+        fields = ["extra_var"]
+
+
 class ExtraVarRefSerializer(serializers.ModelSerializer):
     """Serializer for Extra Var reference."""
 

--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -51,6 +51,7 @@ from .mixins import PartialUpdateOnlyModelMixin, ResponseSerializerMixin
     ),
     create=extend_schema(
         description="Create an extra_var",
+        request=serializers.ExtraVarCreateSerializer,
         responses={
             status.HTTP_201_CREATED: OpenApiResponse(
                 serializers.ExtraVarSerializer,


### PR DESCRIPTION
Use separate ExtraVarCreateSerializer for `POST /extra-vars/` API endpoint.

Issue: https://issues.redhat.com/browse/AAP-10387