### PR TITLE
[AAP-13722] Allow null in openapi.json for activation_instance id

### DIFF
--- a/src/aap_eda/api/serializers/rulebook.py
+++ b/src/aap_eda/api/serializers/rulebook.py
@@ -269,7 +269,7 @@ class AuditRuleDetailSerializer(serializers.Serializer):
         {
             "type": "object",
             "properties": {
-                "id": {"type": "integer"},
+                "id": {"type": "integer", "nullable": True},
                 "name": {"type": "string"},
             },
             "example": {"id": 0, "name": "string"},
@@ -310,7 +310,7 @@ class AuditRuleListSerializer(serializers.Serializer):
         {
             "type": "object",
             "properties": {
-                "id": {"type": "integer"},
+                "id": {"type": "integer", "nullable": True},
                 "name": {"type": "string"},
             },
             "example": {"id": 0, "name": "string"},


### PR DESCRIPTION
Fixes AAP-13772: Wrong schema for audit_rules list response