### PR TITLE
Update docker compose dev: equate with stage env

### DIFF
--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -160,7 +160,7 @@ tasks:
     cmds:
       - task: docker
         vars:
-          CLI_ARGS: run --rm api aap-eda-manage migrate
+          CLI_ARGS: run --rm eda-api aap-eda-manage migrate
 
   docker:down:
     desc: "Stop all services."
@@ -188,14 +188,14 @@ tasks:
       cmds:
         - task: docker
           vars:
-            CLI_ARGS: exec -it api aap-eda-manage shell
+            CLI_ARGS: exec -it eda-api aap-eda-manage shell
 
   docker:shell:worker:
     desc: "Run the management shell in worker container"
     cmds:
       - task: docker
         vars:
-          CLI_ARGS: exec -it worker aap-eda-manage shell
+          CLI_ARGS: exec -it eda-worker aap-eda-manage shell
 
   create:superuser:
     desc: "create a superuser to use with EDA API."

--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -3,12 +3,32 @@ x-environment:
   - EDA_DB_HOST=postgres
   - EDA_MQ_HOST=redis
   - DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-aap_eda.settings.development}
-  - EDA_DEPLOYMENT_TYPE=${EDA_DEPLOYMENT_TYPE:-local}
-  - EDA_WEBSOCKET_BASE_URL=${EDA_WEBSOCKET_BASE_URL:-ws://localhost:8000}
+  - EDA_DEPLOYMENT_TYPE=${EDA_DEPLOYMENT_TYPE:-podman}
+  - EDA_WEBSOCKET_BASE_URL=${EDA_WEBSOCKET_BASE_URL:-ws://eda-api:8000}
   - EDA_WEBSOCKET_SSL_VERIFY=no
+  - EDA_PODMAN_SOCKET_URL=tcp://podman:8888
+  - EDA_CONTROLLER_URL=${EDA_CONTROLLER_URL:-https://awx-example.com}
+  - EDA_CONTROLLER_TOKEN=${EDA_CONTROLLER_TOKEN:-some-secret-token}
+  - EDA_CONTROLLER_SSL_VERIFY=${EDA_CONTROLLER_SSL_VERIFY:-no}
 
 services:
-  api:
+  podman:
+    user: "1000"
+    image: quay.io/containers/podman:${EDA_PODMAN_VERSION:-v4.5}
+    privileged: true
+    command: podman system service --time=0 tcp://0.0.0.0:8888
+    ports:
+      - 8888:8888
+
+  eda-ui:
+    image: "${EDA_UI_IMAGE:-quay.io/ansible/eda-ui:main}"
+    ports:
+      - '8080:8080'
+    depends_on:
+      eda-api:
+        condition: service_healthy
+
+  eda-api:
     image: "${EDA_IMAGE:-localhost/aap-eda}"
     build:
       context: ../../
@@ -37,9 +57,9 @@ services:
     volumes:
       - '../../:/app/src:z'
 
-  worker:
+  eda-worker:
     deploy:
-      replicas: 1
+      replicas: ${EDA_NUM_WORKERS:-2}
     image: 'localhost/aap-eda-worker'
     build:
       context: ../../
@@ -59,14 +79,9 @@ services:
     environment:
       POSTGRES_PASSWORD: secret
       POSTGRES_DB: eda
-    command: >
-      postgres -c config_file=/etc/postgresql/postgresql.conf -c log_statement=${PG_LOG_STATEMENT:-none}
     ports:
       - '5432:5432'
     volumes:
-      - "./postgres/postgresql.conf:/etc/postgresql/postgresql.conf:z"
-      - "./postgres/initdb.d:/docker-entrypoint-initdb.d:z"
-      - "./postgres/conf.d:/etc/postgresql/conf.d:z"
       - 'postgres_data:/var/lib/postgresql/data'
     healthcheck:
       test: [ 'CMD', 'pg_isready', '-U', 'postgres' ]


### PR DESCRIPTION
Now that we have a docker-compose for macs we can add the latest updates from the stage env to the docker-compose-dev. 
Includes:
- Add podman service for activations to not depend on local podman anymore as we do in stage env. 
- Add the envvar for EDA_NUM_WORKERS and update the default value to match the stage env
- Remove postgres extra stuff not present in the stage or the operator env to use the default ones. 
- Add envvars for AWX integration. 
- Add UI pod
- Update pod names to the same values in stage (ui expects a hostname called "eda-api")