### PR TITLE
[AAP-14441] Add more details when updating projects

### DIFF
--- a/src/aap_eda/api/serializers/__init__.py
+++ b/src/aap_eda/api/serializers/__init__.py
@@ -46,6 +46,7 @@ from .project import (
     ProjectReadSerializer,
     ProjectRefSerializer,
     ProjectSerializer,
+    ProjectUpdateRequestSerializer,
 )
 from .rulebook import (
     AuditActionSerializer,
@@ -81,6 +82,7 @@ __all__ = (
     "PlaybookSerializer",
     "ProjectSerializer",
     "ProjectCreateRequestSerializer",
+    "ProjectUpdateRequestSerializer",
     "ProjectRefSerializer",
     "AuditActionSerializer",
     "AuditEventSerializer",

--- a/src/aap_eda/api/serializers/project.py
+++ b/src/aap_eda/api/serializers/project.py
@@ -44,6 +44,30 @@ class ProjectCreateRequestSerializer(serializers.ModelSerializer):
         fields = ["url", "name", "description", "credential_id"]
 
 
+class ProjectUpdateRequestSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        help_text="Name of the project",
+    )
+    description = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        help_text="Description of the project",
+    )
+    credential_id = serializers.IntegerField(
+        required=False,
+        allow_null=True,
+        help_text="Credential id of the project",
+    )
+
+    class Meta:
+        model = models.Project
+        fields = ["name", "description", "credential_id"]
+
+
 class ProjectReadSerializer(serializers.ModelSerializer):
     """Serializer for reading the Project with embedded objects."""
 


### PR DESCRIPTION
In this PR:
1. allow to update project with credential_id is 0 or None (clear credential from project);
2. raise 400 bad request if credential_id is invalid (the credential not found);
3. update fields only accept `name, description and credential_id`, 'url` cannot be updated.

Solves: [AAP-14441](https://issues.redhat.com/browse/AAP-14441)