### PR TITLE
fix: hide password when cloning projects

### DIFF
--- a/src/aap_eda/services/project/git.py
+++ b/src/aap_eda/services/project/git.py
@@ -182,5 +182,5 @@ class GitExecutor:
             )
             logger.warning(message, e.returncode, e.cmd, e.stderr)
             if "Authentication failed" in e.stderr:
-                raise GitError(f"Authentication failed: {e}")
+                raise GitError("Authentication failed")
             raise GitError(str(e))


### PR DESCRIPTION
Includes
- Prevent to leak git password in logs and exception when git fails. 
- Specify in the exception when it is an authentication error. 

Internal ref: https://issues.redhat.com/browse/AAP-12767