### PR TITLE
Fix enqueue_restart_task for activations restart

### DIFF
--- a/src/aap_eda/tasks/ruleset.py
+++ b/src/aap_eda/tasks/ruleset.py
@@ -130,14 +130,17 @@ def enqueue_restart_task(
     ssl_verify: str,
 ) -> None:
     time_at = timezone.now() + timedelta(seconds=seconds)
-    get_scheduler().enqueue_at(
+    logger.info(
+        "Enqueueing restart task for activation id: %s, at %s",
+        activation_id,
+        time_at,
+    )
+    get_scheduler(name="activation").enqueue_at(
         time_at,
         activate_rulesets,
-        args=(
-            True,
-            activation_id,
-            deployment_type,
-            ws_base_url,
-            ssl_verify,
-        ),
+        True,
+        activation_id,
+        deployment_type,
+        ws_base_url,
+        ssl_verify,
     )


### PR DESCRIPTION
After the implementation of the scheduler, activations are no longer restart automatically. It throws the error:
```
eda-default-worker_1     | 2023-07-31 11:51:46,784 INFO     default: aap_eda.tasks.ruleset.activate_rulesets(args=(True, 9, 'podman', 'ws://eda-api:8000', 'no')) (7553dead-9b13-4d62-ab37-4883eafbb4fc)
eda-default-worker_1     | 2023-07-31 11:51:46,792 ERROR    [Job 7553dead-9b13-4d62-ab37-4883eafbb4fc]: exception raised while executing (aap_eda.tasks.ruleset.activate_rulesets)
eda-default-worker_1     | Traceback (most recent call last):
eda-default-worker_1     |   File "/app/venv/lib64/python3.9/site-packages/rq/worker.py", line 1359, in perform_job
eda-default-worker_1     |     rv = job.perform()
eda-default-worker_1     |   File "/app/venv/lib64/python3.9/site-packages/rq/job.py", line 1178, in perform
eda-default-worker_1     |     self._result = self._execute()
eda-default-worker_1     |   File "/app/venv/lib64/python3.9/site-packages/rq/job.py", line 1215, in _execute
eda-default-worker_1     |     result = self.func(*self.args, **self.kwargs)
eda-default-worker_1     | TypeError: activate_rulesets() got an unexpected keyword argument 'args'
```

Internal ref: https://issues.redhat.com/browse/AAP-14571