### PR TITLE
[AAP-13795] Add Activation missing last restarted field

### DIFF
--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -183,6 +183,7 @@ class ActivationReadSerializer(serializers.ModelSerializer):
     )
     rules_count = serializers.IntegerField()
     rules_fired_count = serializers.IntegerField()
+    restarted_at = serializers.DateTimeField(required=False, allow_null=True)
 
     class Meta:
         model = models.Activation
@@ -204,8 +205,9 @@ class ActivationReadSerializer(serializers.ModelSerializer):
             "rules_fired_count",
             "created_at",
             "modified_at",
+            "restarted_at",
         ]
-        read_only_fields = ["id", "created_at", "modified_at"]
+        read_only_fields = ["id", "created_at", "modified_at", "restarted_at"]
 
     def to_representation(self, activation):
         decision_environment = (
@@ -250,4 +252,5 @@ class ActivationReadSerializer(serializers.ModelSerializer):
             "rules_fired_count": activation["rules_fired_count"],
             "created_at": activation["created_at"],
             "modified_at": activation["modified_at"],
+            "restarted_at": activation["restarted_at"],
         }

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -374,6 +374,11 @@ class ActivationViewSet(
             activation_id=activation["id"]
         )
         activation["instances"] = activation_instances
+        activation["restarted_at"] = (
+            activation_instances.latest("started_at").started_at
+            if activation_instances
+            else None
+        )
 
         return activation
 

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -211,6 +211,7 @@ def test_create_activation(activate_rulesets: mock.Mock, client: APIClient):
     }
     assert activation.rulebook_name == TEST_RULEBOOK["name"]
     assert activation.rulebook_rulesets == TEST_RULESETS
+    assert data["restarted_at"] is None
 
 
 @pytest.mark.django_db
@@ -334,6 +335,15 @@ def test_retrieve_activation(client: APIClient, with_project):
     assert data["extra_var"] == {
         "id": activation.extra_var.id,
     }
+    activation_instances = models.ActivationInstance.objects.filter(
+        activation_id=activation.id
+    )
+    if activation_instances:
+        assert data["restarted_at"] == activation_instances.latest(
+            "started_at"
+        ).started_at.strftime(DATETIME_FORMAT)
+    else:
+        assert data["restarted_at"] is None
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
- Add missing last restarted date field on Activations Read Endpoint: `http://localhost:8000/api/eda/v1/activations/<activation_id>/`