### PR TITLE
Fix rqscheduler initialization

### DIFF
--- a/src/aap_eda/core/management/commands/scheduler.py
+++ b/src/aap_eda/core/management/commands/scheduler.py
@@ -136,7 +136,10 @@ def add_cron_jobs(scheduler: Scheduler) -> None:
 
 
 class Command(rqscheduler.Command):
+    help = "Runs RQ scheduler with configured jobs."
+
     def handle(self, *args, **options) -> None:
+        logging.info("Initializing scheduler")
         scheduler = django_rq.get_scheduler()
         delete_scheduled_jobs(scheduler)
         add_startup_jobs(scheduler)


### PR DESCRIPTION
When I took https://github.com/ansible/eda-server/pull/321 I merged two functions thinking they were the same code as it was suggested, but I didn't notice that it calls different methods of the scheduler which accepts a different set of arguments, so even if the code is pretty similar IMO the original approach of keeping them in different functions is the right one. 