### PR TITLE
Check to make sure only one AWX token exists

### DIFF
--- a/src/aap_eda/api/exceptions.py
+++ b/src/aap_eda/api/exceptions.py
@@ -29,6 +29,7 @@ __all__ = (
     "Conflict",
     "Unprocessable",
     "PermissionDenied",
+    "TooManyControllerTokens",
 )
 
 
@@ -70,7 +71,7 @@ class NoControllerToken(APIException):
 class TooManyControllerTokens(APIException):
     status_code = 422
     default_detail = (
-        "More than one controller token found, "
+        "Found an existing controller token, "
         "currently only 1 token is supported"
     )
 

--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -20,6 +20,7 @@ from aap_eda.api.exceptions import (
     InvalidWebsocketHost,
     InvalidWebsocketScheme,
     NoControllerToken,
+    TooManyControllerTokens,
 )
 from aap_eda.api.serializers.decision_environment import (
     DecisionEnvironmentRefSerializer,
@@ -130,6 +131,8 @@ class ActivationCreateSerializer(serializers.ModelSerializer):
         tokens = models.AwxToken.objects.filter(user_id=user.id).count()
         if tokens == 0:
             raise NoControllerToken()
+        elif tokens > 1:
+            raise TooManyControllerTokens()
 
         ws_url = f"{settings.WEBSOCKET_BASE_URL}{ACTIVATION_PATH}"
         parsed_url = urllib.parse.urlparse(ws_url)

--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -20,7 +20,6 @@ from aap_eda.api.exceptions import (
     InvalidWebsocketHost,
     InvalidWebsocketScheme,
     NoControllerToken,
-    TooManyControllerTokens,
 )
 from aap_eda.api.serializers.decision_environment import (
     DecisionEnvironmentRefSerializer,

--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -131,8 +131,6 @@ class ActivationCreateSerializer(serializers.ModelSerializer):
         tokens = models.AwxToken.objects.filter(user_id=user.id).count()
         if tokens == 0:
             raise NoControllerToken()
-        elif tokens > 1:
-            raise TooManyControllerTokens()
 
         ws_url = f"{settings.WEBSOCKET_BASE_URL}{ACTIVATION_PATH}"
         parsed_url = urllib.parse.urlparse(ws_url)

--- a/src/aap_eda/api/views/user.py
+++ b/src/aap_eda/api/views/user.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import django.db.utils
 from drf_spectacular.utils import (
     OpenApiParameter,
     OpenApiResponse,
@@ -23,7 +24,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from aap_eda.api import serializers
-from aap_eda.api.exceptions import TooManyControllerTokens
+from aap_eda.api.exceptions import Conflict, TooManyControllerTokens
 from aap_eda.core import models
 
 from .mixins import (
@@ -164,6 +165,8 @@ class CurrentUserAwxTokenViewSet(
 
             serializer.save(user=self.request.user)
 
+        except django.db.utils.IntegrityError as ie:
+            raise Conflict(str(ie))
         except TooManyControllerTokens as e:
             raise TooManyControllerTokens(e)
 

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -449,24 +449,3 @@ def test_create_activation_no_token(client: APIClient):
     response = client.post(f"{api_url_v1}/activations/", data=test_activation)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert str(response.data["detail"]) == "No controller token specified"
-
-
-@pytest.mark.django_db
-def test_create_activation_more_tokens(client: APIClient):
-    fks = create_activation_related_data()
-    test_activation = TEST_ACTIVATION.copy()
-    test_activation["is_enabled"] = True
-    test_activation["decision_environment_id"] = fks["decision_environment_id"]
-    test_activation["project_id"] = fks["project_id"]
-    test_activation["rulebook_id"] = fks["rulebook_id"]
-    test_activation["extra_var_id"] = fks["extra_var_id"]
-
-    client.post(f"{api_url_v1}/users/me/awx-tokens/", data=TEST_AWX_TOKEN)
-    client.post(f"{api_url_v1}/users/me/awx-tokens/", data=TEST_AWX_TOKEN_2)
-    response = client.post(f"{api_url_v1}/activations/", data=test_activation)
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-    assert (
-        str(response.data["detail"])
-        == "More than one controller token found, "
-        "currently only 1 token is supported"
-    )


### PR DESCRIPTION
Recreates the original PR https://github.com/ansible/eda-server/pull/280, which for some reason it can not be reopened after the migration to a public repo. 

Only grab the first token. So checking to make sure we have at least one token makes sense.
Jira: https://github.com/ansible/eda-server/pull/280