### PR TITLE
[AAP-12987] Fix Rule Fire Count lag

### DIFF
--- a/src/aap_eda/wsapi/consumers.py
+++ b/src/aap_eda/wsapi/consumers.py
@@ -224,7 +224,7 @@ class AnsibleRulebookConsumer(AsyncWebsocketConsumer):
             activation = models.Activation.objects.get(
                 pk=activation_instance.activation_id
             )
-            if activation.ruleset_stats:
+            if message.ruleset in activation.ruleset_stats:
                 activation.ruleset_stats[message.ruleset][
                     "rulesTriggered"
                 ] += 1

--- a/src/aap_eda/wsapi/consumers.py
+++ b/src/aap_eda/wsapi/consumers.py
@@ -217,6 +217,18 @@ class AnsibleRulebookConsumer(AsyncWebsocketConsumer):
             )
 
             logger.info(f"Audit rule [{audit_rule.name}] is created.")
+
+            activation_instance = models.ActivationInstance.objects.get(
+                pk=message.activation_id
+            )
+            activation = models.Activation.objects.get(
+                pk=activation_instance.activation_id
+            )
+            if activation.ruleset_stats:
+                activation.ruleset_stats[message.ruleset][
+                    "rulesTriggered"
+                ] += 1
+            activation.save()
         else:
             audit_rule.fired_at = message.rule_run_at
             audit_rule.status = message.status


### PR DESCRIPTION
- fixes the delay and mismatch between "Fire count" on Activations Page and the number of Audit Rules completed for the given activation

Solves: [AAP-12987](https://issues.redhat.com/browse/AAP-12987)