### PR TITLE
Fix tasking subclasses and use datetime.utcnow

### DIFF
--- a/src/aap_eda/core/tasking/__init__.py
+++ b/src/aap_eda/core/tasking/__init__.py
@@ -52,7 +52,7 @@ class Queue(_Queue):
     def __init__(
         self,
         name: str = "default",
-        default_timeout: Union[int, str, None] = None,
+        default_timeout: int = -1,
         connection: Optional[Connection] = None,
         is_async: bool = True,
         job_class: Optional[_Job] = None,
@@ -64,7 +64,7 @@ class Queue(_Queue):
 
         super().__init__(
             name=name,
-            default_timeout=-1,
+            default_timeout=default_timeout,
             connection=connection,
             is_async=is_async,
             job_class=job_class,
@@ -147,7 +147,6 @@ class ActivationWorker(_Worker):
 
     def __init__(
         self,
-        queues: Iterable[Union[Queue, str]],
         name: Optional[str] = "activation",
         default_result_ttl: int = DEFAULT_RESULT_TTL,
         connection: Optional[Connection] = None,

--- a/src/aap_eda/tasks/ruleset.py
+++ b/src/aap_eda/tasks/ruleset.py
@@ -13,10 +13,9 @@
 #  limitations under the License.
 
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from django.conf import settings
-from django.utils import timezone
 from django_rq import get_scheduler
 
 from aap_eda.core import models
@@ -74,7 +73,7 @@ def monitor_activations() -> None:
     # 2. Restart (check latest instance):
     #    if status is unresponsive and updated_at has timeouted
     logger.info("Task started: monitor_activations")
-    now = timezone.now()
+    now = datetime.utcnow()
     running_statuses = [
         ActivationStatus.RUNNING.value,
         ActivationStatus.STARTING.value,
@@ -129,7 +128,7 @@ def enqueue_restart_task(
     ws_base_url: str,
     ssl_verify: str,
 ) -> None:
-    time_at = timezone.now() + timedelta(seconds=seconds)
+    time_at = datetime.utcnow() + timedelta(seconds=seconds)
     logger.info(
         "Enqueueing restart task for activation id: %s, at %s",
         activation_id,


### PR DESCRIPTION
Minor fixes around tasking:
- Wrong default value and type hint in the Queue subclass
- Remove unused param in the Activation Worker constructor
- Use datetime.utcnow as it is indicated in the [RQ scheduler documentation](https://github.com/rq/rq-scheduler#scheduling-a-job)
