### PR TITLE
Persist podman data for docker-compose

### DIFF
--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -19,6 +19,8 @@ services:
     command: podman system service --time=0 tcp://0.0.0.0:8888
     ports:
       - 8888:8888
+    volumes:
+      - 'podman_data:/var/lib/containers/storage'
 
   eda-ui:
     image: "${EDA_UI_IMAGE:-quay.io/ansible/eda-ui:main}"
@@ -138,3 +140,4 @@ services:
 
 volumes:
   postgres_data: {}
+  podman_data: {}

--- a/tools/docker/docker-compose-stage.yaml
+++ b/tools/docker/docker-compose-stage.yaml
@@ -22,6 +22,8 @@ services:
     command: podman system service --time=0 tcp://0.0.0.0:8888
     ports:
       - 8888:8888
+    volumes:
+      - 'podman_data:/var/lib/containers/storage'
 
   eda-ui:
     image: "${EDA_UI_IMAGE:-quay.io/ansible/eda-ui:main}"
@@ -132,3 +134,4 @@ services:
 
 volumes:
   postgres_data: {}
+  podman_data: {}


### PR DESCRIPTION
Every time the docker-compose is started all the images must be downloaded again. Adding an extra time and traffic. This is unnecessary an inefficient. This PR persist the podman data as we do with the database. 