### PR TITLE
[AAP-11738] Fix 500 error on Activation creation

### DIFF
--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -14,6 +14,7 @@
 import urllib.parse
 
 from django.conf import settings
+from django.db import IntegrityError
 from rest_framework import serializers
 
 from aap_eda.api.exceptions import (
@@ -119,9 +120,12 @@ class ActivationCreateSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data, user):
         self._validate_pre_reqs(user)
-        rulebook = models.Rulebook.objects.get(
-            pk=validated_data["rulebook_id"]
-        )
+        try:
+            rulebook = models.Rulebook.objects.get(
+                pk=validated_data["rulebook_id"]
+            )
+        except models.Rulebook.DoesNotExist:
+            raise IntegrityError
         validated_data["user_id"] = user.id
         validated_data["rulebook_name"] = rulebook.name
         validated_data["rulebook_rulesets"] = rulebook.rulesets

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -32,9 +32,14 @@ from aap_eda.tasks.ruleset import activate_rulesets, deactivate_rulesets
 
 def handle_activation_create_conflict(activation):
     activation_dependent_objects = [
+        (
+            models.DecisionEnvironment,
+            "decision environment",
+            activation.get("decision_environment_id"),
+        ),
         (models.Project, "project", activation.get("project_id")),
         (models.Rulebook, "rulebook", activation.get("rulebook_id")),
-        (models.ExtraVar, "extra_var", activation.get("extra_var_id")),
+        (models.ExtraVar, "extra var", activation.get("extra_var_id")),
     ]
     for object_model, object_name, object_id in activation_dependent_objects:
         if object_id is None:

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -34,12 +34,12 @@ def handle_activation_create_conflict(activation):
     activation_dependent_objects = [
         (
             models.DecisionEnvironment,
-            "decision environment",
+            "decision_environment",
             activation.get("decision_environment_id"),
         ),
         (models.Project, "project", activation.get("project_id")),
         (models.Rulebook, "rulebook", activation.get("rulebook_id")),
-        (models.ExtraVar, "extra var", activation.get("extra_var_id")),
+        (models.ExtraVar, "extra_var", activation.get("extra_var_id")),
     ]
     for object_model, object_name, object_id in activation_dependent_objects:
         if object_id is None:

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -21,7 +21,12 @@ from rest_framework.test import APIClient
 
 from aap_eda.api import serializers
 from aap_eda.core import models
-from aap_eda.core.enums import ActivationStatus, RestartPolicy
+from aap_eda.core.enums import (
+    Action,
+    ActivationStatus,
+    ResourceType,
+    RestartPolicy,
+)
 from tests.integration.constants import api_url_v1
 
 TEST_ACTIVATION = {
@@ -256,7 +261,7 @@ def test_create_activation_bad_entity(client: APIClient):
 )
 @pytest.mark.django_db(transaction=True)
 def test_create_activation_unprocessible_entity(
-    client: APIClient, dependent_object
+    client: APIClient, dependent_object, check_permission_mock: mock.Mock
 ):
     fks = create_activation_related_data()
     test_activation = TEST_ACTIVATION.copy()
@@ -281,6 +286,10 @@ def test_create_activation_unprocessible_entity(
     assert (
         response.data["detail"]
         == f"{dependent_object.capitalize()} with ID=0 does not exist."
+    )
+
+    check_permission_mock.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.ACTIVATION, Action.CREATE
     )
 
 

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -15,11 +15,9 @@ from typing import Any, Dict
 from unittest import mock
 
 import pytest
-from django.db import IntegrityError
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from aap_eda.api import serializers
 from aap_eda.core import models
 from aap_eda.core.enums import (
     Action,
@@ -270,18 +268,14 @@ def test_create_activation_unprocessible_entity(
     test_activation["rulebook_id"] = fks["rulebook_id"]
     test_activation["extra_var_id"] = fks["extra_var_id"]
 
-    with mock.patch.object(
-        serializers.ActivationCreateSerializer,
-        "create",
-        mock.Mock(side_effect=IntegrityError),
-    ):
-        response = client.post(
-            f"{api_url_v1}/activations/",
-            data={
-                **test_activation,
-                f"{dependent_object}_id": 0,
-            },
-        )
+    client.post(f"{api_url_v1}/users/me/awx-tokens/", data=TEST_AWX_TOKEN)
+    response = client.post(
+        f"{api_url_v1}/activations/",
+        data={
+            **test_activation,
+            f"{dependent_object}_id": 0,
+        },
+    )
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert (
         response.data["detail"]

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -252,14 +252,14 @@ def test_create_activation_bad_entity(client: APIClient):
 
 @pytest.mark.django_db(transaction=True)
 def test_create_activation_unprocessible_entity(client: APIClient):
-    test_activation = {
-        "name": "test-activation",
-        "description": "test activation",
-        "is_enabled": True,
-        "decision_environment_id": 32,
-        "rulebook_id": 100,
-    }
+    fks = create_activation_related_data()
+    test_activation = TEST_ACTIVATION.copy()
+    test_activation["decision_environment_id"] = fks["decision_environment_id"]
+    test_activation["project_id"] = fks["project_id"]
+    test_activation["rulebook_id"] = fks["rulebook_id"]
+    test_activation["extra_var_id"] = fks["extra_var_id"]
 
+    # test with non-existent decision environment
     with mock.patch.object(
         serializers.ActivationCreateSerializer,
         "create",
@@ -267,9 +267,61 @@ def test_create_activation_unprocessible_entity(client: APIClient):
     ):
         response = client.post(
             f"{api_url_v1}/activations/",
-            data=test_activation,
+            data={
+                **test_activation,
+                "decision_environment_id": 0,
+            },
         )
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert (
+        response.data["detail"]
+        == "Decision environment with ID=0 does not exist."
+    )
+    # test with non-existent rulebook
+    with mock.patch.object(
+        serializers.ActivationCreateSerializer,
+        "create",
+        mock.Mock(side_effect=IntegrityError),
+    ):
+        response = client.post(
+            f"{api_url_v1}/activations/",
+            data={
+                **test_activation,
+                "rulebook_id": 0,
+            },
+        )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.data["detail"] == "Rulebook with ID=0 does not exist."
+    # test with non-existent project
+    with mock.patch.object(
+        serializers.ActivationCreateSerializer,
+        "create",
+        mock.Mock(side_effect=IntegrityError),
+    ):
+        response = client.post(
+            f"{api_url_v1}/activations/",
+            data={
+                **test_activation,
+                "project_id": 0,
+            },
+        )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.data["detail"] == "Project with ID=0 does not exist."
+    # test with non-existent extra_var
+    with mock.patch.object(
+        serializers.ActivationCreateSerializer,
+        "create",
+        mock.Mock(side_effect=IntegrityError),
+    ):
+        response = client.post(
+            f"{api_url_v1}/activations/",
+            data={
+                **test_activation,
+                "extra_var_id": 0,
+            },
+        )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.data["detail"] == "Extra var with ID=0 does not exist."
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
- Fix 500 error thrown on Activation creation when non-existent rulebook ID is passed
- Improve unit test for create activation unprocessible entity
- Add a check for decision environment existence on Activation creation

Solves: [AAP-11738](https://issues.redhat.com/browse/AAP-11738)