### PR TITLE
Restore queue param in initializer of activation worker

### DIFF
--- a/src/aap_eda/core/tasking/__init__.py
+++ b/src/aap_eda/core/tasking/__init__.py
@@ -147,6 +147,7 @@ class ActivationWorker(_Worker):
 
     def __init__(
         self,
+        queues: Iterable[Union[Queue, str]],
         name: Optional[str] = "activation",
         default_result_ttl: int = DEFAULT_RESULT_TTL,
         connection: Optional[Connection] = None,


### PR DESCRIPTION
Restore required param deleted by mistake in https://github.com/ansible/eda-server/pull/335
