### PR TITLE
Add deployment_type into default worker's envs for K8S

### DIFF
--- a/tools/deploy/eda-default-worker/deployment.yaml
+++ b/tools/deploy/eda-default-worker/deployment.yaml
@@ -32,6 +32,8 @@ spec:
               value: secret
             - name: EDA_MQ_HOST
               value: eda-redis
+            - name: EDA_DEPLOYMENT_TYPE
+              value: k8s
             - name: EDA_WEBSOCKET_BASE_URL
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
Because deactivation is moved to default worker to process, its envs need to set DEPLOYMENT_TYPE=k8s. Otherwise deactivation task will run as local type and fail.