### PR TITLE
[AAP-15014] Do not set network_mode to host

### DIFF
--- a/tools/docker/docker-compose-mac.yml
+++ b/tools/docker/docker-compose-mac.yml
@@ -12,7 +12,7 @@ x-environment:
   - EDA_PODMAN_SOCKET_URL="unix:///run/podman/podman.sock"
   - EDA_CONTROLLER_URL=${EDA_CONTROLLER_URL:?Please specify EDA_CONTROLLER_URL env}
   - EDA_CONTROLLER_SSL_VERIFY=${EDA_CONTROLLER_SSL_VERIFY:-yes}
-  - EDA_PODMAN_EXTRA_ARGS='@json {"network_mode":"host"}'
+
 
 services:
   eda-ui:


### PR DESCRIPTION
host mode does not allow to publish container ports to host. Default network mode bridge better suits for our needs.

Fixes AAP-15014: [API] podman activation does not expose ports properly