### PR TITLE
[AAP-13416] Move activation deletion to default worker

### DIFF
--- a/src/aap_eda/services/ruleset/exceptions.py
+++ b/src/aap_eda/services/ruleset/exceptions.py
@@ -23,3 +23,7 @@ class K8sActivationException(ActivationException):
 
 class DeactivationException(ActivationException):
     pass
+
+
+class ActivationRecordNotFound(ActivationException):
+    pass

--- a/src/aap_eda/tasks/ruleset.py
+++ b/src/aap_eda/tasks/ruleset.py
@@ -36,7 +36,14 @@ def activate_rulesets(
     ws_base_url: str,
     ssl_verify: str,
 ) -> None:
-    activation = models.Activation.objects.get(pk=activation_id)
+    activation = models.Activation.objects.filter(id=activation_id).first()
+    if (
+        not activation
+        or str(activation.status) == ActivationStatus.DELETING.value
+    ):
+        logger.info(f"Activation id: {activation_id} is deleted")
+        return
+
     if is_restart:
         activation.restart_count += 1
         activation.save(update_fields=["restart_count", "modified_at"])
@@ -62,6 +69,7 @@ def activate_rulesets(
 @job("default")
 def deactivate(
     activation_id: int,
+    is_delete: bool = False,
 ):
     activation = models.Activation.objects.get(id=activation_id)
     logger.info(f"Task started: Deactivate Activation ({activation.name})")
@@ -107,9 +115,13 @@ def deactivate(
             deployment_type=settings.DEPLOYMENT_TYPE,
         )
 
-    activation.current_job_id = None
-    activation.status = ActivationStatus.STOPPED
-    activation.save()
+    if is_delete:
+        logger.info(f"Activation {activation.name} is deleted")
+        activation.delete()
+    else:
+        activation.current_job_id = None
+        activation.status = ActivationStatus.STOPPED
+        activation.save()
 
 
 @job("default")

--- a/src/aap_eda/tasks/ruleset.py
+++ b/src/aap_eda/tasks/ruleset.py
@@ -44,22 +44,21 @@ def activate_rulesets(
         logger.info(f"Activation id: {activation_id} is deleted")
         return
 
+    # TODO(hsong): move this to views
     if is_restart:
         activation.restart_count += 1
         activation.save(update_fields=["restart_count", "modified_at"])
     logger.info(f"Task started: Activate rulesets ({activation.name})")
 
     if activation.is_enabled:
-        instance = ActivateRulesets().activate(
+        ActivateRulesets().activate(
             activation,
             deployment_type,
             ws_base_url,
             ssl_verify,
         )
 
-        logger.info(
-            f"Task finished: Rulesets ({activation.name}) {instance.status=}."
-        )
+        logger.info(f"Task finished: Rulesets ({activation.name}).")
     else:
         logger.info(
             f"Task finished: Rulesets ({activation.name}) has been disabled."

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -382,7 +382,8 @@ def test_retrieve_activation_not_exist(client: APIClient):
 
 
 @pytest.mark.django_db
-def test_delete_activation(client: APIClient):
+@mock.patch("aap_eda.tasks.ruleset.deactivate.delay")
+def test_delete_activation(delete_mock: mock.Mock, client: APIClient):
     fks = create_activation_related_data()
     activation = create_activation(fks)
 


### PR DESCRIPTION
This PR refactored the activation deletion logic as follows:
1. marks the activation's status to `deleting` in api worker, so UI can display it with correct status;
2. disable the activation to cleanup the jobs in queue and the running containers if necessary in default worker;
3. delete the activation from DB in default worker;

Solves [AAP-13416](https://issues.redhat.com/browse/AAP-13416)