### PR TITLE
chore: fix docker-compose for changes in eda-ui image

### DIFF
--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -10,6 +10,8 @@ x-environment:
   - EDA_CONTROLLER_URL=${EDA_CONTROLLER_URL:-https://awx-example.com}
   - EDA_CONTROLLER_TOKEN=${EDA_CONTROLLER_TOKEN:-some-secret-token}
   - EDA_CONTROLLER_SSL_VERIFY=${EDA_CONTROLLER_SSL_VERIFY:-no}
+  - EDA_PROTOCOL=http
+  - EDA_HOST=eda-api:8000
 
 services:
   podman:
@@ -24,6 +26,7 @@ services:
 
   eda-ui:
     image: "${EDA_UI_IMAGE:-quay.io/ansible/eda-ui:main}"
+    environment: *common-env
     ports:
       - '8080:8080'
     depends_on:

--- a/tools/docker/docker-compose-mac.yml
+++ b/tools/docker/docker-compose-mac.yml
@@ -12,11 +12,14 @@ x-environment:
   - EDA_PODMAN_SOCKET_URL="unix:///run/podman/podman.sock"
   - EDA_CONTROLLER_URL=${EDA_CONTROLLER_URL:?Please specify EDA_CONTROLLER_URL env}
   - EDA_CONTROLLER_SSL_VERIFY=${EDA_CONTROLLER_SSL_VERIFY:-yes}
+  - EDA_PROTOCOL=http
+  - EDA_HOST=eda-api:8000
 
 
 services:
   eda-ui:
     image: "${EDA_UI_IMAGE:-quay.io/ansible/eda-ui:main}"
+    environment: *common-env
     ports:
       - '8080:8080'
     depends_on:

--- a/tools/docker/docker-compose-stage.yaml
+++ b/tools/docker/docker-compose-stage.yaml
@@ -13,6 +13,8 @@ x-environment:
   - EDA_CONTROLLER_URL=${EDA_CONTROLLER_URL:-https://awx-example.com}
   - EDA_CONTROLLER_TOKEN=${EDA_CONTROLLER_TOKEN:-some-secret-token}
   - EDA_CONTROLLER_SSL_VERIFY=${EDA_CONTROLLER_SSL_VERIFY:-no}
+  - EDA_PROTOCOL=http
+  - EDA_HOST=eda-api:8000
 
 services:
   podman:
@@ -27,6 +29,7 @@ services:
 
   eda-ui:
     image: "${EDA_UI_IMAGE:-quay.io/ansible/eda-ui:main}"
+    environment: *common-env
     ports:
       - '8080:8080'
     depends_on:


### PR DESCRIPTION
Based on PR https://github.com/ansible/ansible-ui/pull/766 We need to add 2 environment variables to the eda-ui container

   * EDA_PROTOCOL
   * EDA_HOST

Without this change in we were getting an error when starting the eda-ui container
```
eda-ui_1                 | /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
eda-ui_1                 | /docker-entrypoint.sh: Configuration complete; ready for start up
eda-ui_1                 | 2023/08/15 18:51:28 [emerg] 1#1: unknown "eda_protocol" variable
eda-ui_1                 | nginx: [emerg] unknown "eda_protocol" variable
docker_eda-ui_1 exited with code 1
```