### PR TITLE
fix: handle multiple rule matching to the same fact/event

### DIFF
--- a/src/aap_eda/wsapi/consumers.py
+++ b/src/aap_eda/wsapi/consumers.py
@@ -261,10 +261,10 @@ class AnsibleRulebookConsumer(AsyncWebsocketConsumer):
                         received_at=meta.get("received_at"),
                         rule_fired_at=message.rule_run_at,
                     )
-                    audit_event.audit_actions.add(audit_action),
-                    audit_event.save()
-
                     logger.info(f"Audit event [{audit_event.id}] is created.")
+
+                audit_event.audit_actions.add(audit_action)
+                audit_event.save()
 
     @database_sync_to_async
     def insert_job_related_data(


### PR DESCRIPTION
When the same fact/event matches multiple rules we were not storing the events for the rules other than the first one. This PR ensures that the events are stored for every rule that matches.
https://issues.redhat.com/browse/AAP-15158