### PR TITLE
Active entities

### DIFF
--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -293,13 +293,7 @@ class ActivationViewSet(
 
         self._check_deleting(activation)
 
-        if activation.is_enabled:
-            activation.status = ActivationStatus.STOPPING
-            activation.is_enabled = False
-            activation.save(
-                update_fields=["is_enabled", "status", "modified_at"]
-            )
-
+        if activation.stop():
             deactivate.delay(activation.id)
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -15,7 +15,6 @@ import logging
 
 from django.conf import settings
 from django.db import IntegrityError
-from django.shortcuts import get_object_or_404
 from django_filters import rest_framework as defaultfilters
 from drf_spectacular.utils import (
     OpenApiParameter,
@@ -239,7 +238,7 @@ class ActivationViewSet(
     )
     @action(methods=["post"], detail=True, rbac_action=Action.ENABLE)
     def enable(self, request, pk):
-        activation = get_object_or_404(models.Activation, pk=pk)
+        activation = models.Activation.object_or_404(pk=pk)
         if activation.is_enabled:
             return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -290,7 +289,7 @@ class ActivationViewSet(
     )
     @action(methods=["post"], detail=True, rbac_action=Action.DISABLE)
     def disable(self, request, pk):
-        activation = get_object_or_404(models.Activation, pk=pk)
+        activation = models.Activation.object_or_404(pk=pk)
 
         self._check_deleting(activation)
 
@@ -317,7 +316,7 @@ class ActivationViewSet(
     )
     @action(methods=["post"], detail=True, rbac_action=Action.RESTART)
     def restart(self, request, pk):
-        activation = get_object_or_404(models.Activation, pk=pk)
+        activation = models.Activation.object_or_404(pk=pk)
 
         self._check_deleting(activation)
 

--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from django.db import IntegrityError, transaction
-from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import (
     OpenApiResponse,
@@ -175,7 +174,7 @@ class ProjectViewSet(
         },
     )
     def partial_update(self, request, pk):
-        project = get_object_or_404(models.Project, pk=pk)
+        project = models.Project.object_or_404(pk=pk)
         serializer = serializers.ProjectUpdateRequestSerializer(
             instance=project, data=request.data, partial=True
         )

--- a/src/aap_eda/api/views/rulebook.py
+++ b/src/aap_eda/api/views/rulebook.py
@@ -14,7 +14,6 @@
 
 import yaml
 from django.http import JsonResponse
-from django.shortcuts import get_object_or_404
 from django_filters import rest_framework as defaultfilters
 from drf_spectacular.utils import (
     OpenApiParameter,
@@ -85,7 +84,7 @@ class RulebookViewSet(
         url_path="(?P<id>[^/.]+)/rulesets",
     )
     def rulesets(self, request, id):
-        rulebook = get_object_or_404(models.Rulebook, id=id)
+        rulebook = models.Rulebook.object_or_404(pk=id)
         rulesets = models.Ruleset.objects.filter(rulebook=rulebook)
 
         rulesets = self.filter_queryset(rulesets)
@@ -107,7 +106,7 @@ class RulebookViewSet(
     )
     @action(detail=True, rbac_action=Action.READ)
     def json(self, request, pk):
-        rulebook = get_object_or_404(models.Rulebook, pk=pk)
+        rulebook = models.Rulebook.object_or_404(pk=pk)
         data = serializers.RulebookSerializer(rulebook).data
         data["rulesets"] = yaml.safe_load(data["rulesets"])
 
@@ -135,7 +134,7 @@ class RulesetViewSet(
         },
     )
     def retrieve(self, request, pk=None):
-        ruleset = get_object_or_404(models.Ruleset, pk=pk)
+        ruleset = models.Ruleset.object_or_404(pk=pk)
         ruleset_data = serializers.RulesetSerializer(ruleset).data
         data = build_ruleset_out_data(ruleset_data)
 
@@ -171,7 +170,7 @@ class RulesetViewSet(
     )
     @action(detail=True, rbac_action=Action.READ)
     def rules(self, _request, pk):
-        ruleset = get_object_or_404(models.Ruleset, pk=pk)
+        ruleset = models.Ruleset.object_or_404(pk=pk)
         rules = models.Rule.objects.filter(ruleset=ruleset).order_by("id")
 
         results = self.paginate_queryset(rules)
@@ -244,7 +243,7 @@ class AuditRuleViewSet(
         url_path="(?P<id>[^/.]+)/actions",
     )
     def actions(self, _request, id):
-        audit_rule = get_object_or_404(models.AuditRule, id=id)
+        audit_rule = models.AuditRule.object_or_404(pk=id)
         audit_actions = models.AuditAction.objects.filter(
             audit_rule=audit_rule,
             rule_fired_at=audit_rule.fired_at,
@@ -280,7 +279,7 @@ class AuditRuleViewSet(
         url_path="(?P<id>[^/.]+)/events",
     )
     def events(self, _request, id):
-        audit_rule = get_object_or_404(models.AuditRule, id=id)
+        audit_rule = models.AuditRule.object_or_404(pk=id)
         audit_actions = models.AuditAction.objects.filter(
             audit_rule=audit_rule,
             rule_fired_at=audit_rule.fired_at,
@@ -347,7 +346,7 @@ class RuleViewSet(
         },
     )
     def retrieve(self, _request, pk=None):
-        rule = get_object_or_404(models.Rule, pk=pk)
+        rule = models.Rule.object_or_404(pk=pk)
         data = self._build_rule_out_data(rule)
 
         return Response(data)

--- a/src/aap_eda/core/models/activation.py
+++ b/src/aap_eda/core/models/activation.py
@@ -72,6 +72,16 @@ class Activation(EDAModelMixin, models.Model):
     created_at = models.DateTimeField(auto_now_add=True, null=False)
     modified_at = models.DateTimeField(auto_now=True, null=False)
 
+    def stop(self):
+        if not self.is_enabled:
+            return False
+
+        self.status = ActivationStatus.STOPPING
+        self.is_enabled = False
+        self.save(update_fields=["is_enabled", "status", "modified_at"])
+
+        return True
+
 
 class ActivationInstance(models.Model):
     class Meta:

--- a/src/aap_eda/core/models/activation.py
+++ b/src/aap_eda/core/models/activation.py
@@ -16,6 +16,7 @@ from django.db import models
 
 from aap_eda.core.enums import ActivationStatus, RestartPolicy
 
+from .eda_model_mixin import EDAModelMixin
 from .user import User
 
 __all__ = (
@@ -25,7 +26,7 @@ __all__ = (
 )
 
 
-class Activation(models.Model):
+class Activation(EDAModelMixin, models.Model):
     class Meta:
         db_table = "core_activation"
         indexes = [models.Index(fields=["name"], name="ix_activation_name")]

--- a/src/aap_eda/core/models/eda_model_mixin.py
+++ b/src/aap_eda/core/models/eda_model_mixin.py
@@ -1,0 +1,23 @@
+#  Copyright 2023 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from django.shortcuts import get_object_or_404
+
+__all__ = ("EDAModelMixin",)
+
+
+class EDAModelMixin(object):
+    @classmethod
+    def object_or_404(cls, pk):
+        return get_object_or_404(cls, pk=pk)

--- a/src/aap_eda/core/models/project.py
+++ b/src/aap_eda/core/models/project.py
@@ -26,10 +26,12 @@
 
 from django.db import models
 
+from .eda_model_mixin import EDAModelMixin
+
 PROJECT_ARCHIVE_DIR = "projects/"
 
 
-class Project(models.Model):
+class Project(EDAModelMixin, models.Model):
     class Meta:
         db_table = "core_project"
         constraints = [

--- a/src/aap_eda/core/models/rulebook.py
+++ b/src/aap_eda/core/models/rulebook.py
@@ -14,6 +14,8 @@
 
 from django.db import models
 
+from .eda_model_mixin import EDAModelMixin
+
 __all__ = (
     "Rulebook",
     "Ruleset",
@@ -22,7 +24,7 @@ __all__ = (
 )
 
 
-class Rulebook(models.Model):
+class Rulebook(EDAModelMixin, models.Model):
     class Meta:
         db_table = "core_rulebook"
         unique_together = ["project_id", "name"]
@@ -41,7 +43,7 @@ class Rulebook(models.Model):
     modified_at = models.DateTimeField(auto_now=True, null=False)
 
 
-class Ruleset(models.Model):
+class Ruleset(EDAModelMixin, models.Model):
     class Meta:
         db_table = "core_ruleset"
         unique_together = ["rulebook_id", "name"]
@@ -55,7 +57,7 @@ class Ruleset(models.Model):
     modified_at = models.DateTimeField(auto_now=True, null=False)
 
 
-class Rule(models.Model):
+class Rule(EDAModelMixin, models.Model):
     class Meta:
         db_table = "core_rule"
         unique_together = ["ruleset", "name"]
@@ -65,7 +67,7 @@ class Rule(models.Model):
     action = models.JSONField(default=dict, null=False)
 
 
-class AuditRule(models.Model):
+class AuditRule(EDAModelMixin, models.Model):
     class Meta:
         db_table = "core_audit_rule"
         indexes = [

--- a/src/aap_eda/tasks/ruleset.py
+++ b/src/aap_eda/tasks/ruleset.py
@@ -112,9 +112,7 @@ def deactivate(
         logger.info(f"Activation {activation.name} is deleted")
         activation.delete()
     else:
-        activation.current_job_id = None
-        activation.status = ActivationStatus.STOPPED
-        activation.save()
+        activation.stopped()
 
 
 @job("default")


### PR DESCRIPTION
This is presented as a topic for discussion of transitioning EDA objects (in particular model objects) from passive (acted upon) to active (performing the required changes) roles.

The first commit is a simple modification whereby specific instances are retrieved via the model class rather than  an external operation executed against the model class.

The second commit incorporates the transition of an `Activation` to `STOPPING` via a method implemented on `Activation`.  This isolates the processing to the class itself reducing the coupling between the view and the model.  As the decoupling of the state changes to `Activation` is the greater motivation the change does not attempt to incorporate the  `deactivate.delay` within the added `Activation.stop` method to avoid the greater restructuring that would be necessary to prevent a circular import issue.