### PR TITLE
chore: missing EDA_DEPLOYMENT_TYPE in the deployment file

### DIFF
--- a/tools/deploy/eda-activation-worker/deployment.yaml
+++ b/tools/deploy/eda-activation-worker/deployment.yaml
@@ -32,6 +32,8 @@ spec:
               value: secret
             - name: EDA_MQ_HOST
               value: eda-redis
+            - name: EDA_DEPLOYMENT_TYPE
+              value: k8s
             - name: EDA_WEBSOCKET_BASE_URL
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
The activation worker deployment file was missing the EDA_DEPLOYMENT_TYPE=k8s

And it would try running the podman deployment type and fail.