### PR TITLE
[AAP-13345] Fix log message when a failed activation restarts

### DIFF
--- a/src/aap_eda/services/ruleset/activate_rulesets.py
+++ b/src/aap_eda/services/ruleset/activate_rulesets.py
@@ -296,9 +296,9 @@ class ActivateRulesets:
         if error:
             seconds = int(settings.ACTIVATION_RESTART_SECONDS_ON_FAILURE)
             msg = (
-                f"Activation {activation.name} failed: {str(error)}, but will "
+                f"Activation {activation.name} failed: {str(error)}, "
                 f"retry ({retry_count}/{max_retries}) in {seconds} seconds "
-                "according to its restart policy"
+                "according to the activation's restart policy."
             )
             logger.warning(msg)
         else:

--- a/src/aap_eda/services/ruleset/activation_kubernetes.py
+++ b/src/aap_eda/services/ruleset/activation_kubernetes.py
@@ -510,7 +510,9 @@ class ActivationKubernetes:
             except ActivationRecordNotFound as e:
                 logger.error(e)
             except Exception as e:
-                raise K8sActivationException(f"Pod {pod_name} Failed: \n {e}")
+                raise K8sActivationException(
+                    f"Pod {pod_name} failed with error {e}"
+                )
 
     def read_job_pod_log(
         self, pod_name, namespace, activation_instance_id


### PR DESCRIPTION
This PR reformats the log message when a failed activation restarts.

Solves: [AAP-13345](https://issues.redhat.com/browse/AAP-13345)