### PR TITLE
Remove project_id from POST Activations

### DIFF
--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -98,7 +98,6 @@ class ActivationListSerializer(serializers.ModelSerializer):
 class ActivationCreateSerializer(serializers.ModelSerializer):
     """Serializer for creating the Activation."""
 
-    project_id = serializers.IntegerField(required=False, allow_null=True)
     rulebook_id = serializers.IntegerField()
     extra_var_id = serializers.IntegerField(required=False, allow_null=True)
     decision_environment_id = serializers.IntegerField()
@@ -110,7 +109,6 @@ class ActivationCreateSerializer(serializers.ModelSerializer):
             "description",
             "is_enabled",
             "decision_environment_id",
-            "project_id",
             "rulebook_id",
             "extra_var_id",
             "restart_policy",
@@ -128,6 +126,7 @@ class ActivationCreateSerializer(serializers.ModelSerializer):
         validated_data["rulebook_name"] = rulebook.name
         validated_data["rulebook_rulesets"] = rulebook.rulesets
         validated_data["git_hash"] = rulebook.project.git_hash
+        validated_data["project_id"] = rulebook.project.id
         return super().create(validated_data)
 
     def _validate_pre_reqs(self, user):

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -41,7 +41,6 @@ def handle_activation_create_conflict(activation):
             "decision_environment",
             activation.get("decision_environment_id"),
         ),
-        (models.Project, "project", activation.get("project_id")),
         (models.Rulebook, "rulebook", activation.get("rulebook_id")),
         (models.ExtraVar, "extra_var", activation.get("extra_var_id")),
     ]

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -186,7 +186,6 @@ def test_create_activation(activate_rulesets: mock.Mock, client: APIClient):
     fks = create_activation_related_data()
     test_activation = TEST_ACTIVATION.copy()
     test_activation["decision_environment_id"] = fks["decision_environment_id"]
-    test_activation["project_id"] = fks["project_id"]
     test_activation["rulebook_id"] = fks["rulebook_id"]
     test_activation["extra_var_id"] = fks["extra_var_id"]
 
@@ -228,7 +227,6 @@ def test_create_activation_disabled(client: APIClient):
     test_activation = TEST_ACTIVATION.copy()
     test_activation["is_enabled"] = False
     test_activation["decision_environment_id"] = fks["decision_environment_id"]
-    test_activation["project_id"] = fks["project_id"]
     test_activation["rulebook_id"] = fks["rulebook_id"]
     test_activation["extra_var_id"] = fks["extra_var_id"]
 
@@ -260,7 +258,7 @@ def test_create_activation_bad_entity(client: APIClient):
 
 @pytest.mark.parametrize(
     "dependent_object",
-    ["decision_environment", "project", "rulebook", "extra_var"],
+    ["decision_environment", "rulebook", "extra_var"],
 )
 @pytest.mark.django_db(transaction=True)
 def test_create_activation_unprocessible_entity(
@@ -269,7 +267,6 @@ def test_create_activation_unprocessible_entity(
     fks = create_activation_related_data()
     test_activation = TEST_ACTIVATION.copy()
     test_activation["decision_environment_id"] = fks["decision_environment_id"]
-    test_activation["project_id"] = fks["project_id"]
     test_activation["rulebook_id"] = fks["rulebook_id"]
     test_activation["extra_var_id"] = fks["extra_var_id"]
 
@@ -575,7 +572,6 @@ def test_create_activation_no_token(client: APIClient):
     test_activation = TEST_ACTIVATION.copy()
     test_activation["is_enabled"] = True
     test_activation["decision_environment_id"] = fks["decision_environment_id"]
-    test_activation["project_id"] = fks["project_id"]
     test_activation["rulebook_id"] = fks["rulebook_id"]
     test_activation["extra_var_id"] = fks["extra_var_id"]
 
@@ -590,7 +586,6 @@ def test_create_activation_more_tokens(client: APIClient):
     test_activation = TEST_ACTIVATION.copy()
     test_activation["is_enabled"] = True
     test_activation["decision_environment_id"] = fks["decision_environment_id"]
-    test_activation["project_id"] = fks["project_id"]
     test_activation["rulebook_id"] = fks["rulebook_id"]
     test_activation["extra_var_id"] = fks["extra_var_id"]
 


### PR DESCRIPTION
  * Removes project_id from POST Activations request payload
  * Populates the project field using the rulebook field value