### PR TITLE
Align postgres and redis images with eda-operator - AAP-15659

### DIFF
--- a/tools/deploy/postgres/deployment.yaml
+++ b/tools/deploy/postgres/deployment.yaml
@@ -18,17 +18,21 @@ spec:
     spec:
       containers:
         - env:
-            - name: POSTGRES_DB
+            - name: POSTGRESQL_DATABASE
               value: eda
-            - name: POSTGRES_PASSWORD
+            - name: POSTGRESQL_USER
+              value: eda
+            - name: POSTGRESQL_PASSWORD
               value: secret
-          image: docker.io/library/postgres:13
+            - name: POSTGRESQL_ADMIN_PASSWORD
+              value: secret
+          image: quay.io/sclorg/postgresql-13-c8s:latest
           name: postgres
           ports:
             - containerPort: 5432
           resources: {}
           volumeMounts:
-            - mountPath: /var/lib/postgresql/data
+            - mountPath: /var/lib/pgsql/data
               name: postgres-data
       restartPolicy: Always
       volumes:

--- a/tools/deploy/redis/deployment.yaml
+++ b/tools/deploy/redis/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - env: []
-          image: docker.io/library/redis:7
+          image: quay.io/sclorg/redis-6-c9s:latest
           name: redis
           ports:
             - containerPort: 6379

--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -120,7 +120,9 @@ services:
   postgres:
     image: 'quay.io/sclorg/postgresql-13-c8s:latest'
     environment:
+      POSTGRESQL_USER: eda
       POSTGRESQL_PASSWORD: secret
+      POSTGRESQL_ADMIN_PASSWORD: secret
       POSTGRESQL_DATABASE: eda
     ports:
       - '5432:5432'
@@ -134,7 +136,7 @@ services:
       start_period: 5s
 
   redis:
-    image: 'docker.io/library/redis:7'
+    image: 'quay.io/sclorg/redis-6-c9s:latest'
     ports:
       - '6379:6379'
     healthcheck:

--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -118,14 +118,14 @@ services:
     restart: always
 
   postgres:
-    image: 'docker.io/library/postgres:13'
+    image: 'quay.io/sclorg/postgresql-13-c8s:latest'
     environment:
-      POSTGRES_PASSWORD: secret
-      POSTGRES_DB: eda
+      POSTGRESQL_PASSWORD: secret
+      POSTGRESQL_DATABASE: eda
     ports:
       - '5432:5432'
     volumes:
-      - 'postgres_data:/var/lib/postgresql/data'
+      - 'postgres_data:/var/lib/pgsql/data'
     healthcheck:
       test: [ 'CMD', 'pg_isready', '-U', 'postgres' ]
       interval: 5s

--- a/tools/docker/docker-compose-mac.yml
+++ b/tools/docker/docker-compose-mac.yml
@@ -113,23 +113,25 @@ services:
         condition: service_healthy
 
   postgres:
-    image: 'docker.io/library/postgres:13'
+    image: 'quay.io/sclorg/postgresql-13-c8s:latest'
     environment:
-      POSTGRES_PASSWORD: secret
-      POSTGRES_DB: eda
+      POSTGRESQL_USER: eda
+      POSTGRESQL_PASSWORD: secret
+      POSTGRESQL_ADMIN_PASSWORD: secret
+      POSTGRESQL_DATABASE: eda
     ports:
       - '5432:5432'
+    volumes:
+      - 'postgres_data:/var/lib/pgsql/data'
     healthcheck:
       test: [ 'CMD', 'pg_isready', '-U', 'postgres' ]
       interval: 5s
       timeout: 5s
       retries: 3
       start_period: 5s
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
 
   redis:
-    image: 'docker.io/library/redis:7'
+    image: 'quay.io/sclorg/redis-6-c9s:latest'
     ports:
       - '6379:6379'
     healthcheck:

--- a/tools/docker/docker-compose-stage.yaml
+++ b/tools/docker/docker-compose-stage.yaml
@@ -111,23 +111,25 @@ services:
     restart: always
 
   postgres:
-    image: 'docker.io/library/postgres:13'
+    image: 'quay.io/sclorg/postgresql-13-c8s:latest'
     environment:
-      POSTGRES_PASSWORD: secret
-      POSTGRES_DB: eda
+      POSTGRESQL_USER: eda
+      POSTGRESQL_PASSWORD: secret
+      POSTGRESQL_ADMIN_PASSWORD: secret
+      POSTGRESQL_DATABASE: eda
     ports:
       - '5432:5432'
+    volumes:
+      - 'postgres_data:/var/lib/pgsql/data'
     healthcheck:
       test: [ 'CMD', 'pg_isready', '-U', 'postgres' ]
       interval: 5s
       timeout: 5s
       retries: 3
       start_period: 5s
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
 
   redis:
-    image: 'docker.io/library/redis:7'
+    image: 'quay.io/sclorg/redis-6-c9s:latest'
     ports:
       - '6379:6379'
     healthcheck:


### PR DESCRIPTION
All our development environments use a different image of postgres and redis than our operator. In the case of the redis we are using a different version as well. We must use the images that use the operator from the sclorg project, based in centos which is an environment closer to downstream.

Jira: https://issues.redhat.com/browse/AAP-15659