### PR TITLE
fix: fix logic of restarted_at field for activations

### DIFF
--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -351,9 +351,14 @@ class ActivationViewSet(
             activation_id=activation["id"]
         )
         activation["instances"] = activation_instances
+
+        # restart_count can be zero even if there are more than one instance
+        # because it is incremented only when the activation
+        # is restarted automatically
         activation["restarted_at"] = (
             activation_instances.latest("started_at").started_at
-            if activation_instances
+            if len(activation_instances) > 1
+            and activation["restart_count"] > 0
             else None
         )
 


### PR DESCRIPTION
Little fix for https://github.com/ansible/eda-server/pull/327
`restarted_at` field should not have value if the activation has not been restarted. 