### PR TITLE
fix: missing arg to _perform_deactivate call at activation restart - AAP-15719

### DIFF
--- a/src/aap_eda/tasks/ruleset.py
+++ b/src/aap_eda/tasks/ruleset.py
@@ -139,7 +139,7 @@ def restart(activation_id: int, requester: str = "User") -> None:
             ActivationStatus.FAILED.value,
             ActivationStatus.STOPPED.value,
         ]:
-            _perform_deactivate(activation)
+            _perform_deactivate(activation, ActivationStatus.STOPPED)
 
         activation.refresh_from_db()
         if str(activation.status) in [


### PR DESCRIPTION
Little hotfix for the changes introduced by https://github.com/ansible/eda-server/pull/338
Jira: https://issues.redhat.com/browse/AAP-15719