### PR TITLE
fix: watch for projects stuck in pending state

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,10 +54,12 @@ jobs:
       EDA_DB_PASSWORD: 'secret'
     services:
       postgres:
-        image: 'postgres:13'
+        image: 'quay.io/sclorg/postgresql-13-c9s:latest'
         env:
-          POSTGRES_DB: 'eda'
-          POSTGRES_PASSWORD: 'secret'
+          POSTGRESQL_USER: eda
+          POSTGRESQL_PASSWORD: secret
+          POSTGRESQL_ADMIN_PASSWORD: secret
+          POSTGRESQL_DATABASE: eda
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -65,6 +67,15 @@ jobs:
           --health-retries 5
         ports:
           - '5432:5432'
+      redis: # Add this section for Redis
+        image: 'quay.io/sclorg/redis-6-c9s:latest'
+        ports:
+          - '6379:6379'
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/docs/development.md
+++ b/docs/development.md
@@ -285,6 +285,8 @@ task docker -- up -d api
 
 ### Running tests
 
+To run tests locally, you need to have a running instance of postgresql and redis.
+
 Run all tests:
 
 ```

--- a/poetry.lock
+++ b/poetry.lock
@@ -952,6 +952,20 @@ files = [
 ]
 
 [[package]]
+name = "mirakuru"
+version = "2.5.1"
+description = "Process executor (not only) for tests."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "mirakuru-2.5.1-py3-none-any.whl", hash = "sha256:0a16f897841741f8cd784f790e54d74e61456ba36be9cb9de731b49e2e7a45dc"},
+    {file = "mirakuru-2.5.1.tar.gz", hash = "sha256:5a60d641fa92c8bfcd383f6e52f7a0bf3f081da0467fc6e3e6a3f6b3e3e47a7b"},
+]
+
+[package.dependencies]
+psutil = {version = ">=4.0.0", markers = "sys_platform != \"cygwin\""}
+
+[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
@@ -1060,6 +1074,43 @@ pyxdg = ">=0.26"
 requests = ">=2.24"
 tomli = {version = ">=1.2.3", markers = "python_version < \"3.11\""}
 urllib3 = ">=1.26.5"
+
+[[package]]
+name = "port-for"
+version = "0.7.1"
+description = "Utility that helps with local TCP ports management. It can find an unused TCP localhost port and remember the association."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "port-for-0.7.1.tar.gz", hash = "sha256:e0f3b8d7ec8bdc388c14d88bdbab8d6441c8081ed2bdec7847b38ca6d1563f23"},
+    {file = "port_for-0.7.1-py3-none-any.whl", hash = "sha256:8abdaa1a7810281b0cecf718a6319da5f8538fdae3a5101d1e9afd54da0baf8c"},
+]
+
+[[package]]
+name = "psutil"
+version = "5.9.5"
+description = "Cross-platform lib for process and system monitoring in Python."
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "psutil-5.9.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:be8929ce4313f9f8146caad4272f6abb8bf99fc6cf59344a3167ecd74f4f203f"},
+    {file = "psutil-5.9.5-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ab8ed1a1d77c95453db1ae00a3f9c50227ebd955437bcf2a574ba8adbf6a74d5"},
+    {file = "psutil-5.9.5-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:4aef137f3345082a3d3232187aeb4ac4ef959ba3d7c10c33dd73763fbc063da4"},
+    {file = "psutil-5.9.5-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:ea8518d152174e1249c4f2a1c89e3e6065941df2fa13a1ab45327716a23c2b48"},
+    {file = "psutil-5.9.5-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:acf2aef9391710afded549ff602b5887d7a2349831ae4c26be7c807c0a39fac4"},
+    {file = "psutil-5.9.5-cp27-none-win32.whl", hash = "sha256:5b9b8cb93f507e8dbaf22af6a2fd0ccbe8244bf30b1baad6b3954e935157ae3f"},
+    {file = "psutil-5.9.5-cp27-none-win_amd64.whl", hash = "sha256:8c5f7c5a052d1d567db4ddd231a9d27a74e8e4a9c3f44b1032762bd7b9fdcd42"},
+    {file = "psutil-5.9.5-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3c6f686f4225553615612f6d9bc21f1c0e305f75d7d8454f9b46e901778e7217"},
+    {file = "psutil-5.9.5-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7a7dd9997128a0d928ed4fb2c2d57e5102bb6089027939f3b722f3a210f9a8da"},
+    {file = "psutil-5.9.5-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89518112647f1276b03ca97b65cc7f64ca587b1eb0278383017c2a0dcc26cbe4"},
+    {file = "psutil-5.9.5-cp36-abi3-win32.whl", hash = "sha256:104a5cc0e31baa2bcf67900be36acde157756b9c44017b86b2c049f11957887d"},
+    {file = "psutil-5.9.5-cp36-abi3-win_amd64.whl", hash = "sha256:b258c0c1c9d145a1d5ceffab1134441c4c5113b2417fafff7315a917a026c3c9"},
+    {file = "psutil-5.9.5-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:c607bb3b57dc779d55e1554846352b4e358c10fff3abf3514a7a6601beebdb30"},
+    {file = "psutil-5.9.5.tar.gz", hash = "sha256:5410638e4df39c54d957fc51ce03048acd8e6d60abc0f5107af51e5fb566eb3c"},
+]
+
+[package.extras]
+test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "psycopg2"
@@ -1410,6 +1461,23 @@ pytest = ">=5.4.0"
 [package.extras]
 docs = ["sphinx", "sphinx-rtd-theme"]
 testing = ["Django", "django-configurations (>=2.0)"]
+
+[[package]]
+name = "pytest-redis"
+version = "3.0.2"
+description = "Redis fixtures and fixture factories for Pytest."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-redis-3.0.2.tar.gz", hash = "sha256:e54660e95fb1ec0feb7426523e37710ac7850380c60f9ee693c4045a6fc28ac5"},
+    {file = "pytest_redis-3.0.2-py3-none-any.whl", hash = "sha256:e2fd39658f396b6ae22976b80f94c61ebda5bc2bb8fe7eabcc7a7f994f7659f8"},
+]
+
+[package.dependencies]
+mirakuru = "*"
+port-for = ">=0.6.0"
+pytest = ">=6.2"
+redis = ">=3"
 
 [[package]]
 name = "python-dateutil"
@@ -1902,4 +1970,4 @@ dev = ["psycopg2-binary"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4"
-content-hash = "0e04913a6698e711e6164e89dbca2ea2cb95f634fb51b2df496cf1c88a912d6c"
+content-hash = "7fb7c6a7e09833a20e68cb5e5c30cf4ff6522e6fda15b34240afafff9fc5075b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ cryptography = "*"
 kubernetes = "*"
 podman = ">=4.5"
 rq-scheduler = "^0.10"
+pytest-redis = "^3.0.2"
 
 [tool.poetry.group.test.dependencies]
 pytest = "*"

--- a/src/aap_eda/core/tasking/__init__.py
+++ b/src/aap_eda/core/tasking/__init__.py
@@ -193,6 +193,11 @@ class ActivationWorker(_Worker):
 
 
 def unique_enqueue(queue_name: str, job_id: str, *args, **kwargs) -> Job:
+    """Enqueue a new job if it is not already enqueued.
+
+    Detects if a job with the same id is already enqueued and if it is
+    it will return it instead of enqueuing a new one.
+    """
     queue = get_queue(queue_name)
     job = job_from_queue(queue, job_id)
     if job:
@@ -202,6 +207,7 @@ def unique_enqueue(queue_name: str, job_id: str, *args, **kwargs) -> Job:
         return job
     else:
         kwargs["job_id"] = job_id
+        logger.info(f"Enqueing unique job: {job_id}")
         return queue.enqueue(*args, **kwargs)
 
 

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -268,7 +268,8 @@ RQ_QUEUES["activation"]["DB"] = settings.get("MQ_DB", 0)
 
 RQ_STARTUP_JOBS = []
 RQ_PERIODIC_JOBS = [
-    {"func": "aap_eda.tasks.ruleset.monitor_activations", "interval": 60}
+    {"func": "aap_eda.tasks.ruleset.monitor_activations", "interval": 60},
+    {"func": "aap_eda.tasks.project.monitor_project_tasks", "interval": 30},
 ]
 RQ_CRON_JOBS = []
 RQ_SCHEDULER_JOB_INTERVAL = settings.get("SCHEDULER_JOB_INTERVAL", 5)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,31 @@
+#  Copyright 2023 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+from pytest_redis import factories
+
+from aap_eda.core.tasking import Queue
+
+ADMIN_USERNAME = "test.admin"
+ADMIN_PASSWORD = "test.admin.123"
+
+
+# fixture for pytest-redis plugin
+# like django-db for a running redis server
+redis_external = factories.redisdb("redis_nooproc")
+
+
+@pytest.fixture
+def default_queue(redis_external) -> Queue:
+    return Queue("default", connection=redis_external)

--- a/tests/integration/core/test_tasking.py
+++ b/tests/integration/core/test_tasking.py
@@ -1,0 +1,60 @@
+#  Copyright 2023 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import logging
+
+import pytest
+
+from aap_eda.core.tasking import logger, unique_enqueue
+
+
+@pytest.fixture
+def eda_caplog(caplog):
+    logger.setLevel(logging.INFO)
+    logger.handlers += [caplog.handler]
+    return caplog
+
+
+def fake_task(number: int):
+    pass
+
+
+def test_unique_enqueue_existing_job(default_queue, eda_caplog):
+    default_queue.enqueue(fake_task, job_id="fake_task", number=1)
+    job = unique_enqueue(default_queue.name, "fake_task", fake_task, number=2)
+    assert job.kwargs["number"] == 1
+    assert "already enqueued" in eda_caplog.text
+
+
+def test_unique_enqueue_old_job_completed(default_queue, eda_caplog):
+    old_job = default_queue.enqueue(fake_task, job_id="fake_task", number=1)
+    old_job.set_status("finished")
+    job = unique_enqueue(default_queue.name, "fake_task", fake_task, number=2)
+    assert job.kwargs["number"] == 2
+    assert "Enqueing unique job" in eda_caplog.text
+
+
+def test_unique_enqueue_old_job_failed(default_queue, eda_caplog):
+    old_job = default_queue.enqueue(fake_task, job_id="fake_task", number=1)
+    old_job.set_status("failed")
+    job = unique_enqueue(default_queue.name, "fake_task", fake_task, number=2)
+    assert job.kwargs["number"] == 2
+    assert "Enqueing unique job" in eda_caplog.text
+
+
+def test_unique_enqueue_new_job(default_queue, eda_caplog):
+    job = unique_enqueue(default_queue.name, "fake_task", fake_task, number=2)
+    assert job.kwargs["number"] == 2
+    assert "Enqueing unique job" in eda_caplog.text

--- a/tests/integration/tasks/test_projects.py
+++ b/tests/integration/tasks/test_projects.py
@@ -1,0 +1,120 @@
+#  Copyright 2023 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from unittest import mock
+
+import pytest
+
+from aap_eda.core import models
+from aap_eda.core.tasking import DefaultWorker, Queue
+from aap_eda.tasks.project import monitor_project_tasks
+
+
+def fake_job():
+    pass
+
+
+@pytest.mark.django_db
+@mock.patch("aap_eda.tasks.project.import_project")
+def test_monitor_project_tasks_import(
+    import_task_mock: mock.Mock,
+    default_queue: Queue,
+):
+    """Test monitor_project_tasks rq task.
+
+    Test that monitor_project_tasks recreate the task
+    when import project task is stuck.
+    """
+    job_id = "b93ae0b6-53fe-11ee-a5c4-482ae389cd08"
+    job = mock.Mock(id=job_id)
+    import_task_mock.delay.return_value = job
+
+    project = models.Project.objects.create(
+        name="test_monitor_project_tasks",
+        url="https://git.example.com/acme/project-01",
+        import_state=models.Project.ImportState.PENDING,
+    )
+    default_queue.enqueue(monitor_project_tasks)
+
+    worker = DefaultWorker(
+        [default_queue], connection=default_queue.connection
+    )
+    worker.work(burst=True)
+    project.refresh_from_db()
+    assert str(project.import_task_id) == job_id
+
+
+@pytest.mark.django_db
+@mock.patch("aap_eda.tasks.project.sync_project")
+def test_monitor_project_tasks_sync(
+    sync_task_mock: mock.Mock,
+    default_queue: Queue,
+):
+    """Test monitor_project_tasks rq task.
+
+    Test that monitor_project_tasks recreate the task
+    when sync project task is stuck.
+    """
+    job_id = "b93ae0b6-53fe-11ee-a5c4-482ae389cd08"
+    job = mock.Mock(id=job_id)
+    sync_task_mock.delay.return_value = job
+
+    project = models.Project.objects.create(
+        name="test_monitor_project_tasks",
+        url="https://git.example.com/acme/project-01",
+        import_state=models.Project.ImportState.PENDING,
+        git_hash="dummy-hash",
+    )
+    default_queue.enqueue(monitor_project_tasks)
+
+    worker = DefaultWorker(
+        [default_queue], connection=default_queue.connection
+    )
+    worker.work(burst=True)
+    project.refresh_from_db()
+    assert str(project.import_task_id) == job_id
+
+
+@pytest.mark.django_db
+@mock.patch("aap_eda.tasks.project.sync_project")
+def test_monitor_project_tasks_with_job(
+    sync_task_mock: mock.Mock,
+    default_queue: Queue,
+):
+    """Test monitor_project_tasks rq task.
+
+    Test that monitor_project_tasks does not recreate the task
+    when sync project task is not stuck
+    """
+    job_id = "b93ae0b6-53fe-11ee-a5c4-482ae389cd08"
+    job = mock.Mock(id=job_id)
+    sync_task_mock.delay.return_value = job
+    expected_job_id = "13affe8a-5401-11ee-8f1c-482ae389cd08"
+
+    project = models.Project.objects.create(
+        name="test_monitor_project_tasks",
+        url="https://git.example.com/acme/project-01",
+        import_state=models.Project.ImportState.PENDING,
+        git_hash="dummy-hash",
+        import_task_id=expected_job_id,
+    )
+    default_queue.enqueue(fake_job, job_id=expected_job_id)
+    default_queue.enqueue(monitor_project_tasks)
+
+    worker = DefaultWorker(
+        [default_queue], connection=default_queue.connection
+    )
+    worker.work(burst=True)
+    project.refresh_from_db()
+    assert str(project.import_task_id) == expected_job_id


### PR DESCRIPTION
Problem: if the broker is restarted we might have stuck projects pending to be synced/imported without a job in the queue. 

Includes:
- A new task to monitor projects in a similar way as monitor_activations does. It recreates the jobs if don't exist and their respective tests
- A new pytest plugin to use redis in a similar way as pytest-django does to use a real redis for integration tests. WARNING: Now redis is required to run the tests. This will be also necessary in later refactors of the integration tests to provide more coverage on tests that involves RQ tasks
- Add a redis instance and updates the postgres image in the CI pipeline following up: https://github.com/ansible/eda-server/pull/405 and https://github.com/ansible/eda-server/pull/384
- Tests for unique_enqueue plus docstring and a log record


Jira: https://issues.redhat.com/browse/AAP-15972