### PR TITLE
Fix the race condition caused by new added refresh_from_db

### DIFF
--- a/src/aap_eda/services/ruleset/activate_rulesets.py
+++ b/src/aap_eda/services/ruleset/activate_rulesets.py
@@ -160,7 +160,6 @@ class ActivateRulesets:
             else:
                 raise ActivationException(f"Unsupported {deployment_type}")
 
-            instance.refresh_from_db()
             if str(instance.status) == ActivationStatus.COMPLETED.value:
                 self._log_activate_complete(
                     instance,


### PR DESCRIPTION
New race condition is caused by recent change https://github.com/ansible/eda-server/pull/394. The GH e2e tests logs have several failures due to it.

```
eda-activation-worker_2  | 2023-09-13 07:16:43,407 ERROR    Exception: ActivationInstance matching query does not exist.
eda-activation-worker_2  | Traceback (most recent call last):
eda-activation-worker_2  |   File "/app/src/src/aap_eda/services/ruleset/activate_rulesets.py", line 163, in activate
eda-activation-worker_2  |     instance.refresh_from_db()
eda-activation-worker_2  |   File "/app/venv/lib64/python3.9/site-packages/django/db/models/base.py", line 650, in refresh_from_db
eda-activation-worker_2  |     db_instance = db_instance_qs.get()
eda-activation-worker_2  |   File "/app/venv/lib64/python3.9/site-packages/django/db/models/query.py", line 435, in get
eda-activation-worker_2  |     raise self.model.DoesNotExist(
eda-activation-worker_2  | aap_eda.core.models.activation.ActivationInstance.DoesNotExist: ActivationInstance matching query does not exist.
eda-activation-worker_2  | 2023-09-13 07:16:43,408 WARNING  Activation QE-activation 1BDOG0dXDKHvFwjenyD7F failed: ActivationInstance matching query does not exist., retry (1/5) in 60 seconds according to the activation's restart policy.
eda-activation-worker_2  | 2023-09-13 07:16:43,412 ERROR    [Job f99143c0-0ae7-4c45-a415-ee14b7e19bf2]: exception raised while executing (aap_eda.tasks.ruleset.activate)
eda-activation-worker_2  | Traceback (most recent call last):
eda-activation-worker_2  |   File "/app/src/src/aap_eda/services/ruleset/activate_rulesets.py", line 163, in activate
eda-activation-worker_2  |     instance.refresh_from_db()
eda-activation-worker_2  |   File "/app/venv/lib64/python3.9/site-packages/django/db/models/base.py", line 650, in refresh_from_db
eda-activation-worker_2  |     db_instance = db_instance_qs.get()
eda-activation-worker_2  |   File "/app/venv/lib64/python3.9/site-packages/django/db/models/query.py", line 435, in get
eda-activation-worker_2  |     raise self.model.DoesNotExist(
eda-activation-worker_2  | aap_eda.core.models.activation.ActivationInstance.DoesNotExist: ActivationInstance matching query does not exist.
eda-activation-worker_2  | 
eda-activation-worker_2  | During handling of the above exception, another exception occurred:
eda-activation-worker_2  | 
eda-activation-worker_2  | Traceback (most recent call last):
eda-activation-worker_2  |   File "/app/venv/lib64/python3.9/site-packages/django/db/backends/base/base.py", line 242, in _commit
eda-activation-worker_2  |     return self.connection.commit()
eda-activation-worker_2  | psycopg2.errors.ForeignKeyViolation: insert or update on table "core_activation_instance_log" violates foreign key constraint "core_activation_inst_activation_instance__e8e77d3d_fk_core_acti"
eda-activation-worker_2  | DETAIL:  Key (activation_instance_id)=(28) is not present in table "core_activation_instance".
eda-activation-worker_2  | 
eda-activation-worker_2  | 
eda-activation-worker_2  | The above exception was the direct cause of the following exception:
eda-activation-worker_2  | 
eda-activation-worker_2  | Traceback (most recent call last):
eda-activation-worker_2  |   File "/app/src/src/aap_eda/services/ruleset/activation_db_logger.py", line 67, in flush
```