### PR TITLE
chore: update activation.rulebook field openapi spec

### DIFF
--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -180,7 +180,7 @@ class ActivationReadSerializer(serializers.ModelSerializer):
         required=False, allow_null=True
     )
     project = ProjectRefSerializer(required=False, allow_null=True)
-    rulebook = RulebookRefSerializer()
+    rulebook = RulebookRefSerializer(required=False, allow_null=True)
     extra_var = ExtraVarRefSerializer(required=False, allow_null=True)
     instances = ActivationInstanceSerializer(many=True)
     rules_count = serializers.IntegerField()


### PR DESCRIPTION
 * Add `allow_null=True` to `activation.rulebook` field to reflect it on the openapi spec, although it is already nullable the openapi doesn't pick it up unless explicitly specified.