### PR TITLE
chore: upgrade pg image and improve startup order

### DIFF
--- a/tools/deploy/postgres/deployment.yaml
+++ b/tools/deploy/postgres/deployment.yaml
@@ -26,7 +26,7 @@ spec:
               value: secret
             - name: POSTGRESQL_ADMIN_PASSWORD
               value: secret
-          image: quay.io/sclorg/postgresql-13-c8s:latest
+          image: quay.io/sclorg/postgresql-13-c9s:latest
           name: postgres
           ports:
             - containerPort: 5432

--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -90,6 +90,8 @@ services:
       - --worker-class
       - aap_eda.core.tasking.DefaultWorker
     depends_on:
+      eda-api:
+        condition: service_healthy
       redis:
         condition: service_healthy
       postgres:
@@ -109,6 +111,8 @@ services:
       - aap_eda.core.tasking.ActivationWorker
     environment: *common-env
     depends_on:
+      eda-api:
+        condition: service_healthy
       redis:
         condition: service_healthy
       postgres:
@@ -118,7 +122,7 @@ services:
     restart: always
 
   postgres:
-    image: 'quay.io/sclorg/postgresql-13-c8s:latest'
+    image: 'quay.io/sclorg/postgresql-13-c9s:latest'
     environment:
       POSTGRESQL_USER: eda
       POSTGRESQL_PASSWORD: secret

--- a/tools/docker/docker-compose-mac.yml
+++ b/tools/docker/docker-compose-mac.yml
@@ -68,6 +68,8 @@ services:
       - --worker-class
       - aap_eda.core.tasking.DefaultWorker
     depends_on:
+      eda-api:
+        condition: service_healthy
       redis:
         condition: service_healthy
       postgres:
@@ -90,6 +92,8 @@ services:
       - --worker-class
       - aap_eda.core.tasking.ActivationWorker
     depends_on:
+      eda-api:
+        condition: service_healthy
       redis:
         condition: service_healthy
       postgres:
@@ -113,7 +117,7 @@ services:
         condition: service_healthy
 
   postgres:
-    image: 'quay.io/sclorg/postgresql-13-c8s:latest'
+    image: 'quay.io/sclorg/postgresql-13-c9s:latest'
     environment:
       POSTGRESQL_USER: eda
       POSTGRESQL_PASSWORD: secret

--- a/tools/docker/docker-compose-stage.yaml
+++ b/tools/docker/docker-compose-stage.yaml
@@ -86,6 +86,8 @@ services:
       - --worker-class
       - aap_eda.core.tasking.DefaultWorker
     depends_on:
+      eda-api:
+        condition: service_healthy
       redis:
         condition: service_healthy
       postgres:
@@ -104,6 +106,8 @@ services:
       - --worker-class
       - aap_eda.core.tasking.ActivationWorker
     depends_on:
+      eda-api:
+        condition: service_healthy
       redis:
         condition: service_healthy
       postgres:
@@ -111,7 +115,7 @@ services:
     restart: always
 
   postgres:
-    image: 'quay.io/sclorg/postgresql-13-c8s:latest'
+    image: 'quay.io/sclorg/postgresql-13-c9s:latest'
     environment:
       POSTGRESQL_USER: eda
       POSTGRESQL_PASSWORD: secret


### PR DESCRIPTION
c8s images doesn't have support for ARM, moving it to c9s that has it. 
Also includes a fix related with the startup order. If the DB is clean, the workers might run before complete the migrations and fail. 