### PR TITLE
fix: handle errors at pulling images for podman - AAP-16189

### DIFF
--- a/src/aap_eda/services/exceptions.py
+++ b/src/aap_eda/services/exceptions.py
@@ -1,0 +1,2 @@
+class PodmanImagePullError(Exception):
+    pass

--- a/src/aap_eda/services/ruleset/activation_podman.py
+++ b/src/aap_eda/services/ruleset/activation_podman.py
@@ -287,7 +287,7 @@ class ActivationPodman:
                     f"Image {image_url} pull failed. The image url "
                     "or the credentials may be incorrect."
                 )
-                logger.exception(msg)
+                logger.error(msg)
                 raise PodmanImagePullError(msg)
 
         except ImageNotFound:


### PR DESCRIPTION
Due to a bug in podman we are not handling exception when the image pull fails, raising a misleading error message after try to run the activation. 
Jira: https://issues.redhat.com/browse/AAP-16189