### PR TITLE
Update EDA UI env variables to support EDA_SERVER

### DIFF
--- a/tools/deploy/eda-ui/deployment.yaml
+++ b/tools/deploy/eda-ui/deployment.yaml
@@ -15,14 +15,16 @@ spec:
         comp: ui
     spec:
       containers:
-      - env:
-          - name: EDA_PROTOCOL
-            value: http
-          - name: EDA_HOST
-            value: eda-api:8000
-        name: eda-ui
-        imagePullPolicy: Never
-        image: eda-ui
-        ports:
-        - containerPort: 8080
+        - env:
+            - name: EDA_PROTOCOL
+              value: http
+            - name: EDA_HOST
+              value: eda-api:8000
+            - name: EDA_SERVER
+              value: http://eda-api:8000
+          name: eda-ui
+          imagePullPolicy: Never
+          image: eda-ui
+          ports:
+            - containerPort: 8080
 status: {}

--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -13,6 +13,7 @@ x-environment:
   - EDA_CONTROLLER_SSL_VERIFY=${EDA_CONTROLLER_SSL_VERIFY:-no}
   - EDA_PROTOCOL=http
   - EDA_HOST=${EDA_HOST:-eda-api:8000}
+  - EDA_SERVER=http://${EDA_HOST:-eda-api:8000}
 
 services:
   podman:

--- a/tools/docker/docker-compose-mac.yml
+++ b/tools/docker/docker-compose-mac.yml
@@ -14,7 +14,7 @@ x-environment:
   - EDA_CONTROLLER_SSL_VERIFY=${EDA_CONTROLLER_SSL_VERIFY:-yes}
   - EDA_PROTOCOL=http
   - EDA_HOST=${EDA_HOST:-eda-api:8000}
-
+  - EDA_SERVER=http://${EDA_HOST:-eda-api:8000}
 
 services:
   eda-ui:

--- a/tools/docker/docker-compose-stage.yaml
+++ b/tools/docker/docker-compose-stage.yaml
@@ -15,6 +15,7 @@ x-environment:
   - EDA_CONTROLLER_SSL_VERIFY=${EDA_CONTROLLER_SSL_VERIFY:-no}
   - EDA_PROTOCOL=http
   - EDA_HOST=eda-api:8000
+  - EDA_SERVER=http://eda-api:8000
 
 services:
   podman:


### PR DESCRIPTION
The image built as part of the Ansible UI will be moving back to the EDA_SERVER env variable instead of EDA_PROTOCOL and EDA_HOST.

This should make it so that the docker-compose supports both until EDA_PROTOCOL and EDA_HOST can be removed in the future.