### PR TITLE
Changed to use v6 Redis image for k8s deployment

### DIFF
--- a/tools/deploy/redis/deployment.yaml
+++ b/tools/deploy/redis/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - env: []
-          image: quay.io/sclorg/redis-6-c9s:latest
+          image: docker.io/library/redis:6
           name: redis
           ports:
             - containerPort: 6379


### PR DESCRIPTION
The `quay.io/sclorg/redis-6-c9s:latest` redis image broke when deploying in k8s env. Changed it to use v6: `docker.io/library/redis:6`