### PR TITLE
chore(deps) fix dep, moves pytest-redis to test group

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1970,4 +1970,4 @@ dev = ["psycopg2-binary"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4"
-content-hash = "7fb7c6a7e09833a20e68cb5e5c30cf4ff6522e6fda15b34240afafff9fc5075b"
+content-hash = "af181b1b1e7514d1d49256ef9ff95656ba07e1e6238b14471e3a476aac3c5f4a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ cryptography = "*"
 kubernetes = "*"
 podman = ">=4.5"
 rq-scheduler = "^0.10"
-pytest-redis = "^3.0.2"
 
 [tool.poetry.group.test.dependencies]
 pytest = "*"
@@ -51,6 +50,7 @@ pytest-django = "*"
 pytest-asyncio = "*"
 requests = { version="*", python="<4.0" }
 pytest-cov = "^4.1.0"
+pytest-redis = "^3.0.2"
 
 [tool.poetry.group.lint.dependencies]
 flake8 = "*"


### PR DESCRIPTION
Fix for https://github.com/ansible/eda-server/pull/396
pytest-redis was added as app dependency instead of test dependency. 