### PR TITLE
[AAP-16339] Add default status_message to activations and instances when updating their status

### DIFF
--- a/src/aap_eda/core/enums.py
+++ b/src/aap_eda/core/enums.py
@@ -87,3 +87,17 @@ class CredentialType(DjangoStrEnum):
     REGISTRY = "Container Registry"
     GITHUB = "GitHub Personal Access Token"
     GITLAB = "GitLab Personal Access Token"
+
+
+ACTIVATION_STATUS_MESSAGE_MAP = {
+    ActivationStatus.PENDING: "Wait for a worker to be available to start activation",  # noqa: E501
+    ActivationStatus.STARTING: "Worker is starting activation",
+    ActivationStatus.RUNNING: "Container running activation",
+    ActivationStatus.STOPPING: "Activation is being disabled",
+    ActivationStatus.DELETING: "Activation is being deleted",
+    ActivationStatus.COMPLETED: "Activation has completed",
+    ActivationStatus.FAILED: "Activation has failed",
+    ActivationStatus.STOPPED: "Activation has stopped",
+    ActivationStatus.UNRESPONSIVE: "Activation is not responsive",
+    ActivationStatus.ERROR: "Activation is in an error state",
+}

--- a/src/aap_eda/core/exceptions.py
+++ b/src/aap_eda/core/exceptions.py
@@ -1,0 +1,25 @@
+#  Copyright 2023 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+class UpdateFieldsRequiredError(Exception):
+    pass
+
+
+class StatusRequiredError(Exception):
+    pass
+
+
+class UnknownStatusError(Exception):
+    pass

--- a/src/aap_eda/core/models/activation.py
+++ b/src/aap_eda/core/models/activation.py
@@ -14,7 +14,16 @@
 
 from django.db import models
 
-from aap_eda.core.enums import ActivationStatus, RestartPolicy
+from aap_eda.core.enums import (
+    ACTIVATION_STATUS_MESSAGE_MAP,
+    ActivationStatus,
+    RestartPolicy,
+)
+from aap_eda.core.exceptions import (
+    StatusRequiredError,
+    UnknownStatusError,
+    UpdateFieldsRequiredError,
+)
 
 from .user import User
 
@@ -74,6 +83,57 @@ class Activation(models.Model):
     status_updated_at = models.DateTimeField(null=True)
     status_message = models.TextField(null=True, default=None)
 
+    def save(self, *args, **kwargs):
+        # when creating
+        if self._state.adding:
+            if self.status_message is None:
+                self._set_status_message()
+        else:
+            if not bool(kwargs) or "update_fields" not in kwargs:
+                raise UpdateFieldsRequiredError(
+                    "update_fields is required to use when saving "
+                    "due to race conditions"
+                )
+            else:
+                if "status" in kwargs["update_fields"]:
+                    self._is_valid_status()
+
+            if (
+                "status_message" in kwargs["update_fields"]
+                and "status" not in kwargs["update_fields"]
+            ):
+                raise StatusRequiredError(
+                    "status_message cannot be set by itself, "
+                    "it requires status and status_message together"
+                )
+            # when updating without status_message
+            elif (
+                "status" in kwargs["update_fields"]
+                and "status_message" not in kwargs["update_fields"]
+            ):
+                self._set_status_message()
+                kwargs["update_fields"].append("status_message")
+
+        super().save(*args, **kwargs)
+
+    def _set_status_message(self):
+        self.status_message = self._get_default_status_message()
+
+        if self.status == ActivationStatus.PENDING and not self.is_enabled:
+            self.status_message = "Activation is marked as disabled"
+
+    def _get_default_status_message(self):
+        try:
+            return ACTIVATION_STATUS_MESSAGE_MAP[self.status]
+        except KeyError:
+            raise UnknownStatusError(f"Status [{self.status}] is invalid")
+
+    def _is_valid_status(self):
+        try:
+            ActivationStatus(self.status)
+        except ValueError as error:
+            raise UnknownStatusError(error)
+
 
 class ActivationInstance(models.Model):
     class Meta:
@@ -92,6 +152,51 @@ class ActivationInstance(models.Model):
     ended_at = models.DateTimeField(null=True)
     activation_pod_id = models.TextField(null=True)
     status_message = models.TextField(null=True, default=None)
+
+    def save(self, *args, **kwargs):
+        # when creating
+        if self._state.adding:
+            if self.status_message is None:
+                self.status_message = self._get_default_status_message()
+        else:
+            if not bool(kwargs) or "update_fields" not in kwargs:
+                raise UpdateFieldsRequiredError(
+                    "update_fields is required to use when saving "
+                    "due to race conditions"
+                )
+            else:
+                if "status" in kwargs["update_fields"]:
+                    self._is_valid_status()
+
+            if (
+                "status_message" in kwargs["update_fields"]
+                and "status" not in kwargs["update_fields"]
+            ):
+                raise StatusRequiredError(
+                    "status_message cannot be set by itself, "
+                    "it requires status and status_message together"
+                )
+            # when updating without status_message
+            elif (
+                "status" in kwargs["update_fields"]
+                and "status_message" not in kwargs["update_fields"]
+            ):
+                self.status_message = self._get_default_status_message()
+                kwargs["update_fields"].append("status_message")
+
+        super().save(*args, **kwargs)
+
+    def _get_default_status_message(self):
+        try:
+            return ACTIVATION_STATUS_MESSAGE_MAP[self.status]
+        except KeyError:
+            raise UnknownStatusError(f"Status [{self.status}] is invalid")
+
+    def _is_valid_status(self):
+        try:
+            ActivationStatus(self.status)
+        except ValueError as error:
+            raise UnknownStatusError(error)
 
 
 class ActivationInstanceLog(models.Model):

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -20,6 +20,7 @@ from rest_framework.test import APIClient
 
 from aap_eda.core import models
 from aap_eda.core.enums import (
+    ACTIVATION_STATUS_MESSAGE_MAP,
     Action,
     ActivationStatus,
     ResourceType,
@@ -222,6 +223,11 @@ def test_create_activation(activate_rulesets: mock.Mock, client: APIClient):
     assert activation.rulebook_rulesets == TEST_RULESETS
     assert data["restarted_at"] is None
     assert activation.current_job_id == job.id
+    assert activation.status == ActivationStatus.PENDING
+    assert (
+        activation.status_message
+        == ACTIVATION_STATUS_MESSAGE_MAP[activation.status]
+    )
 
 
 @pytest.mark.django_db
@@ -241,7 +247,8 @@ def test_create_activation_disabled(client: APIClient):
     activation = models.Activation.objects.filter(id=data["id"]).first()
     assert activation.rulebook_name == TEST_RULEBOOK["name"]
     assert activation.rulebook_rulesets == TEST_RULESETS
-    assert data["status"] == ActivationStatus.PENDING
+    assert activation.status == ActivationStatus.PENDING
+    assert activation.status_message == "Activation is marked as disabled"
     assert not data["instances"]
 
 
@@ -447,6 +454,10 @@ def test_enable_activation(client: APIClient):
         )
 
         assert response.status_code == status.HTTP_409_CONFLICT
+        assert (
+            activation.status_message
+            == ACTIVATION_STATUS_MESSAGE_MAP[activation.status]
+        )
 
     for state in [
         ActivationStatus.COMPLETED,
@@ -462,7 +473,12 @@ def test_enable_activation(client: APIClient):
             f"{api_url_v1}/activations/{activation.id}/enable/"
         )
 
+        activation.refresh_from_db()
         assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert (
+            activation.status_message
+            == ACTIVATION_STATUS_MESSAGE_MAP[activation.status]
+        )
 
 
 @pytest.mark.django_db

--- a/tests/integration/api/test_activation_instance.py
+++ b/tests/integration/api/test_activation_instance.py
@@ -20,6 +20,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from aap_eda.core import models
+from aap_eda.core.enums import ACTIVATION_STATUS_MESSAGE_MAP
 from tests.integration.constants import api_url_v1
 
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
@@ -287,7 +288,7 @@ def assert_activation_instance_data(
         "activation_id": instance.activation.id,
         "started_at": instance.started_at.strftime(DATETIME_FORMAT),
         "ended_at": instance.ended_at,
-        "status_message": None,
+        "status_message": ACTIVATION_STATUS_MESSAGE_MAP[instance.status],
     }
 
 

--- a/tests/integration/core/test_activation.py
+++ b/tests/integration/core/test_activation.py
@@ -1,0 +1,115 @@
+#  Copyright 2023 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import pytest
+
+from aap_eda.core import models
+from aap_eda.core.enums import ACTIVATION_STATUS_MESSAGE_MAP, ActivationStatus
+from aap_eda.core.exceptions import (
+    StatusRequiredError,
+    UnknownStatusError,
+    UpdateFieldsRequiredError,
+)
+
+
+@pytest.fixture()
+def init_data():
+    user = models.User.objects.create(
+        username="tester",
+        password="secret",
+        first_name="Adam",
+        last_name="Tester",
+        email="adam@example.com",
+    )
+    return models.Activation.objects.create(
+        name="activation",
+        user=user,
+    )
+
+
+@pytest.mark.django_db
+def test_activation_save_with_errors(init_data):
+    activation = init_data
+    with pytest.raises(UpdateFieldsRequiredError):
+        activation.save()
+
+    with pytest.raises(StatusRequiredError):
+        activation.save(update_fields=["status_message"])
+
+
+@pytest.mark.django_db
+def test_activation_save_with_invalid_status(init_data):
+    activation = init_data
+    activation.status = "invalid"
+    with pytest.raises(UnknownStatusError):
+        activation.save(update_fields=["status"])
+
+    with pytest.raises(UpdateFieldsRequiredError):
+        activation.save(force_insert=True)
+
+    activation.status_message = "invalid message"
+    with pytest.raises(UnknownStatusError):
+        activation.save(update_fields=["status", "status_message"])
+
+
+@pytest.mark.django_db
+def test_activation_save(init_data):
+    activation = init_data
+
+    assert activation.is_enabled is True
+    assert activation.status == ActivationStatus.PENDING
+    assert (
+        activation.status_message
+        == ACTIVATION_STATUS_MESSAGE_MAP[activation.status]
+    )
+
+    for status in [
+        ActivationStatus.STARTING,
+        ActivationStatus.RUNNING,
+        ActivationStatus.STOPPING,
+        ActivationStatus.DELETING,
+        ActivationStatus.COMPLETED,
+        ActivationStatus.FAILED,
+        ActivationStatus.STOPPED,
+        ActivationStatus.UNRESPONSIVE,
+        ActivationStatus.ERROR,
+        ActivationStatus.PENDING,
+    ]:
+        activation.status = status
+        activation.save(update_fields=["status"])
+
+        activation.refresh_from_db()
+        assert (
+            activation.status_message
+            == ACTIVATION_STATUS_MESSAGE_MAP[activation.status]
+        )
+
+    activation.is_enabled = False
+    activation.save(update_fields=["is_enabled"])
+    activation.refresh_from_db()
+    assert activation.is_enabled is False
+
+    activation.save(update_fields=["status"])
+    activation.refresh_from_db()
+    assert activation.status_message == "Activation is marked as disabled"
+
+    activation.status = ActivationStatus.ERROR
+    error_message = "activation is in error state"
+    activation.status_message = error_message
+    activation.save(update_fields=["status", "status_message"])
+
+    activation.refresh_from_db()
+    assert activation.status == ActivationStatus.ERROR
+    assert activation.status_message == error_message

--- a/tests/integration/core/test_activation_instance.py
+++ b/tests/integration/core/test_activation_instance.py
@@ -1,0 +1,96 @@
+#  Copyright 2023 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import pytest
+
+from aap_eda.core import models
+from aap_eda.core.enums import ACTIVATION_STATUS_MESSAGE_MAP, ActivationStatus
+from aap_eda.core.exceptions import (
+    StatusRequiredError,
+    UnknownStatusError,
+    UpdateFieldsRequiredError,
+)
+
+
+@pytest.fixture()
+def init_data():
+    user = models.User.objects.create(
+        username="tester",
+        password="secret",
+        first_name="Adam",
+        last_name="Tester",
+        email="adam@example.com",
+    )
+    activation = models.Activation.objects.create(
+        name="activation",
+        user=user,
+    )
+    return models.ActivationInstance.objects.create(
+        name="test-instance",
+        activation=activation,
+    )
+
+
+@pytest.mark.django_db
+def test_activation_instance_save_with_errors(init_data):
+    instance = init_data
+    with pytest.raises(UpdateFieldsRequiredError):
+        instance.save()
+
+    with pytest.raises(UpdateFieldsRequiredError):
+        instance.save(force_insert=True)
+
+    with pytest.raises(StatusRequiredError):
+        instance.save(update_fields=["status_message"])
+
+
+@pytest.mark.django_db
+def test_activation_instance_save_with_invalid_status(init_data):
+    instance = init_data
+    instance.status = "invalid"
+    with pytest.raises(UnknownStatusError):
+        instance.save(update_fields=["status"])
+
+
+@pytest.mark.django_db
+def test_activation_instance_save(init_data):
+    instance = init_data
+
+    assert instance.status == ActivationStatus.PENDING
+    assert (
+        instance.status_message
+        == ACTIVATION_STATUS_MESSAGE_MAP[instance.status]
+    )
+
+    for status in [
+        ActivationStatus.STARTING,
+        ActivationStatus.RUNNING,
+        ActivationStatus.STOPPING,
+        ActivationStatus.DELETING,
+        ActivationStatus.COMPLETED,
+        ActivationStatus.FAILED,
+        ActivationStatus.STOPPED,
+        ActivationStatus.UNRESPONSIVE,
+        ActivationStatus.ERROR,
+        ActivationStatus.PENDING,
+    ]:
+        instance.status = status
+        instance.save(update_fields=["status"])
+
+        instance.refresh_from_db()
+        assert (
+            instance.status_message
+            == ACTIVATION_STATUS_MESSAGE_MAP[instance.status]
+        )

--- a/tests/integration/tasks/test_ruleset.py
+++ b/tests/integration/tasks/test_ruleset.py
@@ -20,7 +20,11 @@ from django.conf import settings
 from django.utils import timezone
 
 from aap_eda.core import models
-from aap_eda.core.enums import ActivationStatus, RestartPolicy
+from aap_eda.core.enums import (
+    ACTIVATION_STATUS_MESSAGE_MAP,
+    ActivationStatus,
+    RestartPolicy,
+)
 from aap_eda.services.ruleset.activate_rulesets import ActivateRulesets
 from aap_eda.tasks.ruleset import (
     _activate,
@@ -246,7 +250,9 @@ def test_monitor_activations_restart_completed(
     init_activation.status_updated_at = timezone.now() - timedelta(
         seconds=settings.ACTIVATION_RESTART_SECONDS_ON_COMPLETE + 1
     )
-    init_activation.save()
+    init_activation.save(
+        update_fields=["status", "status_updated_at", "restart_policy"]
+    )
     _monitor_activations()
 
     activate_mock.assert_called_once_with(
@@ -255,6 +261,10 @@ def test_monitor_activations_restart_completed(
     )
     init_activation.refresh_from_db()
     assert init_activation.current_job_id == "jid"
+    assert (
+        init_activation.status_message
+        == ACTIVATION_STATUS_MESSAGE_MAP[init_activation.status]
+    )
 
 
 @pytest.mark.django_db
@@ -277,13 +287,10 @@ def test_monitor_activations_restart_failed(
 @pytest.mark.parametrize(
     "activation_attrs",
     [
-        {"restart_policy": RestartPolicy.NEVER},
-        {"is_valid": False},
-        {"failure_count": settings.ACTIVATION_MAX_RESTARTS_ON_FAILURE + 1},
         {
             "status_updated_at": timezone.now()
             - timedelta(
-                seconds=settings.ACTIVATION_RESTART_SECONDS_ON_FAILURE - 60
+                seconds=settings.ACTIVATION_RESTART_SECONDS_ON_FAILURE - 75
             )
         },
         {
@@ -291,9 +298,12 @@ def test_monitor_activations_restart_failed(
             "status": ActivationStatus.COMPLETED,
             "status_updated_at": timezone.now()
             - timedelta(
-                seconds=settings.ACTIVATION_RESTART_SECONDS_ON_COMPLETE - 60
+                seconds=settings.ACTIVATION_RESTART_SECONDS_ON_COMPLETE - 75
             ),
         },
+        {"restart_policy": RestartPolicy.NEVER},
+        {"is_valid": False},
+        {"failure_count": settings.ACTIVATION_MAX_RESTARTS_ON_FAILURE + 1},
     ],
 )
 @pytest.mark.django_db
@@ -301,9 +311,15 @@ def test_monitor_activations_restart_failed(
 def test_monitor_activations_not_restart(
     activate_mock: mock.Mock, init_activation, activation_attrs
 ):
+    job = mock.Mock()
+    job.id = "jid"
+    activate_mock.return_value = job
+
+    update_fields = []
     for key in activation_attrs:
         setattr(init_activation, key, activation_attrs[key])
-    init_activation.save()
+        update_fields.append(key)
+    init_activation.save(update_fields=update_fields)
     _monitor_activations()
 
     activate_mock.assert_not_called()


### PR DESCRIPTION
This is the followup of https://github.com/ansible/eda-server/pull/416: update the `status_message` of activations/instances with default values when their status is changed.