### PR TITLE
Changed update_fields of save to use list

### DIFF
--- a/src/aap_eda/services/ruleset/activation_podman.py
+++ b/src/aap_eda/services/ruleset/activation_podman.py
@@ -169,7 +169,7 @@ class ActivationPodman:
                 activation_instance.status = ActivationStatus.STOPPED
             else:
                 activation_instance.status = ActivationStatus.COMPLETED
-            activation_instance.save(update_fields={"status"})
+            activation_instance.save(update_fields=["status"])
         except ActivationException as e:
             logger.error(e)
         except ContainerError:


### PR DESCRIPTION
Even `dict` is acceptable in `update_fields` (https://docs.djangoproject.com/en/4.2/ref/models/instances/#ref-models-update-fields), we'd better to change it to list.

> The update_fields argument can be any iterable containing strings. An empty update_fields iterable will skip the save. A value of None will perform an update on all fields.
