### PR TITLE
fix: send the Hello message after the DB is updated

### DIFF
--- a/src/aap_eda/wsapi/consumers.py
+++ b/src/aap_eda/wsapi/consumers.py
@@ -74,8 +74,6 @@ DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
 
 class AnsibleRulebookConsumer(AsyncWebsocketConsumer):
     async def receive(self, text_data=None, bytes_data=None):
-        await self.send(text_data=json.dumps({"type": "Hello"}))
-
         data = json.loads(text_data)
         logger.debug(f"AnsibleRulebookConsumer received: {data}")
 
@@ -100,6 +98,9 @@ class AnsibleRulebookConsumer(AsyncWebsocketConsumer):
                 logger.warning(f"Unsupported message received: {data}")
         except DatabaseError as err:
             logger.error(f"Failed to parse {data} due to DB error: {err}")
+
+        if msg_type != MessageType.SHUTDOWN:
+            await self.send(text_data=json.dumps({"type": "Hello"}))
 
     async def handle_workers(self, message: WorkerMessage):
         logger.info(f"Start to handle workers: {message}")

--- a/tests/integration/wsapi/test_consumer.py
+++ b/tests/integration/wsapi/test_consumer.py
@@ -110,11 +110,11 @@ async def test_handle_workers(ws_communicator: WebsocketCommunicator):
     await ws_communicator.send_json_to(payload)
 
     for type in [
-        "Hello",
         "ExtraVars",
         "Rulebook",
         "ControllerInfo",
         "EndOfResponse",
+        "Hello",
     ]:
         response = await ws_communicator.receive_json_from(timeout=TIMEOUT)
         assert response["type"] == type
@@ -126,10 +126,10 @@ async def test_handle_workers(ws_communicator: WebsocketCommunicator):
     await ws_communicator.send_json_to(payload)
 
     for type in [
-        "Hello",
         "Rulebook",
         "ControllerInfo",
         "EndOfResponse",
+        "Hello",
     ]:
         response = await ws_communicator.receive_json_from(timeout=TIMEOUT)
         assert response["type"] == type


### PR DESCRIPTION
When the server side receives a websocket messages each message is handled by a separate asyncio task. In the task the first thing we do is send a "Hello" message to the ansible-rulebook. If ansible rulebook terminates before this Hello message gets to its the asyncio task aborts and doesn't write any messages into the DB. This leads to messages getting lost.
With this fix now we send the "Hello" message only after we have written the data to the DB.

https://issues.redhat.com/browse/AAP-16264