### PR TITLE
fix: handle import error with missing creds - AAP-16634

### DIFF
--- a/src/aap_eda/services/project/git.py
+++ b/src/aap_eda/services/project/git.py
@@ -188,4 +188,6 @@ class GitExecutor:
             logger.warning(message, e.returncode, e.cmd, e.stderr)
             if "Authentication failed" in e.stderr:
                 raise GitError("Authentication failed")
+            if "could not read Username" in e.stderr:
+                raise GitError("Authentication failed")
             raise GitError(str(e))

--- a/src/aap_eda/services/project/git.py
+++ b/src/aap_eda/services/project/git.py
@@ -189,5 +189,5 @@ class GitExecutor:
             if "Authentication failed" in e.stderr:
                 raise GitError("Authentication failed")
             if "could not read Username" in e.stderr:
-                raise GitError("Authentication failed")
+                raise GitError("Credentials not provided")
             raise GitError(str(e))


### PR DESCRIPTION
Follow up: https://github.com/ansible/eda-server/pull/322 which handle wrong credentials. 
Now we handle as well the repo requires creds but are not present. 
Jira: https://issues.redhat.com/browse/AAP-16634
![Screenshot from 2023-09-28 23-31-26](https://github.com/ansible/eda-server/assets/86774347/b611d0d2-1819-4416-87df-a64272edf698)
