### PR TITLE
(chore) Add api fallback exception handler.

### DIFF
--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -238,6 +238,7 @@ REST_FRAMEWORK = {
         "aap_eda.api.permissions.RoleBasedPermission",
     ],
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
+    "EXCEPTION_HANDLER": "aap_eda.api.exceptions.api_fallback_handler",
 }
 
 # ---------------------------------------------------------

--- a/tests/integration/api/test_fallback_handler.py
+++ b/tests/integration/api/test_fallback_handler.py
@@ -19,11 +19,8 @@ def raise_exception():
 @mock.patch("aap_eda.api.views.tasks.list_jobs", new=raise_exception)
 def test_debug_unexpected_exception(client: APIClient, settings):
     settings.DEBUG = True
-    try:
+    with pytest.raises(FallbackException):
         client.get(f"{api_url_v1}/tasks/")
-        raise Exception
-    except FallbackException:
-        pass
 
 
 @pytest.mark.django_db

--- a/tests/integration/api/test_fallback_handler.py
+++ b/tests/integration/api/test_fallback_handler.py
@@ -11,23 +11,27 @@ class FallbackException(Exception):
     pass
 
 
-def raise_exception():
+def raise_exception(self, request):
     raise FallbackException
 
 
 @pytest.mark.django_db
-@mock.patch("aap_eda.api.views.tasks.list_jobs", new=raise_exception)
+@mock.patch(
+    "aap_eda.api.views.project.ProjectViewSet.list", new=raise_exception
+)
 def test_debug_unexpected_exception(client: APIClient, settings):
     settings.DEBUG = True
     with pytest.raises(FallbackException):
-        client.get(f"{api_url_v1}/tasks/")
+        client.get(f"{api_url_v1}/projects/")
 
 
 @pytest.mark.django_db
-@mock.patch("aap_eda.api.views.tasks.list_jobs", new=raise_exception)
+@mock.patch(
+    "aap_eda.api.views.project.ProjectViewSet.list", new=raise_exception
+)
 def test_non_debug_unexpected_exception(client: APIClient, settings):
     settings.DEBUG = False
-    response = client.get(f"{api_url_v1}/tasks/")
+    response = client.get(f"{api_url_v1}/projects/")
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
 
     data = response.json()


### PR DESCRIPTION
Prevents stack trace on unexpected exceptions in deployment. If there is no already extant Response instance and debug is not enabled generates an internal server error Response containing contextual information as to the origin of the exception (what api and parameters were specified).