### PR TITLE
chore: Fix Delete Decision Environment response type

### DIFF
--- a/src/aap_eda/api/views/decision_environment.py
+++ b/src/aap_eda/api/views/decision_environment.py
@@ -117,6 +117,9 @@ class DecisionEnvironmentViewSet(
             status.HTTP_204_NO_CONTENT: OpenApiResponse(
                 None, description="Delete successful."
             ),
+            status.HTTP_403_FORBIDDEN: OpenApiResponse(
+                None, description="Decision Environment in use by Activations."
+            ),
         },
         parameters=[
             OpenApiParameter(

--- a/src/aap_eda/api/views/decision_environment.py
+++ b/src/aap_eda/api/views/decision_environment.py
@@ -113,7 +113,11 @@ class DecisionEnvironmentViewSet(
 
     @extend_schema(
         description="Delete a decision environment by id",
-        responses=status.HTTP_204_NO_CONTENT,
+        responses={
+            status.HTTP_204_NO_CONTENT: OpenApiResponse(
+                None, description="Delete successful."
+            ),
+        },
         parameters=[
             OpenApiParameter(
                 name="force",


### PR DESCRIPTION
Test suites is failing due to wrong defined response type for DE. This PR will set the correctly formatted response type for Delete DE endpoint. 