### PR TITLE
chore: make docker-compose docker rootful compat

### DIFF
--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -16,15 +16,30 @@ x-environment:
   - EDA_SERVER=http://${EDA_HOST:-eda-api:8000}
 
 services:
-  podman:
-    user: "1000"
+  podman-pre-setup:
+    user: "0"
     image: quay.io/containers/podman:${EDA_PODMAN_VERSION:-v4}
     privileged: true
-    command: podman system service --time=0 tcp://0.0.0.0:8888
+    command: >-
+      chown -R podman /home/podman/.local/share/containers/storage
     ports:
       - 8888:8888
     volumes:
       - 'podman_data:/home/podman/.local/share/containers/storage'
+
+  podman:
+    user: "1000"
+    image: quay.io/containers/podman:${EDA_PODMAN_VERSION:-v4}
+    privileged: true
+    command: >-
+      podman system service --time=0 tcp://0.0.0.0:8888
+    ports:
+      - 8888:8888
+    volumes:
+      - 'podman_data:/home/podman/.local/share/containers/storage'
+    depends_on:
+     - podman-pre-setup
+
 
   eda-ui:
     image: "${EDA_UI_IMAGE:-quay.io/ansible/eda-ui:main}"

--- a/tools/docker/docker-compose-stage.yaml
+++ b/tools/docker/docker-compose-stage.yaml
@@ -18,15 +18,29 @@ x-environment:
   - EDA_SERVER=http://eda-api:8000
 
 services:
-  podman:
-    user: "1000"
+  podman-pre-setup:
+    user: "0"
     image: quay.io/containers/podman:${EDA_PODMAN_VERSION:-v4}
     privileged: true
-    command: podman system service --time=0 tcp://0.0.0.0:8888
+    command: >-
+      chown -R podman /home/podman/.local/share/containers/storage
     ports:
       - 8888:8888
     volumes:
       - 'podman_data:/home/podman/.local/share/containers/storage'
+
+  podman:
+    user: "1000"
+    image: quay.io/containers/podman:${EDA_PODMAN_VERSION:-v4}
+    privileged: true
+    command: >-
+      podman system service --time=0 tcp://0.0.0.0:8888
+    ports:
+      - 8888:8888
+    volumes:
+      - 'podman_data:/home/podman/.local/share/containers/storage'
+    depends_on:
+     - podman-pre-setup
 
   eda-ui:
     image: "${EDA_UI_IMAGE:-quay.io/ansible/eda-ui:main}"


### PR DESCRIPTION
Follow up https://github.com/ansible/eda-server/pull/407
In podman rootless the volume works out of the box because usually the host user is also 1000. 
In docker rootful hosts the path is mount as root so we need to change the owner. This affects the GitHub runners which has by default docker. 
We could address this issue running the docker-compose with podman instead docker, but in this way the docker-compose is more compatible without requiring podman. 