### PR TITLE
fix(test): Task queued execution in testing

### DIFF
--- a/src/aap_eda/tasks/project.py
+++ b/src/aap_eda/tasks/project.py
@@ -42,13 +42,14 @@ def sync_project(project_id: int):
     logger.info(f"Task complete: Sync project ( project_id={project.id} )")
 
 
-# Started by the scheduler, unique concurrent execution on default queue
-def monitor_project_tasks():
+# Started by the scheduler, unique concurrent execution on specified queue;
+# default is the default queue
+def monitor_project_tasks(queue_name: str = PROJECT_TASKS_QUEUE):
     job_id = "monitor_project_tasks"
-    unique_enqueue(PROJECT_TASKS_QUEUE, job_id, _monitor_project_tasks)
+    unique_enqueue(queue_name, job_id, _monitor_project_tasks, queue_name)
 
 
-def _monitor_project_tasks() -> None:
+def _monitor_project_tasks(queue_name: str) -> None:
     """Handle project tasks that are stuck.
 
     Check if there are projects in PENDING state that doesn't have
@@ -57,7 +58,7 @@ def _monitor_project_tasks() -> None:
     """
     logger.info("Task started: Monitor project tasks")
 
-    queue = get_queue(PROJECT_TASKS_QUEUE)
+    queue = get_queue(queue_name)
 
     # Filter projects that doesn't have any related job
     pending_projects = models.Project.objects.filter(

--- a/tests/integration/tasks/test_projects.py
+++ b/tests/integration/tasks/test_projects.py
@@ -45,7 +45,7 @@ def test_monitor_project_tasks_import(
         url="https://git.example.com/acme/project-01",
         import_state=models.Project.ImportState.PENDING,
     )
-    default_queue.enqueue(monitor_project_tasks)
+    default_queue.enqueue(monitor_project_tasks, default_queue.name)
 
     worker = DefaultWorker(
         [default_queue], connection=default_queue.connection
@@ -76,7 +76,7 @@ def test_monitor_project_tasks_sync(
         import_state=models.Project.ImportState.PENDING,
         git_hash="dummy-hash",
     )
-    default_queue.enqueue(monitor_project_tasks)
+    default_queue.enqueue(monitor_project_tasks, default_queue.name)
 
     worker = DefaultWorker(
         [default_queue], connection=default_queue.connection


### PR DESCRIPTION
In an environment with a default worker running, tests that enqueue tasks on the default queue  result in the task being executed by the default worker within the default worker's environment.  This causes a cross-environment issue for tests (e.g., test_projects) which depend on the executing task accessing the test environment's DB which results in test failure.  This change adds a test environment-specific queue (still referenced as 'default_queue' thereby providing a logically consistent facade) on which these tasks are run within the same environment as the test's DB.