### PR TITLE
chore: change delete DE & credentials to use 409 response code

### DIFF
--- a/src/aap_eda/api/views/credential.py
+++ b/src/aap_eda/api/views/credential.py
@@ -142,7 +142,7 @@ class CredentialViewSet(
         ).exists()
 
         if is_used and not force:
-            raise exceptions.Forbidden(
+            raise exceptions.Conflict(
                 "Credential is being used by Activations "
                 "and cannot be deleted. If you want to force delete, "
                 "please add /?force=true query param."

--- a/src/aap_eda/api/views/decision_environment.py
+++ b/src/aap_eda/api/views/decision_environment.py
@@ -117,7 +117,7 @@ class DecisionEnvironmentViewSet(
             status.HTTP_204_NO_CONTENT: OpenApiResponse(
                 None, description="Delete successful."
             ),
-            status.HTTP_403_FORBIDDEN: OpenApiResponse(
+            status.HTTP_409_CONFLICT: OpenApiResponse(
                 None, description="Decision Environment in use by Activations."
             ),
         },
@@ -139,7 +139,7 @@ class DecisionEnvironmentViewSet(
         ).exists()
 
         if activations_exist and force_delete not in ["true", "1", "yes"]:
-            raise api_exc.Forbidden(
+            raise api_exc.Conflict(
                 "Decision Environment is being used by Activations "
                 "and cannot be deleted. If you want to force delete, "
                 "please add /?force=True query param."

--- a/tests/integration/api/test_credential.py
+++ b/tests/integration/api/test_credential.py
@@ -127,7 +127,7 @@ def test_delete_credential_used_by_activation(client: APIClient):
     create_activation(activation_dependencies)
     credential_id = activation_dependencies["credential_id"]
     response = client.delete(f"{api_url_v1}/credentials/{credential_id}/")
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_409_CONFLICT
 
 
 @pytest.mark.django_db

--- a/tests/integration/api/test_decision_environment.py
+++ b/tests/integration/api/test_decision_environment.py
@@ -130,10 +130,10 @@ def test_partial_update_decision_environment(client: APIClient, init_db):
 
 
 @pytest.mark.django_db
-def test_delete_decision_environment_forbidden(client: APIClient, init_db):
+def test_delete_decision_environment_conflict(client: APIClient, init_db):
     obj_id = int(init_db.decision_environment.id)
     response = client.delete(f"{api_url_v1}/decision-environments/{obj_id}/")
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_409_CONFLICT
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Following a discussion with @Alex-Izquierdo and @mkanoor, we decided to use 409 response code for deleting DE & credentials when they are in use by activations. 