### PR TITLE
Set default timeout for queues using unix socket

### DIFF
--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -255,9 +255,11 @@ if RQ_UNIX_SOCKET_PATH:
     RQ_QUEUES = {
         "default": {
             "UNIX_SOCKET_PATH": RQ_UNIX_SOCKET_PATH,
+            "DEFAULT_TIMEOUT": -1,
         },
         "activation": {
             "UNIX_SOCKET_PATH": RQ_UNIX_SOCKET_PATH,
+            "DEFAULT_TIMEOUT": -1,
         },
     }
 else:


### PR DESCRIPTION
The default -1 for timeout will let the activation job run without a timeout for long running activation.

Fixes AAP-17613: Activations die after running for approx 12 minutes