### PR TITLE
fix: capture git's stderr for generic errors

### DIFF
--- a/src/aap_eda/services/project/git.py
+++ b/src/aap_eda/services/project/git.py
@@ -190,4 +190,5 @@ class GitExecutor:
                 raise GitError("Authentication failed")
             if "could not read Username" in e.stderr:
                 raise GitError("Credentials not provided")
-            raise GitError(str(e))
+            usr_msg = f"{e} Error: {e.stderr}"
+            raise GitError(usr_msg) from e


### PR DESCRIPTION
Capture the stderr from git for generic errors at importing/sync projects. 
Jira: https://issues.redhat.com/browse/AAP-17705