### PR TITLE
Take over OS env variables in the GitExecutor

### DIFF
--- a/src/aap_eda/services/project/git.py
+++ b/src/aap_eda/services/project/git.py
@@ -144,9 +144,8 @@ class GitRepository:
 
 class GitExecutor:
     DEFAULT_TIMEOUT: Final = 30
-    ENVIRON: dict = {
-        "GIT_TERMINAL_PROMPT": "0",
-    }
+    ENVIRON: dict = os.environ.copy()
+    ENVIRON["GIT_TERMINAL_PROMPT"] = "0"
 
     def __call__(
         self,


### PR DESCRIPTION
With the current setup the GitExecutor does NOT take over the OS environment variables. Because of this it fails to pull the configured SCM URL as it doesn't take into account the http_proxy settings from in the environment variables.

This PR makes sure the GitExecutor runs with the same environment variables as the main process.