### PR TITLE
fix: fix update logs podman

### DIFF
--- a/src/aap_eda/services/activation/db_log_handler.py
+++ b/src/aap_eda/services/activation/db_log_handler.py
@@ -14,7 +14,7 @@
 
 import logging
 from datetime import datetime
-from typing import Union
+from typing import Optional, Union
 
 from django.conf import settings
 from django.db import IntegrityError
@@ -76,7 +76,7 @@ class DBLogger(LogHandler):
 
         self.activation_instance_log_buffer = []
 
-    def get_log_read_at(self) -> datetime:
+    def get_log_read_at(self) -> Optional[datetime]:
         try:
             activation_instance = models.ActivationInstance.objects.get(
                 pk=self.activation_instance_id

--- a/src/aap_eda/services/activation/engine/common.py
+++ b/src/aap_eda/services/activation/engine/common.py
@@ -29,7 +29,7 @@ class LogHandler(ABC):
         pass
 
     @abstractmethod
-    def get_log_read_at(self) -> datetime:
+    def get_log_read_at(self) -> tp.Optional[datetime]:
         pass
 
     @abstractmethod


### PR DESCRIPTION
split method can fail at unpacking if there is a log line without real content (like "\n")
also the current approach adds a second for the "since" value, in that second we might lose records. "since" is compatible with datetimes. 
Also fixes type hints