### PR TITLE
feat: support port as string

### DIFF
--- a/src/aap_eda/services/activation/engine/ports.py
+++ b/src/aap_eda/services/activation/engine/ports.py
@@ -1,3 +1,5 @@
+import contextlib
+
 import yaml
 
 
@@ -31,8 +33,8 @@ def find_ports(rulebook_text: str) -> list[tuple]:
             host = source_args.get("host")
             # Get port if it exists
             maybe_port = source_args.get("port")
-            # If port is an int we found a port to expose
-            if isinstance(maybe_port, int):
-                found_ports.append((host, maybe_port))
+            # port may be a string or an integer
+            with contextlib.suppress(ValueError):
+                found_ports.append((host, int(maybe_port)))
 
     return found_ports

--- a/tests/integration/services/activation/engine/test_ports.py
+++ b/tests/integration/services/activation/engine/test_ports.py
@@ -30,6 +30,20 @@ def test_ports():
     assert ports == [("0.0.0.0", 5555)]
 
 
+def test_ports_as_string():
+    rulebook = """
+---
+- name: Run a webhook service
+  hosts: all
+  sources:
+    - ansible.eda.webhook:
+        port: "5555"
+"""
+    ports = find_ports(rulebook)
+
+    assert ports == [(None, 5555)]
+
+
 def test_ports_with_multi_sources():
     rulebook = """
 ---


### PR DESCRIPTION
Port as string is usually supported in ansible. We should support customer plugins that support it. 