### PR TITLE
fix: remove increase restart count from the view

### DIFF
--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -305,9 +305,6 @@ class ActivationViewSet(
 
         restart_activation(activation_id=activation.id)
 
-        activation.restart_count += 1
-        activation.save(update_fields=["restart_count", "modified_at"])
-
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def _check_deleting(self, activation):


### PR DESCRIPTION
The view should not increase the restart counter because it doesn't know yet if is restartable or is effectively restarted. The counter should be increased by the manager only when the activation was actually restarted. 