### PR TITLE
[AAP-18000] chore: change validation errors format

### DIFF
--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -356,6 +356,6 @@ def parse_validation_errors(errors: dict) -> str:
     messages = {key: str(error[0]) for key, error in errors.items() if error}
 
     if "non_field_errors" in messages:
-        messages["errors"] = messages.pop("non_field_errors")
+        messages["field_errors"] = messages.pop("non_field_errors")
 
     return str(messages)

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -490,7 +490,7 @@ def test_restart_activation_with_invalid_tokens(client: APIClient, action):
     )
 
     error_message = (
-        "{'errors': 'More than one controller token found, "
+        "{'field_errors': 'More than one controller token found, "
         "currently only 1 token is supported'}"
     )
 
@@ -510,13 +510,13 @@ def test_restart_activation_with_invalid_tokens(client: APIClient, action):
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert (
         response.data["errors"]
-        == "{'errors': 'No controller token specified'}"
+        == "{'field_errors': 'No controller token specified'}"
     )
     activation.refresh_from_db()
     assert activation.status == ActivationStatus.ERROR
     assert (
         activation.status_message
-        == "{'errors': 'No controller token specified'}"
+        == "{'field_errors': 'No controller token specified'}"
     )
 
 
@@ -798,7 +798,7 @@ def test_create_activation_no_token(client: APIClient):
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert (
         str(response.data["errors"])
-        == "{'errors': 'No controller token specified'}"
+        == "{'field_errors': 'No controller token specified'}"
     )
 
 
@@ -817,6 +817,6 @@ def test_create_activation_more_tokens(client: APIClient):
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert (
         str(response.data["errors"])
-        == "{'errors': 'More than one controller token found, "
+        == "{'field_errors': 'More than one controller token found, "
         "currently only 1 token is supported'}"
     )


### PR DESCRIPTION
The second `errors` is changed to `field_errors`. Now the validation error looks like:
```
{
  "errors": {
       "field_errors": "No controller token specified"   
  }
}
```

Resolves [AAP-18000](https://issues.redhat.com/browse/AAP-18000)