### PR TITLE
refactor: update activation status when stopping it without the instance

### DIFF
--- a/src/aap_eda/services/activation/manager.py
+++ b/src/aap_eda/services/activation/manager.py
@@ -707,6 +707,7 @@ class ActivationManager:
                 f"Stop operation activation id: {self.db_instance.id} "
                 "No instance or pod id found.",
             )
+            self._set_activation_status(ActivationStatus.STOPPED)
             return
 
         try:


### PR DESCRIPTION
Update the status of activation from `Stopping` to `Stopped` when it's disabled without instances.