### PR TITLE
chore: split the ws service in mac

### DIFF
--- a/tools/docker/docker-compose-mac.yml
+++ b/tools/docker/docker-compose-mac.yml
@@ -7,7 +7,7 @@ x-environment:
   - EDA_SECRET_KEY=secret
   - EDA_ALLOWED_HOSTS=['*']
   - EDA_DEPLOYMENT_TYPE=podman
-  - EDA_WEBSOCKET_BASE_URL=${EDA_WEBSOCKET_BASE_URL:-wss://host.containers.internal:8443}
+  - EDA_WEBSOCKET_BASE_URL=${EDA_WEBSOCKET_BASE_URL:-ws://host.containers.internal:8001}
   - EDA_WEBSOCKET_SSL_VERIFY=no
   - EDA_PODMAN_SOCKET_URL="unix:///run/podman/podman.sock"
   - EDA_CONTROLLER_URL=${EDA_CONTROLLER_URL:?Please specify EDA_CONTROLLER_URL env}
@@ -53,6 +53,20 @@ services:
       retries: 10
     volumes:
       - ${EDA_HOST_PODMAN_SOCKET_URL:-/run/user/501/podman/podman.sock}:/run/podman/podman.sock:z
+
+  eda-ws:
+    image: "${EDA_IMAGE:-quay.io/ansible/eda-server:main}"
+    environment: *common-env
+    command:
+      - /bin/bash
+      - -c
+      - >-
+        aap-eda-manage runserver 0.0.0.0:8000
+    ports:
+      - '8001:8000'
+    depends_on:
+      eda-api:
+        condition: service_healthy
 
   eda-default-worker:
     user: "${EDA_POD_USER_ID:-0}"


### PR DESCRIPTION
The API service becomes unresponsive when we push a lot of events/rules from multiple running activations

Based on PR https://github.com/ansible/eda-server/pull/495