### PR TITLE
refactor: add container exit code in podman

### DIFF
--- a/src/aap_eda/services/activation/engine/podman.py
+++ b/src/aap_eda/services/activation/engine/podman.py
@@ -202,6 +202,13 @@ class Engine(ContainerEngine):
                     log_handler.flush()
                     log_handler.set_log_read_at(dt)
 
+                if container.status == "exited":
+                    exit_code = container.attrs.get("State").get("ExitCode")
+                    log_handler.write(
+                        f"Container {container_id} exited with {exit_code}.",
+                        True,
+                    )
+
         except APIError as e:
             msg = (
                 "Failed to fetch container logs: "

--- a/tests/integration/services/activation/engine/test_podman.py
+++ b/tests/integration/services/activation/engine/test_podman.py
@@ -31,14 +31,11 @@ from aap_eda.services.activation.engine.common import (
 from aap_eda.services.activation.engine.exceptions import (
     ContainerCleanupError,
     ContainerEngineInitError,
+    ContainerImagePullError,
     ContainerNotFoundError,
     ContainerStartError,
 )
 from aap_eda.services.activation.engine.podman import Engine
-from aap_eda.services.activation.exceptions import (
-    ActivationImageNotFound,
-    ActivationImagePullError,
-)
 
 
 @dataclass
@@ -222,7 +219,7 @@ def test_engine_start_with_image_not_found_exception(init_data, podman_engine):
     engine.client.images.pull.side_effect = raise_error
 
     with pytest.raises(
-        ActivationImageNotFound, match=f"Image {request.image_url} not found"
+        ContainerImagePullError, match=f"Image {request.image_url} not found"
     ):
         engine.start(request, log_handler)
 
@@ -250,7 +247,7 @@ def test_engine_start_with_image_pull_exception(init_data, podman_engine):
     )
 
     with mock.patch.object(engine.client, "images", image_mock):
-        with pytest.raises(ActivationImagePullError, match=msg):
+        with pytest.raises(ContainerImagePullError, match=msg):
             engine.start(request, log_handler)
 
     assert models.ActivationInstanceLog.objects.last().log == msg


### PR DESCRIPTION
Add these logs in activation instance db logs when activation is stopped.
```
......
ACTIVATION BEING STOPPED AT USER REQUEST
......
......
Container 936b3632680df33b257bf0e6077ba72687df970a6e8f0dd6f94c275f233b98ae exited with 143.
Container 936b3632680df33b257bf0e6077ba72687df970a6e8f0dd6f94c275f233b98ae is cleaned up.
```