### PR TITLE
refactor: add default prefix to podman containers

### DIFF
--- a/src/aap_eda/services/activation/manager.py
+++ b/src/aap_eda/services/activation/manager.py
@@ -924,7 +924,10 @@ class ActivationManager:
         return ContainerRequest(
             credential=self._build_credential(),
             cmdline=self._build_cmdline(),
-            name=f"eda-{self.latest_instance.id}-{uuid.uuid4()}",
+            name=(
+                f"{settings.CONTAINER_NAME_PRREFIX}-{self.latest_instance.id}"
+                f"-{uuid.uuid4()}"
+            ),
             image_url=self.db_instance.decision_environment.image_url,
             ports=find_ports(self.db_instance.rulebook_rulesets),
             activation_id=self.db_instance.id,

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -368,6 +368,7 @@ PODMAN_ENV_VARS = settings.get("PODMAN_ENV_VARS", {})
 PODMAN_MOUNTS = settings.get("PODMAN_MOUNTS", [])
 PODMAN_EXTRA_ARGS = settings.get("PODMAN_EXTRA_ARGS", {})
 DEFAULT_PULL_POLICY = settings.get("DEFAULT_PULL_POLICY", "Always")
+CONTAINER_NAME_PRREFIX = settings.get("CONTAINER_NAME_PRREFIX", "eda")
 
 # ---------------------------------------------------------
 # RULEBOOK LIVENESS SETTINGS


### PR DESCRIPTION
Add prefix (default from settings) to the podman containers. The default container name looks like: `eda-3-c48e6107-b531-46e6-b6e4-fbc0f7b2b145`