### PR TITLE
refactor: add timestamp flag in log writer

### DIFF
--- a/src/aap_eda/services/activation/db_log_handler.py
+++ b/src/aap_eda/services/activation/db_log_handler.py
@@ -42,7 +42,9 @@ class DBLogger(LogHandler):
     def lines_written(self) -> int:
         return self.line_number
 
-    def write(self, lines: Union[list[str], str], flush=False) -> None:
+    def write(
+        self, lines: Union[list[str], str], flush=False, timestamp=True
+    ) -> None:
         if self.incremental_flush and self.line_number % self.flush_after == 0:
             self.flush()
 
@@ -50,6 +52,10 @@ class DBLogger(LogHandler):
             lines = [lines]
 
         for line in lines:
+            if timestamp:
+                dt = f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S,%f')[:-3]}"
+                line = f"{dt} {line}"
+
             self.activation_instance_log_buffer.append(
                 models.ActivationInstanceLog(
                     line_number=self.line_number,

--- a/src/aap_eda/services/activation/engine/common.py
+++ b/src/aap_eda/services/activation/engine/common.py
@@ -26,7 +26,9 @@ from aap_eda.core.enums import ActivationStatus
 
 class LogHandler(ABC):
     @abstractmethod
-    def write(self, lines: tp.Union[list[str], str], flush: bool) -> None:
+    def write(
+        self, lines: tp.Union[list[str], str], flush: bool, timestamp: bool
+    ) -> None:
         pass
 
     @abstractmethod

--- a/src/aap_eda/services/activation/engine/kubernetes.py
+++ b/src/aap_eda/services/activation/engine/kubernetes.py
@@ -202,7 +202,9 @@ class Engine(ContainerEngine):
 
                 for line in log.splitlines():
                     timestamp, content = line.split(" ", 1)
-                    log_handler.write(content)
+                    log_handler.write(
+                        lines=content, flush=False, timestamp=False
+                    )
 
                 if timestamp:
                     dt = parser.parse(timestamp)

--- a/src/aap_eda/services/activation/engine/podman.py
+++ b/src/aap_eda/services/activation/engine/podman.py
@@ -192,7 +192,9 @@ class Engine(ContainerEngine):
                     log_parts = log.split(" ", 1)
                     timestamp = log_parts[0]
                     if len(log_parts) > 1:
-                        log_handler.write(log_parts[1])
+                        log_handler.write(
+                            lines=log_parts[1], flush=False, timestamp=False
+                        )
 
                 if timestamp:
                     dt = parser.parse(timestamp)

--- a/src/aap_eda/services/activation/manager.py
+++ b/src/aap_eda/services/activation/manager.py
@@ -925,7 +925,7 @@ class ActivationManager:
             credential=self._build_credential(),
             cmdline=self._build_cmdline(),
             name=(
-                f"{settings.CONTAINER_NAME_PRREFIX}-{self.latest_instance.id}"
+                f"{settings.CONTAINER_NAME_PREFIX}-{self.latest_instance.id}"
                 f"-{uuid.uuid4()}"
             ),
             image_url=self.db_instance.decision_environment.image_url,

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -368,7 +368,7 @@ PODMAN_ENV_VARS = settings.get("PODMAN_ENV_VARS", {})
 PODMAN_MOUNTS = settings.get("PODMAN_MOUNTS", [])
 PODMAN_EXTRA_ARGS = settings.get("PODMAN_EXTRA_ARGS", {})
 DEFAULT_PULL_POLICY = settings.get("DEFAULT_PULL_POLICY", "Always")
-CONTAINER_NAME_PRREFIX = settings.get("CONTAINER_NAME_PRREFIX", "eda")
+CONTAINER_NAME_PREFIX = settings.get("CONTAINER_NAME_PREFIX", "eda")
 
 # ---------------------------------------------------------
 # RULEBOOK LIVENESS SETTINGS

--- a/tests/integration/services/activation/engine/test_podman.py
+++ b/tests/integration/services/activation/engine/test_podman.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import re
 from dataclasses import dataclass
 from unittest import mock
 
@@ -136,9 +135,8 @@ def test_engine_start(init_data, podman_engine):
 
     engine.client.containers.run.assert_called_once()
     assert models.ActivationInstanceLog.objects.count() == 4
-    assert re.match(
-        r"^Container .+ is started",
-        models.ActivationInstanceLog.objects.last().log,
+    assert models.ActivationInstanceLog.objects.last().log.endswith(
+        "is started."
     )
 
 
@@ -223,9 +221,8 @@ def test_engine_start_with_image_not_found_exception(init_data, podman_engine):
     ):
         engine.start(request, log_handler)
 
-    assert (
-        models.ActivationInstanceLog.objects.last().log
-        == f"Image {request.image_url} not found"
+    assert models.ActivationInstanceLog.objects.last().log.endswith(
+        f"Image {request.image_url} not found"
     )
 
 
@@ -250,7 +247,7 @@ def test_engine_start_with_image_pull_exception(init_data, podman_engine):
         with pytest.raises(ContainerImagePullError, match=msg):
             engine.start(request, log_handler)
 
-    assert models.ActivationInstanceLog.objects.last().log == msg
+    assert models.ActivationInstanceLog.objects.last().log.endswith(msg)
 
 
 @pytest.mark.django_db
@@ -276,9 +273,9 @@ def test_engine_start_with_containers_run_exception(init_data, podman_engine):
     with pytest.raises(ContainerStartError, match=r"Container Start Error:"):
         engine.start(request, log_handler)
 
-    assert re.match(
-        r"^Container Start Error:",
-        models.ActivationInstanceLog.objects.last().log,
+    assert (
+        "Container Start Error:"
+        in models.ActivationInstanceLog.objects.last().log
     )
 
 
@@ -328,9 +325,8 @@ def test_engine_cleanup(init_data, podman_engine):
 
     engine.cleanup("100", log_handler)
 
-    assert (
-        models.ActivationInstanceLog.objects.last().log
-        == "Container 100 is cleaned up."
+    assert models.ActivationInstanceLog.objects.last().log.endswith(
+        "Container 100 is cleaned up."
     )
 
 
@@ -348,9 +344,8 @@ def test_engine_cleanup_with_not_found_exception(init_data, podman_engine):
 
     engine.cleanup("100", log_handler)
 
-    assert (
-        models.ActivationInstanceLog.objects.last().log
-        == "Container 100 not found."
+    assert models.ActivationInstanceLog.objects.last().log.endswith(
+        "Container 100 not found."
     )
 
 
@@ -421,7 +416,6 @@ def test_engine_update_logs_with_container_not_found(init_data, podman_engine):
     engine.client.containers.exists.return_value = None
     engine.update_logs("100", log_handler)
 
-    assert (
-        models.ActivationInstanceLog.objects.last().log
-        == "Container 100 not found."
+    assert models.ActivationInstanceLog.objects.last().log.endswith(
+        "Container 100 not found."
     )


### PR DESCRIPTION
Add timestamp choice in log writer. When turn it on, the message logged look like:
```
2023-11-09 21:08:24,244 Pulling image quay.io/ansible/ansible-rulebook:main
2023-11-09 21:08:24,971 Starting Container
2023-11-09 21:08:24,973 Container args ['ansible-rulebook', '--worker', '--websocket-ssl-verify', 'no', '--websocket-address', 'ws://host.containers.internal:8000/api/eda/ws/ansible-rulebook', '--id', '6', '--heartbeat', '300', '-v']
2023-11-09 21:08:25,054 Container 1cd965b5f50853196f12a555f44e0cf599937b48d68482c15e5dc23e479540fe is started.
2023-11-09 21:08:25,325 - ansible_rulebook.app - INFO - Starting worker mode
2023-11-09 21:08:25,325 - ansible_rulebook.websocket - INFO - websocket ws://host.containers.internal:8000/api/eda/ws/ansible-rulebook connecting
```

Also, fix the typo in the env name CONTAINER_NAME_PREFIX.

Resolves: [AAP-18126](https://issues.redhat.com/browse/AAP-18126)