### PR TITLE
[AAP-18000] Restore non_field_errors key in validation errors

### DIFF
--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -355,7 +355,4 @@ def is_activation_valid(activation: models.Activation) -> tuple[bool, str]:
 def parse_validation_errors(errors: dict) -> str:
     messages = {key: str(error[0]) for key, error in errors.items() if error}
 
-    if "non_field_errors" in messages:
-        messages["field_errors"] = messages.pop("non_field_errors")
-
     return str(messages)

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -26,10 +26,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from aap_eda.api import exceptions as api_exc, filters, serializers
-from aap_eda.api.serializers.activation import (
-    is_activation_valid,
-    parse_validation_errors,
-)
+from aap_eda.api.serializers.activation import is_activation_valid
 from aap_eda.core import models
 from aap_eda.core.enums import Action, ActivationStatus, ResourceType
 from aap_eda.tasks.ruleset import activate, deactivate, restart
@@ -79,12 +76,7 @@ class ActivationViewSet(
         serializer = serializers.ActivationCreateSerializer(
             data=request.data, context=context
         )
-        valid = serializer.is_valid()
-        if not valid:
-            error = parse_validation_errors(serializer.errors)
-            return Response(
-                {"errors": error}, status=status.HTTP_400_BAD_REQUEST
-            )
+        serializer.is_valid(raise_exception=True)
 
         response = serializer.create(serializer.validated_data)
 


### PR DESCRIPTION
As discussed with @lgalis, we keep the validation error format as it is, and UI will decide how to display it to the end users.

This is also a follow-up with https://github.com/ansible/eda-server/pull/492.

Resolves: [AAP-18000](https://issues.redhat.com/browse/AAP-18000)