### PR TITLE
chore: fix image of eda-ws pod in docker dev

### DIFF
--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -81,7 +81,7 @@ services:
       - '../../:/app/src:z'
 
   eda-ws:
-    image: "${EDA_IMAGE:-quay.io/ansible/eda-server:main}"
+    image: "${EDA_IMAGE:-localhost/aap-eda}"
     environment: *common-env
     command:
       - /bin/bash


### PR DESCRIPTION
Follow up: https://github.com/ansible/eda-server/pull/495

The service should use by default the local development image. 