### PR TITLE
 chore: increase max-log-requests on task minikube:logs:eda

### DIFF
--- a/scripts/eda_kube.sh
+++ b/scripts/eda_kube.sh
@@ -218,7 +218,7 @@ port-forward-pg() {
 
 get-eda-logs() {
   log-debug "kubectl logs -n ${NAMESPACE} -l app=eda -f"
-  kubectl logs -n "${NAMESPACE}" -l app=eda -f
+  kubectl logs -n "${NAMESPACE}" -l app=eda --max-log-requests=10 -f
 }
 
 #


### PR DESCRIPTION
❯ task minikube:logs:eda
task: [minikube] scripts/eda_kube.sh eda-logs 
Defaulted container "eda-api" out of: eda-api, wait-for-postgres (init)
error: you are attempting to follow 8 log streams, but maximum allowed concurrency is 5, use --max-log-requests to increase the limit
task: Failed to run task "minikube:logs:eda": exit status 1