### PR TITLE
chore: remove unused mixins from Activation

### DIFF
--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -45,13 +45,8 @@ logger = logging.getLogger(__name__)
         },
     ),
 )
-# REVIEW(cutwater): Since this class implements `create` method,
-#   the `CreateModelMixin` is redundant.
 class ActivationViewSet(
-    mixins.CreateModelMixin,
-    mixins.RetrieveModelMixin,
     mixins.DestroyModelMixin,
-    mixins.ListModelMixin,
     viewsets.GenericViewSet,
 ):
     queryset = models.Activation.objects.all()


### PR DESCRIPTION
This PR removes the unused model mixins from Activation since we have manually implemented `create`, `retrieve` and `list` methods on Activation viewset.