### PR TITLE
fix: remove duplicated container log at exit

### DIFF
--- a/src/aap_eda/services/activation/engine/podman.py
+++ b/src/aap_eda/services/activation/engine/podman.py
@@ -251,13 +251,6 @@ class Engine(ContainerEngine):
                 log_handler.flush()
                 log_handler.set_log_read_at(dt)
 
-            if container.status == "exited":
-                exit_code = container.attrs.get("State").get("ExitCode")
-                log_handler.write(
-                    f"Container {container_id} exited with {exit_code}.",
-                    flush=True,
-                )
-
         # ContainerUpdateLogsError handled by the manager
         except APIError as e:
             raise exceptions.ContainerUpdateLogsError(str(e)) from e


### PR DESCRIPTION
update_logs should not log messages about the exit code, we are duplicating this message since the manager by default also prints the message returned by get_status. Also this method could be called multiple times, it should be idempotent to prevent other duplicates. 