### PR TITLE
chore: allow arbitrary envvars in minikube

### DIFF
--- a/tools/deploy/eda-activation-worker/deployment.yaml
+++ b/tools/deploy/eda-activation-worker/deployment.yaml
@@ -34,26 +34,9 @@ spec:
               value: eda-redis
             - name: EDA_DEPLOYMENT_TYPE
               value: k8s
-            - name: EDA_WEBSOCKET_BASE_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: eda-env-properties
-                  key: EDA_WEBSOCKET_BASE_URL
-            - name: EDA_WEBSOCKET_SSL_VERIFY
-              valueFrom:
-                configMapKeyRef:
-                  name: eda-env-properties
-                  key: EDA_WEBSOCKET_SSL_VERIFY
-            - name: EDA_CONTROLLER_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: eda-env-properties
-                  key: EDA_CONTROLLER_URL
-            - name: EDA_CONTROLLER_SSL_VERIFY
-              valueFrom:
-                configMapKeyRef:
-                  name: eda-env-properties
-                  key: EDA_CONTROLLER_SSL_VERIFY
+          envFrom:
+          - configMapRef:
+              name: eda-env-properties
           image: aap-eda
           imagePullPolicy: Never
           name: eda-activation-worker

--- a/tools/deploy/eda-api/deployment.yaml
+++ b/tools/deploy/eda-api/deployment.yaml
@@ -22,7 +22,7 @@ spec:
             - -c
             - >-
               aap-eda-manage migrate
-              && aap-eda-manage create_initial_data 
+              && aap-eda-manage create_initial_data
               && scripts/create_superuser.sh
               && aap-eda-manage runserver 0.0.0.0:8000
           env:
@@ -40,26 +40,9 @@ spec:
               value: "['*']"
             - name: EDA_DEPLOYMENT_TYPE
               value: k8s
-            - name: EDA_WEBSOCKET_BASE_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: eda-env-properties
-                  key: EDA_WEBSOCKET_BASE_URL
-            - name: EDA_WEBSOCKET_SSL_VERIFY
-              valueFrom:
-                configMapKeyRef:
-                  name: eda-env-properties
-                  key: EDA_WEBSOCKET_SSL_VERIFY
-            - name: EDA_CONTROLLER_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: eda-env-properties
-                  key: EDA_CONTROLLER_URL
-            - name: EDA_CONTROLLER_SSL_VERIFY
-              valueFrom:
-                configMapKeyRef:
-                  name: eda-env-properties
-                  key: EDA_CONTROLLER_SSL_VERIFY
+          envFrom:
+          - configMapRef:
+              name: eda-env-properties
           image: aap-eda
           imagePullPolicy: Never
           name: eda-api

--- a/tools/deploy/eda-default-worker/deployment.yaml
+++ b/tools/deploy/eda-default-worker/deployment.yaml
@@ -34,26 +34,9 @@ spec:
               value: eda-redis
             - name: EDA_DEPLOYMENT_TYPE
               value: k8s
-            - name: EDA_WEBSOCKET_BASE_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: eda-env-properties
-                  key: EDA_WEBSOCKET_BASE_URL
-            - name: EDA_WEBSOCKET_SSL_VERIFY
-              valueFrom:
-                configMapKeyRef:
-                  name: eda-env-properties
-                  key: EDA_WEBSOCKET_SSL_VERIFY
-            - name: EDA_CONTROLLER_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: eda-env-properties
-                  key: EDA_CONTROLLER_URL
-            - name: EDA_CONTROLLER_SSL_VERIFY
-              valueFrom:
-                configMapKeyRef:
-                  name: eda-env-properties
-                  key: EDA_CONTROLLER_SSL_VERIFY
+          envFrom:
+          - configMapRef:
+              name: eda-env-properties
           image: aap-eda
           imagePullPolicy: Never
           name: eda-default-worker

--- a/tools/deploy/eda-scheduler/deployment.yaml
+++ b/tools/deploy/eda-scheduler/deployment.yaml
@@ -32,26 +32,9 @@ spec:
               value: secret
             - name: EDA_MQ_HOST
               value: eda-redis
-            - name: EDA_WEBSOCKET_BASE_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: eda-env-properties
-                  key: EDA_WEBSOCKET_BASE_URL
-            - name: EDA_WEBSOCKET_SSL_VERIFY
-              valueFrom:
-                configMapKeyRef:
-                  name: eda-env-properties
-                  key: EDA_WEBSOCKET_SSL_VERIFY
-            - name: EDA_CONTROLLER_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: eda-env-properties
-                  key: EDA_CONTROLLER_URL
-            - name: EDA_CONTROLLER_SSL_VERIFY
-              valueFrom:
-                configMapKeyRef:
-                  name: eda-env-properties
-                  key: EDA_CONTROLLER_SSL_VERIFY
+          envFrom:
+          - configMapRef:
+              name: eda-env-properties
           image: aap-eda
           imagePullPolicy: Never
           name: eda-scheduler


### PR DESCRIPTION
No need to define explicitly the envvars consumed by pods in minikube, since we create a custom config map we can inject it and allow to pass any envvar.  