### PR TITLE
Fix port conflicts when running other Ansible dev environments

### DIFF
--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -69,7 +69,7 @@ services:
         && scripts/create_superuser.sh
         && aap-eda-manage runserver 0.0.0.0:8000
     ports:
-      - '8000:8000'
+      - '8010:8000'
     depends_on:
       redis:
         condition: service_healthy
@@ -166,7 +166,7 @@ services:
       POSTGRESQL_ADMIN_PASSWORD: secret
       POSTGRESQL_DATABASE: eda
     ports:
-      - '5432:5432'
+      - '5433:5432'
     volumes:
       - 'postgres_data:/var/lib/pgsql/data'
     healthcheck:

--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -38,7 +38,7 @@ services:
     command: >-
       podman system service --time=0 tcp://0.0.0.0:8888
     ports:
-      - 8888:8888
+      - "${EDA_PODMAN_PORT:-8888}:8888"
     volumes:
       - 'podman_data:/home/podman/.local/share/containers/storage'
     depends_on:
@@ -49,7 +49,7 @@ services:
     image: "${EDA_UI_IMAGE:-quay.io/ansible/eda-ui:main}"
     environment: *common-env
     ports:
-      - '8443:443'
+      - '${EDA_UI_PORT:-8443}:443'
     depends_on:
       eda-api:
         condition: service_healthy
@@ -69,7 +69,7 @@ services:
         && scripts/create_superuser.sh
         && aap-eda-manage runserver 0.0.0.0:8000
     ports:
-      - '8010:8000'
+      - "${EDA_API_PORT:-8000}:8000"
     depends_on:
       redis:
         condition: service_healthy
@@ -92,7 +92,7 @@ services:
       - >-
         aap-eda-manage runserver 0.0.0.0:8000
     ports:
-      - '8001:8000'
+      - "${EDA_WS_PORT:-8001}:8000"
     depends_on:
       eda-api:
         condition: service_healthy
@@ -166,7 +166,7 @@ services:
       POSTGRESQL_ADMIN_PASSWORD: secret
       POSTGRESQL_DATABASE: eda
     ports:
-      - '5433:5432'
+      - '${EDA_PG_PORT:-5432}:5432'
     volumes:
       - 'postgres_data:/var/lib/pgsql/data'
     healthcheck:
@@ -179,7 +179,7 @@ services:
   redis:
     image: 'quay.io/sclorg/redis-6-c9s:latest'
     ports:
-      - '6379:6379'
+      - '${EDA_REDIS_PORT:-6379}:6379'
     healthcheck:
       test: [ 'CMD', 'redis-cli', 'ping' ]
       interval: 5s

--- a/tools/docker/docker-compose-mac.yml
+++ b/tools/docker/docker-compose-mac.yml
@@ -27,7 +27,7 @@ services:
     image: "${EDA_UI_IMAGE:-quay.io/ansible/eda-ui:main}"
     environment: *common-env
     ports:
-      - '8443:443'
+      - '${EDA_UI_PORT:-8443}:443'
     depends_on:
       eda-api:
         condition: service_healthy
@@ -46,7 +46,7 @@ services:
         && scripts/create_superuser.sh
         && aap-eda-manage runserver 0.0.0.0:8000
     ports:
-      - '8000:8000'
+      - '${EDA_API_PORT:-8000}:8000'
     depends_on:
       redis:
         condition: service_healthy
@@ -69,7 +69,7 @@ services:
       - >-
         aap-eda-manage runserver 0.0.0.0:8000
     ports:
-      - '8001:8000'
+      - '${EDA_WS_PORT:-8001}:8000'
     depends_on:
       eda-api:
         condition: service_healthy
@@ -144,7 +144,7 @@ services:
       POSTGRESQL_ADMIN_PASSWORD: secret
       POSTGRESQL_DATABASE: eda
     ports:
-      - '5432:5432'
+      - '${EDA_PG_PORT:-5432}:5432'
     volumes:
       - 'postgres_data:/var/lib/pgsql/data'
     healthcheck:
@@ -157,7 +157,7 @@ services:
   redis:
     image: 'quay.io/sclorg/redis-6-c9s:latest'
     ports:
-      - '6379:6379'
+      - '${EDA_REDIS_PORT:-6379}:6379'
     healthcheck:
       test: [ 'CMD', 'redis-cli', 'ping' ]
       interval: 5s


### PR DESCRIPTION
Following exposed docker ports conflicts with other AAP services:

- 8000:
  - conflicts with Gateway API
  - configurable by ENV `EDA_API_PORT` (`EDA_API_PORT=8010 go-task docker:up`)
- 5432:
  - conflicts with Gateway Postgres
  - configurable by ENV `EDA_PG_PORT`
- 6379 Redis
  - configurable by ENV `EDA_REDIS_PORT`
- 8001 WS
  - configurable by ENV `EDA_WS_PORT`
- 8443 UI
  - configurable by ENV `EDA_UI_PORT`
- 8888 Podman
  - configurable by ENV `EDA_PODMAN_PORT`
