### PR TITLE
chore: add matrix versions for ci until python 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,12 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
     env:
       EDA_SECRET_KEY: 'test'
       EDA_DB_PASSWORD: 'secret'
@@ -93,7 +99,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "${{ matrix.python-version }}"
           cache: 'poetry'
 
       - name: Install package
@@ -111,6 +117,6 @@ jobs:
           env_vars: OS,PYTHON
           fail_ci_if_error: false
           files: ./coverage.xml
-          flags: "unit-int-tests"
+          flags: "unit-int-tests-${{ matrix.python-version }}"
           name: codecov-umbrella
           verbose: true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+**Maintenance Status**
+
+![Maintained? yes](https://img.shields.io/badge/Maintained%3F-yes-green.svg)
+
+**Codecov**
+
+[![codecov](https://codecov.io/gh/ansible/eda-server/graph/badge.svg?token=N6Z2DZGKGZ)](https://codecov.io/gh/ansible/eda-server)
+
+**GitHub Workflow**
+
+[![GitHub Workflow Status](https://github.com/ansible/eda-server/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ansible/eda-server/actions/workflows/ci.yaml?query=branch%3Amain)
+
+**Version**
+![Python 3.9](https://img.shields.io/badge/Python-3.9-blue)
+![Python 3.10](https://img.shields.io/badge/Python-3.10-blue)
+![Python 3.11](https://img.shields.io/badge/Python-3.11-blue)
+
 # Event Driven Ansible Controller
 
 This repository contains the source code for the Event Driven Ansible Controller, aka EDA-Controller.
@@ -15,7 +32,7 @@ Refer to the [development guide](docs/development.md) for further information if
 ## Contributing
 
 We ask all of our community members and contributors to adhere to the [Ansible code of conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
-If you have questions or need assistance, please reach out to our community team at codeofconduct@ansible.com
+If you have questions or need assistance, please reach out to our community team at <codeofconduct@ansible.com>
 
 Refer to the [Contributing guide](docs/contributing.md) for further information.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2672,5 +2672,5 @@ dev = ["psycopg2-binary"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.9,<4"
-content-hash = "7bbb72cc3351198e69f694b28527ec8452849cde6a736da9cfa40ac476785dfb"
+python-versions = ">=3.9,<3.12"
+content-hash = "08385ce5c76a39f7c55dfc60d1b32957c970d5fb2a7e252c88c9d091f8539be5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ all = ["psycopg2"]
 dev = ["psycopg2-binary"]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<4"
+python = ">=3.9,<3.12"
 django = ">=4.2,<4.3"
 djangorestframework = "*"
 dynaconf = ">=3"


### PR DESCRIPTION
- Run tests for supported versions of python 3.9, 3.10, 3.11
- Pin versions in metadata
- Add nice looking badges. 
jira: https://issues.redhat.com/browse/AAP-13387