### PR TITLE
chore: increase default timeout for git clone project

### DIFF
--- a/src/aap_eda/services/project/git.py
+++ b/src/aap_eda/services/project/git.py
@@ -165,7 +165,7 @@ class GitRepository:
 
 
 class GitExecutor:
-    DEFAULT_TIMEOUT: Final = 30
+    DEFAULT_TIMEOUT: Final = 120
     ENVIRON: dict = {
         "GIT_TERMINAL_PROMPT": "0",
     }

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -187,7 +187,7 @@ def test_git_executor_call(run_mock: mock.Mock):
         },
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        timeout=30,
+        timeout=120,
         cwd=None,
     )
 


### PR DESCRIPTION
We have received several reports of timeouts occurring with large projects. Until we implement a feature allowing for a configurable timeout, we will increase the default hardcoded value to a more reasonable level.
Jira: https://issues.redhat.com/browse/AAP-19052