### PR TITLE
[AAP-19019] Fan-out: Add endpoint to list sources from rulebook

### DIFF
--- a/src/aap_eda/api/serializers/__init__.py
+++ b/src/aap_eda/api/serializers/__init__.py
@@ -61,6 +61,7 @@ from .rulebook import (
     RulesetOutSerializer,
     RulesetSerializer,
 )
+from .source import SourceSerializer
 from .tasks import TaskRefSerializer, TaskSerializer
 from .user import (
     AwxTokenCreateSerializer,
@@ -122,4 +123,6 @@ __all__ = (
     "RoleSerializer",
     "RoleListSerializer",
     "RoleDetailSerializer",
+    # sources
+    "SourceSerializer",
 )

--- a/src/aap_eda/api/serializers/source.py
+++ b/src/aap_eda/api/serializers/source.py
@@ -1,0 +1,32 @@
+#  Copyright 2023 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from rest_framework import serializers
+
+
+class SourceSerializer(serializers.Serializer):
+    type = serializers.CharField(
+        required=True,
+        help_text="Type of the source",
+    )
+
+    name = serializers.CharField(
+        required=True,
+        help_text="Name of the source",
+    )
+
+    args = serializers.JSONField(
+        required=True,
+        help_text="The arguments for the source",
+    )

--- a/src/aap_eda/services/rulebook.py
+++ b/src/aap_eda/services/rulebook.py
@@ -14,6 +14,43 @@
 
 from aap_eda.core import models
 
+DEFAULT_SOURCE_NAME_PREFIX = "EDA_AUTO_SOURCE_"
+
+
+def build_source_list(rulesets: list[dict]) -> list[dict]:
+    results = []
+    if rulesets is None:
+        return results
+
+    i = 1
+    for ruleset in rulesets:
+        duplicate_names = {}
+        srcs = ruleset.get("sources", [])
+        for src in srcs:
+            src_record = {}
+            src_record["name"] = f"{DEFAULT_SOURCE_NAME_PREFIX}{i}"
+            for src_key, src_val in src.items():
+                if src_key == "name":
+                    if src_val in duplicate_names.keys():
+                        duplicate_names[src_val] += 1
+                        src_record[
+                            "name"
+                        ] = f"{src_val} #{duplicate_names[src_val]}"
+                    else:
+                        src_record["name"] = src_val
+
+                if src_key not in ["name", "filters"]:
+                    src_record["type"] = src_key
+                    src_record["args"] = src_val or {}
+
+            if src_record not in results:
+                results.append(src_record)
+                i += 1
+
+                duplicate_names[src_record["name"]] = 1
+
+    return results
+
 
 def expand_ruleset_sources(rulebook_data: dict) -> dict:
     # TODO(cutwater): Docstring needed

--- a/tests/integration/api/test_rulebook.py
+++ b/tests/integration/api/test_rulebook.py
@@ -21,6 +21,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from aap_eda.core import models
+from aap_eda.services.rulebook import DEFAULT_SOURCE_NAME_PREFIX
 from tests.integration.constants import api_url_v1
 
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
@@ -194,6 +195,23 @@ def test_list_rulesets_from_rulebook(client: APIClient, init_db):
         "rule_count",
         "fired_stats",
     ]
+
+
+@pytest.mark.django_db
+def test_list_sources_from_rulebook(client: APIClient, init_db):
+    rulebook_id = init_db.rulebook.id
+
+    response = client.get(f"{api_url_v1}/rulebooks/{rulebook_id}/sources/")
+    assert response.status_code == status.HTTP_200_OK
+
+    sources = response.data["results"]
+    assert len(sources) == 2
+    assert sources[0]["name"] == f"{DEFAULT_SOURCE_NAME_PREFIX}1"
+    assert sources[0]["type"] == "ansible.eda.range"
+    assert sources[0]["args"] == {"limit": 5, "delay": 1}
+    assert sources[1]["name"] == f"{DEFAULT_SOURCE_NAME_PREFIX}2"
+    assert sources[1]["type"] == "ansible.eda.range"
+    assert sources[1]["args"] == {"limit": 5, "delay": 1}
 
 
 def assert_rulebook_data(data: Dict[str, Any], rulebook: models.Rulebook):

--- a/tests/integration/services/test_rulebook.py
+++ b/tests/integration/services/test_rulebook.py
@@ -1,0 +1,294 @@
+#  Copyright 2023 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import yaml
+
+from aap_eda.services.rulebook import (
+    DEFAULT_SOURCE_NAME_PREFIX,
+    build_source_list,
+)
+
+
+def test_single_source_with_full_parameters():
+    single_source = """
+---
+- name: Test sample 001
+  hosts: all
+  sources:
+      - name: my source
+        ansible.eda.range:
+          limit: 5
+          delay: 1
+        filters:
+          - noop:
+""".strip()
+
+    sources = yaml.safe_load(single_source)
+    results = build_source_list(sources)
+
+    assert len(results) == 1
+    assert results[0]["name"] == "my source"
+    assert results[0]["type"] == "ansible.eda.range"
+    assert results[0]["args"] == {"limit": 5, "delay": 1}
+    assert results[0].keys() == {"name", "type", "args"}
+
+
+def test_single_source_1():
+    single_source = """
+---
+- name: Test sample 001
+  hosts: all
+  sources:
+    - ansible.eda.generic:
+        event_delay: 1
+        payload:
+          - user: "Rick"
+            universe: C-137
+            hosts:
+              - eda_localhost2
+
+          - user: "Morty"
+            universe: C-137
+
+          - user: "Rick"
+            universe: C-132
+
+          - user: "Rick"
+            universe: J-19-Zeta-1
+
+          - user: "Beth"
+            universe: K-22
+
+          - user: "Jerry"
+            universe: C-137
+""".strip()
+    sources = yaml.safe_load(single_source)
+    results = build_source_list(sources)
+
+    assert len(results) == 1
+    assert results[0]["name"] == f"{DEFAULT_SOURCE_NAME_PREFIX}1"
+    assert results[0]["type"] == "ansible.eda.generic"
+    assert results[0]["args"].keys() == {"event_delay", "payload"}
+    assert results[0].keys() == {"name", "type", "args"}
+
+
+def test_single_source_without_name():
+    single_source = """
+---
+- name: Test sample 001
+  hosts: all
+  sources:
+    - ansible.eda.range:
+        limit: 5
+        delay: 1
+      filters:
+        - noop:
+""".strip()
+
+    sources = yaml.safe_load(single_source)
+    results = build_source_list(sources)
+
+    assert len(results) == 1
+    assert results[0]["name"] == f"{DEFAULT_SOURCE_NAME_PREFIX}1"
+    assert results[0]["type"] == "ansible.eda.range"
+    assert results[0]["args"] == {"limit": 5, "delay": 1}
+    assert results[0].keys() == {"name", "type", "args"}
+
+
+def test_multiple_sources():
+    sources = """
+---
+- name: Test sample 001
+  hosts: all
+  sources:
+    - name: my source
+      ansible.eda.range:
+        limit: 5
+        delay: 1
+      filters:
+        - noop:
+    - name: my 2nd source
+      ansible.eda.generic:
+        event_delay: 1
+        payload:
+          - user: "Rick"
+            universe: C-137
+""".strip()
+
+    sources = yaml.safe_load(sources)
+    results = build_source_list(sources)
+
+    assert len(results) == 2
+    assert results[0]["name"] == "my source"
+    assert results[0]["type"] == "ansible.eda.range"
+    assert results[0]["args"] == {"limit": 5, "delay": 1}
+    assert results[1]["name"] == "my 2nd source"
+    assert results[1]["type"] == "ansible.eda.generic"
+    assert results[1]["args"] == {
+        "event_delay": 1,
+        "payload": [{"universe": "C-137", "user": "Rick"}],
+    }
+
+
+def test_multiple_sources_without_names():
+    sources = """
+---
+- name: Test sample 001
+  hosts: all
+  sources:
+    - ansible.eda.range:
+        limit: 5
+        delay: 1
+      filters:
+        - noop:
+    - ansible.eda.range:
+        limit: 6
+        delay: 2
+      filters:
+        - noop:
+""".strip()
+
+    sources = yaml.safe_load(sources)
+    results = build_source_list(sources)
+
+    assert len(results) == 2
+    assert results[0]["name"] == f"{DEFAULT_SOURCE_NAME_PREFIX}1"
+    assert results[1]["name"] == f"{DEFAULT_SOURCE_NAME_PREFIX}2"
+
+
+def test_duplicate_sources():
+    sources = """
+---
+- name: Test sample 001
+  hosts: all
+  sources:
+    - name: my source
+      ansible.eda.range:
+        limit: 5
+        delay: 1
+      filters:
+        - noop:
+    - name: my source
+      ansible.eda.range:
+        limit: 5
+        delay: 1
+      filters:
+        - noop:
+""".strip()
+
+    sources = yaml.safe_load(sources)
+    results = build_source_list(sources)
+
+    assert len(results) == 2
+    assert results[0]["name"] == "my source"
+    assert results[1]["name"] == "my source #2"
+
+
+def test_duplicate_sources_with_different_names():
+    sources = """
+---
+- name: Test sample 001
+  hosts: all
+  sources:
+    - ansible.eda.range:
+        limit: 5
+        delay: 1
+      filters:
+        - noop:
+    - name: my source
+      ansible.eda.range:
+        limit: 5
+        delay: 1
+      filters:
+        - noop:
+""".strip()
+
+    sources = yaml.safe_load(sources)
+    results = build_source_list(sources)
+
+    assert len(results) == 2
+    assert results[0]["name"] == f"{DEFAULT_SOURCE_NAME_PREFIX}1"
+    assert results[1]["name"] == "my source"
+
+
+def test_multple_rulesets():
+    sources = """
+---
+- name: Test sample 001
+  hosts: all
+  sources:
+    - name: my source
+      ansible.eda.range:
+        limit: 5
+        delay: 1
+      filters:
+        - noop:
+- name: Run a webhook listener service
+  hosts: all
+  sources:
+    - ansible.eda.webhook:
+  rules:
+    - name: Webhook event
+      condition: event.payload.ping == "pong"
+      action:
+        debug:
+          msg: "Webhook triggered!"
+
+    - name: Shutdown
+      condition: event.payload.shutdown is defined
+      action:
+        shutdown:
+""".strip()
+
+    sources = yaml.safe_load(sources)
+    results = build_source_list(sources)
+
+    assert len(results) == 2
+    assert results[0]["name"] == "my source"
+    assert results[0]["type"] == "ansible.eda.range"
+    assert results[0]["args"] == {"limit": 5, "delay": 1}
+    assert results[1]["name"] == f"{DEFAULT_SOURCE_NAME_PREFIX}2"
+    assert results[1]["type"] == "ansible.eda.webhook"
+    assert results[1]["args"] == {}
+
+
+def test_multple_rulesets_with_duplicate_sources():
+    sources = """
+---
+- name: Test sample 001
+  hosts: all
+  sources:
+    - name: my source
+      ansible.eda.range:
+        limit: 5
+        delay: 1
+      filters:
+        - noop:
+- name: Test sample 002
+  hosts: all
+  sources:
+    - name: my source
+      ansible.eda.range:
+        limit: 5
+        delay: 1
+      filters:
+        - noop:
+""".strip()
+
+    sources = yaml.safe_load(sources)
+    results = build_source_list(sources)
+
+    assert len(results) == 1
+    assert results[0]["name"] == "my source"
+    assert results[0]["type"] == "ansible.eda.range"
+    assert results[0]["args"] == {"limit": 5, "delay": 1}


### PR DESCRIPTION
Add the endpoint `api/eda/v1/rulebooks/{id}/sources/` to list the sources defined in the rulebook.

Resolves: [AAP-19019](https://issues.redhat.com/browse/AAP-19019)