### PR TITLE
fix: handle all potential states from podman

### DIFF
--- a/src/aap_eda/services/activation/engine/messages.py
+++ b/src/aap_eda/services/activation/engine/messages.py
@@ -7,9 +7,9 @@ IMAGE_PULL_ERROR = (
 )
 
 POD_COMPLETED = "Pod {pod_id} has successfully exited."
-POD_ERROR = "Pod {pod_id} status is unknown."
+POD_UNEXPECTED = "Pod {pod_id} is in an unexpected state: {pod_state}."
 POD_RUNNING = "Pod {pod_id} is running."
 POD_STOPPED = "Pod {pod_id} is stopped."
 POD_GENERIC_FAIL = "Pod {pod_id} exited with code {exit_code}."
 POD_NOT_RUNNING = "Pod {pod_id} is not running."
-POD_PAUSED = "Pod {pod_id} is paused."
+POD_WRONG_STATE = "Pod {pod_id} is in a wrong state: {pod_state}."


### PR DESCRIPTION
We are not handling all the possible states returned by podman. An existing container transitions to "stopping/stopped" status before being "exited".

Ensure we handle all the potential states from podman. 

Fixes https://issues.redhat.com/browse/AAP-19142