### PR TITLE
chore: update django-ansible-base dependency installation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -600,22 +600,25 @@ develop = false
 [package.dependencies]
 cryptography = "*"
 Django = ">=4.2.5,<4.3.0"
-django-auth-ldap = "*"
+django-auth-ldap = {version = "*", optional = true, markers = "extra == \"authentication\""}
 django-crum = "*"
-django-filter = "*"
 djangorestframework = "*"
-drf-spectacular = "*"
 inflection = "*"
-python-ldap = "*"
-python3-saml = "*"
-social-auth-app-django = "*"
-tabulate = "*"
+python-ldap = {version = "*", optional = true, markers = "extra == \"authentication\""}
+python3-saml = {version = "*", optional = true, markers = "extra == \"authentication\""}
+social-auth-app-django = {version = "*", optional = true, markers = "extra == \"authentication\""}
+tabulate = {version = "*", optional = true, markers = "extra == \"authentication\""}
+
+[package.extras]
+all = ["django-auth-ldap", "drf-spectacular", "python-ldap", "python3-saml", "social-auth-app-django", "tabulate"]
+authentication = ["django-auth-ldap", "python-ldap", "python3-saml", "social-auth-app-django", "tabulate"]
+swagger = ["drf-spectacular"]
 
 [package.source]
 type = "git"
 url = "https://github.com/ansible/django-ansible-base.git"
-reference = "HEAD"
-resolved_reference = "aa83898bcee29b24405cfd19ec714611a8ff32ab"
+reference = "devel"
+resolved_reference = "83c75f17b468cfb4949a52ccdef54cab266c9018"
 
 [[package]]
 name = "django-auth-ldap"
@@ -2673,4 +2676,4 @@ dev = ["psycopg2-binary"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "08385ce5c76a39f7c55dfc60d1b32957c970d5fb2a7e252c88c9d091f8539be5"
+content-hash = "91c3d85f08e5ffdd3153ef54b642c7b0c6be0e48aacd4a4f7403d657ccfc152a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ rq-scheduler = "^0.10"
 # Experimental LDAP Integration https://issues.redhat.com/browse/AAP-16938
 # We are temporarily updating it to use latest from devel branch to keep consistency accross
 # other AAP components
-django-ansible-base = { git = "https://github.com/ansible/django-ansible-base.git" }
+django-ansible-base = { git = "https://github.com/ansible/django-ansible-base.git", branch="devel", extras=["authentication"] }
 jinja2 = "*"
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
Following the PR https://github.com/ansible/django-ansible-base/pull/55, we are now able to install DAB-related packages based on each feature (authentication, filtering, etc.). This PR changes DAB installation to reflect those changes. 

NOTE: If we want to use other features such as `filtering` from DAB in the future, we will need update pyproject.toml to include those features in extras.