### PR TITLE
fix: ensure types for podman mounts and rulebookcmdline

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,3 +13,6 @@ per-file-ignores =
     src/aap_eda/core/migrations/*:E501
     # Ignore docstring errors in tests.
     tests/*:D
+classmethod-decorators =
+    classmethod
+    validator

--- a/src/aap_eda/services/activation/engine/common.py
+++ b/src/aap_eda/services/activation/engine/common.py
@@ -18,7 +18,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 
 from django.conf import settings
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 import aap_eda.services.activation.engine.exceptions as exceptions
 from aap_eda.core.enums import ActivationStatus
@@ -51,8 +51,12 @@ class AnsibleRulebookCmdLine(BaseModel):
     ws_url: str
     ws_ssl_verify: str
     heartbeat: int
-    id: str
+    id: tp.Union[str, int]  # casted to str
     log_level: tp.Optional[str] = None  # -v or -vv or None
+
+    @validator("id", pre=True)
+    def cast_to_str(cls, v):
+        return str(v)
 
     def command(self) -> str:
         return "ansible-rulebook"
@@ -95,7 +99,7 @@ class ContainerRequest(BaseModel):
     ports: tp.Optional[list[tuple]] = None
     pull_policy: str = settings.DEFAULT_PULL_POLICY  # Always by default
     mem_limit: tp.Optional[str] = None
-    mounts: tp.Optional[dict] = None
+    mounts: tp.Optional[list[dict]] = None
     env_vars: tp.Optional[dict] = None
     extra_args: tp.Optional[dict] = None
 

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -56,6 +56,18 @@ Redis queue settings:
 * MQ_HOST - Redis queue hostname (default: "127.0.0.1")
 * MQ_PORT - Redis queue port (default: 6379)
 * MQ_DB - Redis queue database (default: 0)
+
+
+Podman settings:
+PODMAN_MOUNTS - A list of dicts with mount options. Each dict must contain
+    the following keys: source, target, type.
+    Look at https://docs.podman.io/en/v4.4/markdown/options/mount.html
+    for more information.
+    Example:
+      export PODMAN_MOUNTS='@json [{"source": "/var/run/containers/storage",
+                             "target": "/var/run/containers/storage",
+                             "type": "bind"}]'
+
 """
 import dynaconf
 from django.core.exceptions import ImproperlyConfigured
@@ -378,7 +390,7 @@ WEBSOCKET_SSL_VERIFY = settings.get("WEBSOCKET_SSL_VERIFY", "yes")
 PODMAN_SOCKET_URL = settings.get("PODMAN_SOCKET_URL", None)
 PODMAN_MEM_LIMIT = settings.get("PODMAN_MEM_LIMIT", "200m")
 PODMAN_ENV_VARS = settings.get("PODMAN_ENV_VARS", {})
-PODMAN_MOUNTS = settings.get("PODMAN_MOUNTS", [])
+PODMAN_MOUNTS = settings.get("PODMAN_MOUNTS", [{}])
 PODMAN_EXTRA_ARGS = settings.get("PODMAN_EXTRA_ARGS", {})
 DEFAULT_PULL_POLICY = settings.get("DEFAULT_PULL_POLICY", "Always")
 CONTAINER_NAME_PREFIX = settings.get("CONTAINER_NAME_PREFIX", "eda")

--- a/tests/integration/services/activation/engine/test_kubernetes.py
+++ b/tests/integration/services/activation/engine/test_kubernetes.py
@@ -98,7 +98,6 @@ def get_request(data: InitData):
         credential=Credential(username="admin", secret="secret"),
         ports=[("localhost", 8080)],
         mem_limit="8G",
-        mounts={"/dev": "/opt"},
         env_vars={"a": 1},
         extra_args={"b": 2},
     )

--- a/tests/integration/services/activation/engine/test_podman.py
+++ b/tests/integration/services/activation/engine/test_podman.py
@@ -95,7 +95,7 @@ def get_request(data: InitData):
         cmdline=get_ansible_rulebook_cmdline(data),
         ports=[("localhost", 8080)],
         mem_limit="8G",
-        mounts={"/dev": "/opt"},
+        mounts=[{"/dev": "/opt"}],
         env_vars={"a": 1},
         extra_args={"b": 2},
     )
@@ -243,7 +243,7 @@ def test_engine_start_with_credential(init_data, podman_engine):
         name=request.name,
         ports={"8080/tcp": 8080},
         mem_limit="8G",
-        mounts={"/dev": "/opt"},
+        mounts=request.mounts,
         environment={"a": 1},
         b=2,
     )


### PR DESCRIPTION
Fix the type of podman mounts to avoid errors like:
```
aap_eda.tasks.orchestrator ERROR    [...] Reason Activation 20 failed to start. Reason: Container request is not valid.Errors: [{'loc': ('mounts',), 'msg': 'value is not a valid dict', 'type': 'type_error.dict'}]
```
Also ensures the id of the rulebookcmdline is always str. 

Update internal docs of settings accordingly.

Jira: https://issues.redhat.com/browse/AAP-19513