### PR TITLE
fix: tests respect setting of XDG_RUNTIME_DIR

### DIFF
--- a/tests/integration/services/activation/engine/test_podman.py
+++ b/tests/integration/services/activation/engine/test_podman.py
@@ -151,9 +151,15 @@ def test_get_podman_client(settings):
         assert client.api.base_url.netloc == "%2Frun%2Fpodman%2Fpodman.sock"
 
     client = get_podman_client()
+    xdg_runtime_dir = os.getenv(
+        "XDG_RUNTIME_DIR", f"%2Frun%2Fuser%2F{os.getuid()}"
+    )
+    # Replace any '/'s from XDG_RUNTIME_DIR.
+    xdg_runtime_dir = xdg_runtime_dir.replace("/", "%2F")
+
     assert (
         client.api.base_url.netloc
-        == f"%2Frun%2Fuser%2F{os.getuid()}%2Fpodman%2Fpodman.sock"
+        == f"{xdg_runtime_dir}%2Fpodman%2Fpodman.sock"
     )
 
 
@@ -589,9 +595,11 @@ def test_set_auth_json(podman_engine):
     with mock.patch("os.path.dirname"):
         engine._set_auth_json_file()
 
-        assert (
-            engine.auth_file == f"/run/user/{os.getuid()}/containers/auth.json"
+        xdg_runtime_dir = os.getenv(
+            "XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}"
         )
+
+        assert engine.auth_file == f"{xdg_runtime_dir}/containers/auth.json"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
services/activation/podman.py uses XDG_RUNTIME_DIR; the tests need to as well in order to pass with it set.