### PR TITLE
feat: honor http_proxy envvar for git command

### DIFF
--- a/src/aap_eda/services/project/git.py
+++ b/src/aap_eda/services/project/git.py
@@ -184,6 +184,8 @@ class GitExecutor:
         if timeout is None:
             timeout = self.DEFAULT_TIMEOUT
 
+        self._set_http_proxy()
+
         try:
             return subprocess.run(
                 [GIT_COMMAND, *args],
@@ -210,3 +212,15 @@ class GitExecutor:
             if e.stderr:
                 usr_msg += f" Error: {e.stderr}"
             raise GitError(usr_msg) from None
+
+    def _set_http_proxy(self) -> None:
+        """Set http proxy from environment variables."""
+        supported_env = (
+            "http_proxy",
+            "https_proxy",
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+        )
+        for env in supported_env:
+            if env in os.environ:
+                self.ENVIRON[env] = os.environ[env]

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -19,6 +19,7 @@ import typing as tp
 from unittest import mock
 
 import pytest
+
 from aap_eda.core.models import Credential
 from aap_eda.services.project.git import (
     GitAuthenticationError,

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -267,4 +267,4 @@ def test_set_http_proxy(update_environment, envvar: str):
     with mock.patch("subprocess.run"):
         executor(["clone", "https://git.example.com/repo.git", "/test/repo"])
 
-    assert executor.ENVIRON["http_proxy"] == test_proxy
+    assert executor.ENVIRON[envvar] == test_proxy


### PR DESCRIPTION
A quick workaround to support http_proxies at system level until decide/implement a more robust solution for the RFE: https://issues.redhat.com/browse/AAPRFE-835
