### PR TITLE
chore: bump minimal python version to 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ 'main' ]
   pull_request:
-    branches: [ 'main' ]
+    branches: [ 'main', 'devel' ]
   merge_group:
     branches: [ 'main' ]
 
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.11'
           cache: 'poetry'
 
       - name: Install dependencies
@@ -52,8 +52,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
-          - "3.10"
           - "3.11"
     env:
       EDA_SECRET_KEY: 'test'

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 [![GitHub Workflow Status](https://github.com/ansible/eda-server/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/ansible/eda-server/actions/workflows/ci.yaml?query=branch%3Amain)
 
-![Python 3.9](https://img.shields.io/badge/Python-3.9-blue)
-![Python 3.10](https://img.shields.io/badge/Python-3.10-blue)
 ![Python 3.11](https://img.shields.io/badge/Python-3.11-blue)
 
 # Event Driven Ansible Controller

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,11 +27,11 @@ If you are proposing a feature:
 Before you submit a pull request, check that it meets these guidelines:
 
 1. The pull request should include tests.
-2. The pull request should work for Python 3.9
+2. The pull request should work for Python 3.11
 3. The pull request should pass all tests, linters and CI checks. You can run
    each of these locally in your [development environment](docs/development.md)
 
 ## Contact
 
 Also you can check the [Matrix chat](https://matrix.to/#/#eda:ansible.com), or via the
-event-driven-automation@redhat.com email.
+<event-driven-automation@redhat.com> email.

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,7 +11,7 @@
 
 For running services locally:
 
-* Python >= 3.9
+* Python >= 3.11
 
 For standalone development tools written in Python, such as `pre-commit`,
 we recommend using your system package manager,
@@ -86,7 +86,7 @@ systemctl --user enable --now podman.socket
 On Linux and macOS, Poetry can be installed with the official installer:
 
 ```shell
-curl -sSL https://install.python-poetry.org | python3 -
+curl -sSL https://install.python-poetry.org | python3.11 -
 ```
 
 Alternatively, you can install it with manually with `pip` or `pipx`:
@@ -157,7 +157,7 @@ git clone git@github.com:ansible/eda-server.git
 
 ### Install dependencies
 
-**NOTE**: Since we added experimental [LDAP authentication](https://github.com/ansible/eda-server/pull/557), the following additional packages are required: `openldap-devel xmlsec1-devel libtool-ltdl-devel`. 
+**NOTE**: Since we added experimental [LDAP authentication](https://github.com/ansible/eda-server/pull/557), the following additional packages are required: `openldap-devel xmlsec1-devel libtool-ltdl-devel`.
 
 Go to your project directory and install dependencies for local development:
 
@@ -188,6 +188,7 @@ $ docker images
 REPOSITORY                                    TAG         IMAGE ID       CREATED        SIZE
 localhost/aap-eda                             latest      28fd94c8cf89   5 hours ago    611MB
 ```
+
 To override image name:(using short git hash for version here)
 
 ```shell
@@ -255,6 +256,7 @@ task docker:migrate
 ### Seeding the database
 
 Locally:
+
 ```shell
 task manage -- create_initial_data
 ```
@@ -314,8 +316,8 @@ task test -- tests/integration/api/test_activation.py::test_retrieve_activation
 
 With docker compose:
 
-```shell 
-task docker -- run api --rm python -m pytest  
+```shell
+task docker -- run api --rm python3.11 -m pytest  
 ```
 
 ### Running linters

--- a/poetry.lock
+++ b/poetry.lock
@@ -158,8 +158,6 @@ mypy-extensions = ">=0.4.3"
 packaging = ">=22.0"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
@@ -466,9 +464,6 @@ files = [
     {file = "coverage-7.3.0.tar.gz", hash = "sha256:49dbb19cdcafc130f597d9e04a29d0a032ceedf729e41b181f51cd170e6ee865"},
 ]
 
-[package.dependencies]
-tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
-
 [package.extras]
 toml = ["tomli"]
 
@@ -610,15 +605,16 @@ social-auth-app-django = {version = "*", optional = true, markers = "extra == \"
 tabulate = {version = "*", optional = true, markers = "extra == \"authentication\""}
 
 [package.extras]
-all = ["django-auth-ldap", "drf-spectacular", "python-ldap", "python3-saml", "social-auth-app-django", "tabulate"]
+all = ["channels", "django-auth-ldap", "drf-spectacular", "python-ldap", "python3-saml", "social-auth-app-django", "tabulate"]
 authentication = ["django-auth-ldap", "python-ldap", "python3-saml", "social-auth-app-django", "tabulate"]
+channel-auth = ["channels"]
 swagger = ["drf-spectacular"]
 
 [package.source]
 type = "git"
 url = "https://github.com/ansible/django-ansible-base.git"
-reference = "devel"
-resolved_reference = "83c75f17b468cfb4949a52ccdef54cab266c9018"
+reference = "96072a16629e7d714a46b181d5fc3a7d314a6215"
+resolved_reference = "96072a16629e7d714a46b181d5fc3a7d314a6215"
 
 [[package]]
 name = "django-auth-ldap"
@@ -752,20 +748,6 @@ files = [
     {file = "eradicate-2.2.0-py3-none-any.whl", hash = "sha256:751813c315a48ce7e3d0483410991015342d380a956e86e0265c61bfb875bcbc"},
     {file = "eradicate-2.2.0.tar.gz", hash = "sha256:c329a05def6a4b558dab58bb1b694f5209706b7c99ba174d226dfdb69a5ba0da"},
 ]
-
-[[package]]
-name = "exceptiongroup"
-version = "1.1.1"
-description = "Backport of PEP 654 (exception groups)"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "exceptiongroup-1.1.1-py3-none-any.whl", hash = "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e"},
-    {file = "exceptiongroup-1.1.1.tar.gz", hash = "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"},
-]
-
-[package.extras]
-test = ["pytest (>=6)"]
 
 [[package]]
 name = "executing"
@@ -1019,7 +1001,6 @@ files = [
 appnope = {version = "*", markers = "sys_platform == \"darwin\""}
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 decorator = "*"
-exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
 jedi = ">=0.16"
 matplotlib-inline = "*"
 pexpect = {version = ">4.3", markers = "sys_platform != \"win32\""}
@@ -1027,7 +1008,6 @@ prompt-toolkit = ">=3.0.30,<3.0.37 || >3.0.37,<3.1.0"
 pygments = ">=2.4.0"
 stack-data = "*"
 traitlets = ">=5"
-typing-extensions = {version = "*", markers = "python_version < \"3.10\""}
 
 [package.extras]
 all = ["black", "curio", "docrepr", "exceptiongroup", "ipykernel", "ipyparallel", "ipywidgets", "matplotlib", "matplotlib (!=3.2.0)", "nbconvert", "nbformat", "notebook", "numpy (>=1.22)", "pandas", "pickleshare", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio (<0.22)", "qtconsole", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "trio", "typing-extensions"]
@@ -1505,7 +1485,6 @@ files = [
 [package.dependencies]
 pyxdg = ">=0.26"
 requests = ">=2.24"
-tomli = {version = ">=1.2.3", markers = "python_version < \"3.11\""}
 urllib3 = ">=1.26.5"
 
 [[package]]
@@ -1903,11 +1882,9 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
@@ -2414,17 +2391,6 @@ files = [
 widechars = ["wcwidth"]
 
 [[package]]
-name = "tomli"
-version = "2.0.1"
-description = "A lil' TOML parser"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
-]
-
-[[package]]
 name = "traitlets"
 version = "5.13.0"
 description = "Traitlets Python configuration system"
@@ -2675,5 +2641,5 @@ dev = ["psycopg2-binary"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.9,<3.12"
-content-hash = "91c3d85f08e5ffdd3153ef54b642c7b0c6be0e48aacd4a4f7403d657ccfc152a"
+python-versions = ">=3.11,<3.12"
+content-hash = "0203f5780e177db7cddbeef4b2032541549a6ac5be862476e7d385ac9f540b89"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ all = ["psycopg2"]
 dev = ["psycopg2-binary"]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.12"
+python = ">=3.11,<3.12"
 django = ">=4.2,<4.3"
 djangorestframework = "*"
 dynaconf = ">=3"
@@ -44,7 +44,9 @@ rq-scheduler = "^0.10"
 # Experimental LDAP Integration https://issues.redhat.com/browse/AAP-16938
 # We are temporarily updating it to use latest from devel branch to keep consistency accross
 # other AAP components
-django-ansible-base = { git = "https://github.com/ansible/django-ansible-base.git", branch="devel", extras=["authentication"] }
+django-ansible-base = { git = "https://github.com/ansible/django-ansible-base.git", rev = "96072a16629e7d714a46b181d5fc3a7d314a6215", extras = [
+    "authentication",
+] }
 jinja2 = "*"
 
 [tool.poetry.group.test.dependencies]

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -7,9 +7,9 @@ RUN useradd --uid "$USER_ID" --gid 0 --home-dir /app --create-home eda \
     && chmod 0775 /app /var/lib/eda
 
 RUN DNF=dnf \
-    INSTALL_PACKAGES="python3 \
-    python3-devel \
-    python3-pip \
+    INSTALL_PACKAGES="python3.11 \
+    python3.11-devel \
+    python3.11-pip \
     libpq-devel \
     gcc \
     gettext \
@@ -24,7 +24,7 @@ RUN DNF=dnf \
     && rm -rf /var/cache/dnf
 
 USER "$USER_ID"
-ENV POETRY_VERSION='1.4.0' \
+ENV POETRY_VERSION='1.7.1' \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
@@ -32,11 +32,12 @@ ENV POETRY_VERSION='1.4.0' \
     POETRY_NO_INTERACTION=1 \
     VIRTUAL_ENV=/app/venv \
     SOURCES_DIR=/app/src \
-    PATH="/app/.local/bin:$PATH"
+    PATH="/app/.local/bin:$PATH" \
+    PYTHON_BIN="python3.11"
 
 # Install poetry, create virtual environment
-RUN python3 -m pip install --user "poetry==${POETRY_VERSION}" \
-    && python3 -m venv "$VIRTUAL_ENV" \
+RUN ${PYTHON_BIN} -m pip install --user "poetry==${POETRY_VERSION}" \
+    && ${PYTHON_BIN} -m venv "$VIRTUAL_ENV" \
     && poetry config virtualenvs.create false
 
 WORKDIR $SOURCES_DIR
@@ -44,7 +45,7 @@ WORKDIR $SOURCES_DIR
 ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 COPY pyproject.toml poetry.lock $SOURCES_DIR/
 RUN poetry install -E all --no-root --no-cache \
-    && python3 -m pip install gunicorn
+    && ${PYTHON_BIN} -m pip install gunicorn
 COPY . $SOURCES_DIR/
 RUN poetry install -E all --only-root
 


### PR DESCRIPTION
Make python3.11 the minimal supported version of python, required for incoming features and dependencies. 
Jira: https://issues.redhat.com/browse/AAP-19615