### PR TITLE
ci: set GH token when running scheduled tests

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -59,6 +59,7 @@ jobs:
         env:
           EDAQA_FERNET_PASSWORD: ${{ secrets.EDAQA_FERNET_PASSWORD }}
           EDAQA_ENV: authenticated
+          EDAQA_GH_TOKEN: ${{ secrets.EDA_QA_GITHUB_TOKEN }}
         run: pytest
 
       - name: Print EDA logs


### PR DESCRIPTION
Set the EDAQA_GH_TOKEN environment variable when running the scheduled eda-qa test suite. Fixes potential failures due to rate limiting.