### PR TITLE
Revert changes to pre DAB app split & tag version to 96072a

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -618,8 +618,8 @@ swagger = ["drf-spectacular"]
 [package.source]
 type = "git"
 url = "https://github.com/ansible/django-ansible-base.git"
-reference = "devel"
-resolved_reference = "bfab25f642aed81df8c8e2e348e09484744871d1"
+reference = "96072a16629e7d714a46b181d5fc3a7d314a6215"
+resolved_reference = "96072a16629e7d714a46b181d5fc3a7d314a6215"
 
 [[package]]
 name = "django-auth-ldap"
@@ -2688,4 +2688,4 @@ dev = ["psycopg2-binary"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "5b77ea2ab0e72c15def4df863515bba9caf9a7130b433652ef05ee6bfb44ddd1"
+content-hash = "a40f8684a0a0c9252c8a1c066c9b421fda61d157fc6741300ae072959f776f95"

--- a/poetry.lock
+++ b/poetry.lock
@@ -619,7 +619,7 @@ swagger = ["drf-spectacular"]
 type = "git"
 url = "https://github.com/ansible/django-ansible-base.git"
 reference = "devel"
-resolved_reference = "6d9febccf3f80c8dc6e0c18ec7dbc9674c6aebe9"
+resolved_reference = "bfab25f642aed81df8c8e2e348e09484744871d1"
 
 [[package]]
 name = "django-auth-ldap"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ rq-scheduler = "^0.10"
 # Experimental LDAP Integration https://issues.redhat.com/browse/AAP-16938
 # We are temporarily updating it to use latest from devel branch to keep consistency accross
 # other AAP components
-django-ansible-base = { git = "https://github.com/ansible/django-ansible-base.git", branch = "devel", extras = [
+django-ansible-base = { git = "https://github.com/ansible/django-ansible-base.git", rev = "96072a16629e7d714a46b181d5fc3a7d314a6215", extras = [
     "authentication",
 ] }
 jinja2 = "*"

--- a/src/aap_eda/api/urls.py
+++ b/src/aap_eda/api/urls.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from ansible_base.lib.dynamic_config.dynamic_urls import api_version_urls
+from ansible_base.urls import urls as base_urls
 from django.urls import include, path
 from drf_spectacular.views import (
     SpectacularJSONAPIView,
@@ -67,14 +67,13 @@ openapi_urls = [
 ]
 
 v1_urls = [
-    # <- Experimental LDAP Auth https://issues.redhat.com/browse/AAP-16938
-    path("", include(api_version_urls)),
-    # ->
     path("", include(openapi_urls)),
     path("auth/session/login/", views.SessionLoginView.as_view()),
     path("auth/session/logout/", views.SessionLogoutView.as_view()),
     path("users/me/", views.CurrentUserView.as_view()),
     *router.urls,
+    # Experimental LDAP Integration https://issues.redhat.com/browse/AAP-16938
+    path("", include(base_urls)),
 ]
 
 urlpatterns = [

--- a/src/aap_eda/core/authenticator_plugins/ldap.py
+++ b/src/aap_eda/core/authenticator_plugins/ldap.py
@@ -1,1 +1,1 @@
-from ansible_base.authentication.authenticator_plugins.ldap import *  # noqa
+from ansible_base.authenticator_plugins.ldap import *  # noqa

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -143,8 +143,8 @@ INSTALLED_APPS = [
     "drf_spectacular",
     "django_rq",
     "django_filters",
-    # Experimental LDAP Auth https://issues.redhat.com/browse/AAP-16938
-    "ansible_base.authentication",
+    # Experimental LDAP Integration https://issues.redhat.com/browse/AAP-16938
+    "ansible_base",
     # Local apps
     "aap_eda.api",
     "aap_eda.core",
@@ -156,11 +156,10 @@ MIDDLEWARE = [
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
-    # <- Experimental LDAP Auth https://issues.redhat.com/browse/AAP-16938
-    "ansible_base.authentication.middleware.AuthenticatorBackendMiddleware",
-    # ->
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    # Experimental LDAP Integration https://issues.redhat.com/browse/AAP-16938
+    "ansible_base.utils.middleware.AuthenticatorBackendMiddleware",
 ]
 
 ROOT_URLCONF = "aap_eda.urls"
@@ -438,10 +437,15 @@ AUTHENTICATION_BACKENDS = [
     "ansible_base.authentication.backend.AnsibleBaseAuth",
     "django.contrib.auth.backends.ModelBackend",
 ]
+ANSIBLE_BASE_FEATURES = {
+    "AUTHENTICATION": True,
+    "FILTERING": False,
+    "SWAGGER": False,
+}
 
-from ansible_base.lib import dynamic_config  # noqa: E402
+from ansible_base import settings  # noqa: E402
 
-dab_settings = os.path.join(
-    os.path.dirname(dynamic_config.__file__), "dynamic_settings.py"
+settings_file = os.path.join(
+    os.path.dirname(settings.__file__), "dynamic_settings.py"
 )
-include(dab_settings)
+include(settings_file)


### PR DESCRIPTION
* Revert "Update for django-ansible-base app split
* _temporary_: tag DAB version to 96072a until we get a new tag 