### PR TITLE
feat: [AAP-19417] Enable to send vault credentials to rulebook

### DIFF
--- a/src/aap_eda/wsapi/messages.py
+++ b/src/aap_eda/wsapi/messages.py
@@ -85,6 +85,17 @@ class ControllerInfo(BaseModel):
     ssl_verify: str
 
 
+class VaultPassword(BaseModel):
+    type: str = "VaultPassword"
+    label: Optional[str]
+    password: str
+
+
+class VaultCollection(BaseModel):
+    type: str = "VaultCollection"
+    data: list[VaultPassword]
+
+
 class HeartbeatMessage(BaseModel):
     type: str = "SessionStats"
     activation_id: int


### PR DESCRIPTION
This PR adds the logic to send vault-type credentials to the rulebook engine via WebSocket channels

Resolves: [AAP-19417](https://issues.redhat.com/browse/AAP-19417)