### PR TITLE
fix: handle empty job uuid in action messages properly

### DIFF
--- a/src/aap_eda/wsapi/consumers.py
+++ b/src/aap_eda/wsapi/consumers.py
@@ -208,9 +208,12 @@ class AnsibleRulebookConsumer(AsyncWebsocketConsumer):
 
     @database_sync_to_async
     def insert_audit_rule_data(self, message: ActionMessage) -> None:
-        job_id = message.job_id
-        job_instance = models.JobInstance.objects.filter(uuid=job_id).first()
-        job_instance_id = job_instance.id if job_instance else None
+        job_instance_id = None
+        if message.job_id:
+            job_instance = models.JobInstance.objects.filter(
+                uuid=message.job_id
+            ).first()
+            job_instance_id = job_instance.id if job_instance else None
 
         audit_rule = models.AuditRule.objects.filter(
             rule_uuid=message.rule_uuid, fired_at=message.rule_run_at

--- a/tests/integration/wsapi/test_consumer.py
+++ b/tests/integration/wsapi/test_consumer.py
@@ -201,6 +201,30 @@ async def test_handle_actions_multiple_firing(
 
 
 @pytest.mark.django_db(transaction=True)
+async def test_handle_actions_with_empty_job_uuid(
+    ws_communicator: WebsocketCommunicator,
+):
+    activation_instance_id = await _prepare_db_data()
+    assert (await get_audit_rule_count()) == 0
+
+    # job uuid is empty string
+    payload = create_action_payload(
+        DUMMY_UUID,
+        activation_instance_id,
+        "",
+        DUMMY_UUID,
+        "2023-03-29T15:00:17.260803Z",
+        _matching_events(),
+    )
+    await ws_communicator.send_json_to(payload)
+    await ws_communicator.wait()
+
+    assert (await get_audit_rule_count()) == 1
+    assert (await get_audit_action_count()) == 1
+    assert (await get_audit_event_count()) == 2
+
+
+@pytest.mark.django_db(transaction=True)
 async def test_handle_actions(ws_communicator: WebsocketCommunicator):
     activation_instance_id = await _prepare_db_data()
     job_instance = await _prepare_job_instance()


### PR DESCRIPTION
The empty job uuid will fail to update audit actions and events correctly to DB.
```
eda-ws_1                 | 2024-01-30 15:25:36,077 daphne.server ERROR    Exception inside application: ['"" is not a valid UUID.']
eda-ws_1                 | Traceback (most recent call last):
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/django/db/models/fields/__init__.py", line 2688, in to_python
eda-ws_1                 |     return uuid.UUID(**{input_form: value})
eda-ws_1                 |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/usr/lib64/python3.11/uuid.py", line 178, in __init__
eda-ws_1                 |     raise ValueError('badly formed hexadecimal UUID string')
eda-ws_1                 | ValueError: badly formed hexadecimal UUID string
eda-ws_1                 | 
eda-ws_1                 | During handling of the above exception, another exception occurred:
eda-ws_1                 | 
eda-ws_1                 | Traceback (most recent call last):
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/channels/routing.py", line 62, in __call__
eda-ws_1                 |     return await application(scope, receive, send)
eda-ws_1                 |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/channels/routing.py", line 116, in __call__
eda-ws_1                 |     return await application(
eda-ws_1                 |            ^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/channels/routing.py", line 116, in __call__
eda-ws_1                 |     return await application(
eda-ws_1                 |            ^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/channels/consumer.py", line 94, in app
eda-ws_1                 |     return await consumer(scope, receive, send)
eda-ws_1                 |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/channels/consumer.py", line 62, in __call__
eda-ws_1                 |     await await_many_dispatch([receive], self.dispatch)
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/channels/utils.py", line 50, in await_many_dispatch
eda-ws_1                 |     await dispatch(result)
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/channels/consumer.py", line 73, in dispatch
eda-ws_1                 |     await handler(message)
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/channels/generic/websocket.py", line 194, in websocket_receive
eda-ws_1                 |     await self.receive(text_data=message["text"])
eda-ws_1                 |   File "/app/src/src/aap_eda/wsapi/consumers.py", line 95, in receive
eda-ws_1                 |     await self.handle_actions(ActionMessage.parse_obj(data))
eda-ws_1                 |   File "/app/src/src/aap_eda/wsapi/consumers.py", line 147, in handle_actions
eda-ws_1                 |     await self.insert_audit_rule_data(message)
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/asgiref/sync.py", line 448, in __call__
eda-ws_1                 |     ret = await asyncio.wait_for(future, timeout=None)
eda-ws_1                 |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/usr/lib64/python3.11/asyncio/tasks.py", line 442, in wait_for
eda-ws_1                 |     return await fut
eda-ws_1                 |            ^^^^^^^^^
eda-ws_1                 |   File "/usr/lib64/python3.11/concurrent/futures/thread.py", line 58, in run
eda-ws_1                 |     result = self.fn(*self.args, **self.kwargs)
eda-ws_1                 |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/channels/db.py", line 13, in thread_handler
eda-ws_1                 |     return super().thread_handler(loop, *args, **kwargs)
eda-ws_1                 |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/asgiref/sync.py", line 490, in thread_handler
eda-ws_1                 |     return func(*args, **kwargs)
eda-ws_1                 |            ^^^^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/app/src/src/aap_eda/wsapi/consumers.py", line 221, in insert_audit_rule_data
eda-ws_1                 |     job_instance = models.JobInstance.objects.filter(uuid=job_id).first()
eda-ws_1                 |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/django/db/models/manager.py", line 87, in manager_method
eda-ws_1                 |     return getattr(self.get_queryset(), name)(*args, **kwargs)
eda-ws_1                 |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/django/db/models/query.py", line 1436, in filter
eda-ws_1                 |     return self._filter_or_exclude(False, args, kwargs)
eda-ws_1                 |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/django/db/models/query.py", line 1454, in _filter_or_exclude
eda-ws_1                 |     clone._filter_or_exclude_inplace(negate, args, kwargs)
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/django/db/models/query.py", line 1461, in _filter_or_exclude_inplace
eda-ws_1                 |     self._query.add_q(Q(*args, **kwargs))
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/django/db/models/sql/query.py", line 1545, in add_q
eda-ws_1                 |     clause, _ = self._add_q(q_object, self.used_aliases)
eda-ws_1                 |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/django/db/models/sql/query.py", line 1576, in _add_q
eda-ws_1                 |     child_clause, needed_inner = self.build_filter(
eda-ws_1                 |                                  ^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/django/db/models/sql/query.py", line 1491, in build_filter
eda-ws_1                 |     condition = self.build_lookup(lookups, col, value)
eda-ws_1                 |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/django/db/models/sql/query.py", line 1318, in build_lookup
eda-ws_1                 |     lookup = lookup_class(lhs, rhs)
eda-ws_1                 |              ^^^^^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/django/db/models/lookups.py", line 27, in __init__
eda-ws_1                 |     self.rhs = self.get_prep_lookup()
eda-ws_1                 |                ^^^^^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/django/db/models/lookups.py", line 341, in get_prep_lookup
eda-ws_1                 |     return super().get_prep_lookup()
eda-ws_1                 |            ^^^^^^^^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/django/db/models/lookups.py", line 85, in get_prep_lookup
eda-ws_1                 |     return self.lhs.output_field.get_prep_value(self.rhs)
eda-ws_1                 |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/django/db/models/fields/__init__.py", line 2672, in get_prep_value
eda-ws_1                 |     return self.to_python(value)
eda-ws_1                 |            ^^^^^^^^^^^^^^^^^^^^^
eda-ws_1                 |   File "/app/venv/lib64/python3.11/site-packages/django/db/models/fields/__init__.py", line 2690, in to_python
eda-ws_1                 |     raise exceptions.ValidationError(
eda-ws_1                 | django.core.exceptions.ValidationError: ['"" is not a valid UUID.']
```