### PR TITLE
fix: importing package from ansible_base.lib

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -603,6 +603,7 @@ cryptography = "*"
 Django = ">=4.2.5,<4.3.0"
 django-auth-ldap = {version = "*", optional = true, markers = "extra == \"authentication\""}
 django-crum = "*"
+django-split-settings = "*"
 djangorestframework = "*"
 inflection = "*"
 python-ldap = {version = "*", optional = true, markers = "extra == \"authentication\""}
@@ -611,16 +612,18 @@ social-auth-app-django = {version = "*", optional = true, markers = "extra == \"
 tabulate = {version = "*", optional = true, markers = "extra == \"authentication\""}
 
 [package.extras]
-all = ["channels", "django-auth-ldap", "drf-spectacular", "python-ldap", "python3-saml", "social-auth-app-django", "tabulate"]
+all = ["channels", "cryptography", "django-auth-ldap", "drf-spectacular", "pyjwt", "pytest", "pytest-django", "python-ldap", "python3-saml", "requests", "social-auth-app-django", "tabulate"]
+api-documentation = ["drf-spectacular"]
 authentication = ["django-auth-ldap", "python-ldap", "python3-saml", "social-auth-app-django", "tabulate"]
 channel-auth = ["channels"]
-swagger = ["drf-spectacular"]
+jwt-consumer = ["pyjwt", "requests"]
+testing = ["cryptography", "pytest", "pytest-django"]
 
 [package.source]
 type = "git"
 url = "https://github.com/ansible/django-ansible-base.git"
 reference = "devel"
-resolved_reference = "a8525aceda31d2a79058e0952ac0688e28ebf109"
+resolved_reference = "a84bdef8b0bd856ead8b910381d2ffd277925ed2"
 
 [[package]]
 name = "django-auth-ldap"

--- a/src/aap_eda/wsapi/routes.py
+++ b/src/aap_eda/wsapi/routes.py
@@ -1,4 +1,4 @@
-from ansible_base.channels.middleware import DrfAuthMiddlewareStack
+from ansible_base.lib.channels.middleware import DrfAuthMiddlewareStack
 from channels.routing import URLRouter
 from channels.security.websocket import AllowedHostsOriginValidator
 from django.conf import settings


### PR DESCRIPTION
Due to recent restructure of dependency library django-ansible-base, `lib` was inserted into the package path.