### PR TITLE
Remove AllowedHostsOriginValidator

### DIFF
--- a/src/aap_eda/wsapi/routes.py
+++ b/src/aap_eda/wsapi/routes.py
@@ -1,6 +1,5 @@
 from ansible_base.lib.channels.middleware import DrfAuthMiddlewareStack
 from channels.routing import URLRouter
-from channels.security.websocket import AllowedHostsOriginValidator
 from django.conf import settings
 from django.urls import path
 
@@ -16,4 +15,4 @@ wsapi_router = URLRouter(
     ]
 )
 
-router = AllowedHostsOriginValidator(DrfAuthMiddlewareStack(wsapi_router))
+router = DrfAuthMiddlewareStack(wsapi_router)


### PR DESCRIPTION
The websocket is between eda-server and ansible-rulebook only.

https://issues.redhat.com/browse/AAP-20292