### PR TITLE
ci: add workflow for e2e test run on demand

### DIFF
--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -7,6 +7,8 @@ on:
         description: 'ref of the eda-qa repository, default is main'
         required: false
         default: 'main'
+  pull_request_target:
+    types: [labeled]
 
 env:
   EDA_QA_PATH: "./eda-qa"
@@ -15,7 +17,10 @@ env:
 
 jobs:
   api-e2e-tests:
-    if: github.repository == 'ansible/eda-server'
+    if: >
+      (github.repository == 'ansible/eda-server' && github.event_name == 'workflow_dispatch') ||
+      (github.repository == 'ansible/eda-server' && github.event_name == 'pull_request_target' &&
+        contains(github.event.pull_request.labels.*.name, 'run-e2e'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -1,0 +1,75 @@
+name: e2e tests on demand
+
+on:
+  workflow_dispatch:
+    inputs:
+      edaqa_ref:
+        description: 'ref of the eda-qa repository, default is main'
+        required: false
+        default: 'main'
+
+env:
+  EDA_QA_PATH: "./eda-qa"
+  REGISTRY: quay.io
+  QUAY_USER: ansible+eda_gha
+
+jobs:
+  api-e2e-tests:
+    if: github.repository == 'ansible/eda-server'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.QUAY_USER }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Run api in background
+        working-directory: tools/docker
+        env:
+          DJANGO_SETTINGS_MODULE: aap_eda.settings.default
+          EDA_DEBUG: "false"
+        run: |
+          docker-compose -p eda -f docker-compose-dev.yaml pull
+          docker-compose -p eda -f docker-compose-dev.yaml build
+          docker-compose -p eda -f docker-compose-dev.yaml up -d
+          while ! curl -s http://localhost:8000/_healthz | grep -q "OK"; do
+            echo "Waiting for API to be ready..."
+            sleep 1
+          done
+
+      - name: Fetch test suite
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          repository: ansible/eda-qa
+          ref: ${{ github.event.inputs.edaqa_ref }}
+          path: ${{ env.EDA_QA_PATH }}
+          token: ${{ secrets.EDA_QA_GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Install dependencies
+        working-directory: ${{ env.EDA_QA_PATH }}
+        run: pip install .
+
+      - name: Run tests
+        working-directory: ${{ env.EDA_QA_PATH }}
+        env:
+          EDAQA_FERNET_PASSWORD: ${{ secrets.EDAQA_FERNET_PASSWORD }}
+          EDAQA_ENV: authenticated
+        run: pytest
+
+      - name: Print EDA logs
+        if: always()
+        working-directory: tools/docker
+        run: |
+          docker-compose -p eda -f docker-compose-dev.yaml logs
+


### PR DESCRIPTION
This workflow allows us to build eda-server from some branch and run on demand the private e2e test suite through the Actions tab in the UI.
It can be triggered against some PR if "run-e2e" label is added. 
It also has a variable to set a different ref for the test suite (main by default)

Warn, it might not work and need fixes, we need to merge it. 