### PR TITLE
ci: remove pull step in e2e on demand workflow

### DIFF
--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -39,7 +39,6 @@ jobs:
           DJANGO_SETTINGS_MODULE: aap_eda.settings.default
           EDA_DEBUG: "false"
         run: |
-          docker-compose -p eda -f docker-compose-dev.yaml pull
           docker-compose -p eda -f docker-compose-dev.yaml build
           docker-compose -p eda -f docker-compose-dev.yaml up -d
           while ! curl -s http://localhost:8000/_healthz | grep -q "OK"; do


### PR DESCRIPTION
The workflow fails because it tries to pull a local image, we don't need to pull the images in this case so I deleted that line. 