### PR TITLE
feat: Rename service name for event streams in k8s

### DIFF
--- a/src/aap_eda/services/activation/engine/common.py
+++ b/src/aap_eda/services/activation/engine/common.py
@@ -122,7 +122,7 @@ class ContainerEngine(ABC):
     """Abstract interface to connect to the deployment backend."""
 
     @abstractmethod
-    def __init__(self, activation_id: str):
+    def __init__(self, activation_id: str, resource_prefix: str):
         ...
 
     @abstractmethod

--- a/src/aap_eda/services/activation/engine/factory.py
+++ b/src/aap_eda/services/activation/engine/factory.py
@@ -21,12 +21,12 @@ from .kubernetes import Engine as KubernetesEngine
 from .podman import Engine as PodmanEngine
 
 
-def new_container_engine(activation_id: str):
+def new_container_engine(activation_id: str, resource_prefix: str):
     """Activation service factory."""
     """Returns an activation object based on the deployment type"""
     # TODO: deployment type should not be plain strings
     if settings.DEPLOYMENT_TYPE == "podman":
-        return PodmanEngine(activation_id)
+        return PodmanEngine(activation_id, resource_prefix)
     if settings.DEPLOYMENT_TYPE == "k8s":
-        return KubernetesEngine(activation_id)
+        return KubernetesEngine(activation_id, resource_prefix)
     raise exceptions.InvalidDeploymentTypeError("Wrong deployment type")

--- a/src/aap_eda/services/activation/engine/kubernetes.py
+++ b/src/aap_eda/services/activation/engine/kubernetes.py
@@ -83,6 +83,7 @@ class Engine(ContainerEngine):
     def __init__(
         self,
         activation_id: str,
+        resource_prefix: str,
         client=None,
     ) -> None:
         if client:
@@ -91,7 +92,8 @@ class Engine(ContainerEngine):
             self.client = get_k8s_client()
 
         self._set_namespace()
-        self.secret_name = f"activation-secret-{activation_id}"
+        self.resource_prefix = resource_prefix.replace("_", "-")
+        self.secret_name = f"{self.resource_prefix}-secret-{activation_id}"
         self.job_name = None
         self.pod_name = None
 
@@ -99,11 +101,11 @@ class Engine(ContainerEngine):
         # TODO : Should this be compatible with the previous version
         # Previous Version
         self.job_name = (
-            f"activation-job-{request.activation_id}"
+            f"{self.resource_prefix}-job-{request.activation_id}"
             f"-{request.activation_instance_id}"
         )
         self.pod_name = (
-            f"activation-pod-{request.activation_id}"
+            f"{self.resource_prefix}-pod-{request.activation_id}"
             f"-{request.activation_instance_id}"
         )
 

--- a/src/aap_eda/services/activation/engine/podman.py
+++ b/src/aap_eda/services/activation/engine/podman.py
@@ -63,6 +63,7 @@ class Engine(ContainerEngine):
     def __init__(
         self,
         _activation_id: str,
+        _resource_prefix: str = None,
         client=None,
     ) -> None:
         try:

--- a/src/aap_eda/services/activation/manager.py
+++ b/src/aap_eda/services/activation/manager.py
@@ -116,7 +116,9 @@ class ActivationManager:
         if container_engine:
             self.container_engine = container_engine
         else:
-            self.container_engine = new_container_engine(db_instance.id)
+            self.container_engine = new_container_engine(
+                db_instance.id, self.db_instance_type
+            )
 
         self.container_logger_class = container_logger_class
 

--- a/tests/integration/services/activation/engine/test_kubernetes.py
+++ b/tests/integration/services/activation/engine/test_kubernetes.py
@@ -22,7 +22,7 @@ from kubernetes.client.rest import ApiException
 from kubernetes.config.config_exception import ConfigException
 
 from aap_eda.core import models
-from aap_eda.core.enums import ActivationStatus
+from aap_eda.core.enums import ActivationStatus, ProcessParentType
 from aap_eda.services.activation.db_log_handler import DBLogger
 from aap_eda.services.activation.engine.common import (
     AnsibleRulebookCmdLine,
@@ -267,23 +267,49 @@ def kubernetes_engine(init_data):
     with mock.patch("builtins.open", mock.mock_open(read_data="aap-eda")):
         engine = Engine(
             activation_id=str(activation_id),
+            resource_prefix=ProcessParentType.ACTIVATION,
             client=mock.Mock(),
         )
 
         yield engine
 
 
-@pytest.mark.django_db
-def test_engine_init(init_data):
+@pytest.fixture
+def kubernetes_event_stream_engine(init_data):
     activation_id = init_data.activation.id
     with mock.patch("builtins.open", mock.mock_open(read_data="aap-eda")):
         engine = Engine(
             activation_id=str(activation_id),
+            resource_prefix=ProcessParentType.EVENT_STREAM,
             client=mock.Mock(),
         )
 
-        assert engine.namespace == "aap-eda"
-        assert engine.secret_name == f"activation-secret-{activation_id}"
+        yield engine
+
+
+@pytest.mark.parametrize(
+    "resource_prefixes",
+    [
+        {ProcessParentType.ACTIVATION: "activation"},
+        {ProcessParentType.EVENT_STREAM: "event-stream"},
+    ],
+)
+@pytest.mark.django_db
+def test_engine_init(init_data, resource_prefixes):
+    activation_id = init_data.activation.id
+    with mock.patch("builtins.open", mock.mock_open(read_data="aap-eda")):
+        for prefix in resource_prefixes:
+            engine = Engine(
+                activation_id=str(activation_id),
+                resource_prefix=prefix,
+                client=mock.Mock(),
+            )
+
+            assert engine.namespace == "aap-eda"
+            assert (
+                engine.secret_name
+                == f"{resource_prefixes[prefix]}-secret-{activation_id}"
+            )
 
 
 @pytest.mark.django_db
@@ -298,6 +324,7 @@ def test_engine_init_with_exception(init_data):
     ):
         Engine(
             activation_id=str(activation_id),
+            resource_prefix=ProcessParentType.ACTIVATION,
             client=mock.Mock(),
         )
 
@@ -339,6 +366,30 @@ def test_engine_start(init_data, kubernetes_engine):
     )
     assert engine.pod_name == (
         f"activation-pod-{init_data.activation.id}-"
+        f"{init_data.activation_instance.id}"
+    )
+
+    assert models.RulebookProcessLog.objects.count() == 5
+    assert models.RulebookProcessLog.objects.last().log.endswith(
+        f"Job {engine.job_name} is running"
+    )
+
+
+@pytest.mark.django_db
+def test_event_stream_engine_start(init_data, kubernetes_event_stream_engine):
+    engine = kubernetes_event_stream_engine
+    request = get_request(init_data)
+    log_handler = DBLogger(init_data.activation_instance.id)
+
+    with mock.patch("aap_eda.services.activation.engine.kubernetes.watch"):
+        engine.start(request, log_handler)
+
+    assert engine.job_name == (
+        f"event-stream-job-{init_data.activation.id}-"
+        f"{init_data.activation_instance.id}"
+    )
+    assert engine.pod_name == (
+        f"event-stream-pod-{init_data.activation.id}-"
         f"{init_data.activation_instance.id}"
     )
 


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-20691

In K8S the resource prefixes are added to secret, service, job, and pod names to avoid conflicting resources for event streams and activations. They looks like:

![image](https://github.com/ansible/eda-server/assets/12900250/4052d693-ca01-4c43-abaa-ef7e930bc5db)

![image](https://github.com/ansible/eda-server/assets/12900250/a6591759-65e0-4d6a-9215-b79ec965bc92)

![image](https://github.com/ansible/eda-server/assets/12900250/4b0a548b-7bc7-4635-a473-d6efd870eee0)

![image](https://github.com/ansible/eda-server/assets/12900250/da9da35e-f3d3-4699-8691-6c683adb3d27)
