### PR TITLE
chore: allow for minikube deployments to use quay images

### DIFF
--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -241,12 +241,26 @@ tasks:
         vars:
           CLI_ARGS: build-api {{.CLI_ARGS}}
 
+  minikube:build:ui:
+    desc: "Build EDA UI image and push to minikube"
+    cmds:
+      - task: minikube
+        vars:
+          CLI_ARGS: build-ui {{.CLI_ARGS}}
+
   minikube:deploy:
     desc: "Build deployment and deploy to minikube"
     cmds:
       - task: minikube
         vars:
           CLI_ARGS: deploy {{.CLI_ARGS}}
+
+  minikube:quay-deploy:
+    desc: "Build deployment from quay deploy to minikube"
+    cmds:
+      - task: minikube
+        vars:
+          CLI_ARGS: quay-deploy {{.CLI_ARGS}}
 
   minikube:clean:
     desc: "Clean deployment directory and clean minikube resources"

--- a/scripts/eda_kube.sh
+++ b/scripts/eda_kube.sh
@@ -22,6 +22,11 @@ source "${SCRIPTS_DIR}"/common/utils.sh
 
 trap handle_errors ERR
 
+export EDA_IMAGE=${EDA_IMAGE:-'quay.io/ansible/eda-server:main'}
+export EDA_UI_IMAGE=${EDA_UI_IMAGE:-'quay.io/ansible/eda-ui:main'}
+export EDA_IMAGE_PULL_POLICY=${EDA_IMAGE_PULL_POLICY:-'Always'}
+export EDA_UI_IMAGE_PULL_POLICY=${EDA_UI_IMAGE_PULL_POLICY:-'Always'}
+
 handle_errors() {
   log-err "An error occurred on or around line ${BASH_LINENO[0]}. Unable to continue."
   exit 1
@@ -76,6 +81,41 @@ build-deployment() {
   kustomize build "${DEPLOY_DIR}" -o "${DEPLOY_DIR}/temp"
 }
 
+build-quay-deployment() {
+  local _temp_dir="${DEPLOY_DIR}"/temp
+  declare -a app_dirs=("eda-api" "eda-activation-worker" "eda-default-worker" "eda-scheduler")
+
+  log-info "Using Deployment Directory: ${DEPLOY_DIR}/temp"
+
+  if [ -d "${_temp_dir}" ]; then
+    rm -rf "${_temp_dir}"
+  fi
+  mkdir "${_temp_dir}"
+
+  for app_dir in "${app_dirs[@]}"
+   do
+       cd "${DEPLOY_DIR}"/"$app_dir"
+       log-debug "kustomize edit set image aap-eda=${EDA_IMAGE}"
+       kustomize edit set image aap-eda="${EDA_IMAGE}"
+       kustomize edit add patch --group apps --version v1  --name "$app_dir" --kind Deployment --patch "[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/imagePullPolicy\", \"value\": \""${EDA_IMAGE_PULL_POLICY}"\"}]"
+   done
+
+  cd "${DEPLOY_DIR}"/eda-ui
+  log-debug "kustomize edit set image eda-ui=${EDA_UI_IMAGE}"
+  kustomize edit set image eda-ui="${EDA_UI_IMAGE}"
+  kustomize edit add patch --group apps --version v1  --name eda-ui --kind Deployment --patch "[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/imagePullPolicy\", \"value\": \""${EDA_UI_IMAGE_PULL_POLICY}"\"}]"
+
+  cd "${PROJECT_DIR}"
+  log-debug "kustomize build ${DEPLOY_DIR} -o ${DEPLOY_DIR}/temp"
+  kustomize build "${DEPLOY_DIR}" -o "${DEPLOY_DIR}/temp"
+
+  for app_dir in "${app_dirs[@]}"
+   do
+       git checkout -- "${DEPLOY_DIR}/${app_dir}/kustomization.yaml"
+   done
+  git checkout -- "${DEPLOY_DIR}/eda-ui/kustomization.yaml"
+}
+
 build-deployment-api() {
   local _api_image="aap-eda:${1}"
   local _temp_dir="${DEPLOY_DIR}"/temp
@@ -124,9 +164,18 @@ build-all() {
   build-deployment "${1}"
 }
 
+quay-deploy() {
+  build-quay-deployment "${1}"
+  deploy "${1}"
+}
+
 build-api() {
   build-eda-api-image "${1}"
   build-deployment-api "${1}"
+}
+
+build-ui() {
+  build-eda-ui-image "${1}"
 }
 
 remove-image() {
@@ -217,9 +266,9 @@ port-forward() {
 }
 
 port-forward-ui() {
-  local _local_port=${PORT:-"8080"}
+  local _local_port=${PORT:-"8443"}
   local _svc_name=eda-ui
-  local _svc_port=8080
+  local _svc_port=8443
 
   log-debug "port-forward ${_svc_name} ${_local_port} ${_svc_port}"
   port-forward "${_svc_name}" "${_local_port}" "${_svc_port}"
@@ -255,9 +304,11 @@ get-eda-logs() {
 case ${CMD} in
   "build") build-all "${VERSION}" ;;
   "build-api") build-api "${VERSION}" ;;
+  "build-ui") build-ui "${VERSION}" ;;
   "clean") clean-deployment "${VERSION}";;
   "clean-api") clean-api-deployment "${VERSION}";;
   "deploy") deploy "${VERSION}" ;;
+  "quay-deploy") quay-deploy "${VERSION}" ;;
   "port-forward-api") port-forward-api ${PORT} ;;
   "port-forward-ui") port-forward-ui ${PORT} ;;
   "port-forward-pg") port-forward-pg 5432 ;;

--- a/tools/deploy/eda-ui/service.yaml
+++ b/tools/deploy/eda-ui/service.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   ports:
     - name: "8080"
-      port: 8080
-      targetPort: 8080
+      port: 8443
+      targetPort: 443
   selector:
     app: eda
     comp: ui


### PR DESCRIPTION
Previously the minikube workflow required the UI and eda server images to be built locally before they can be used. Which is cumbersome, this PR adds a new task called
 * quay-deploy

which allows us to run directly from quay images and it also allows for the images to be overridden for UI and eda server local images using the following env vars

* EDA_UI_IMAGE=localhost/eda-ui:latest
* EDA_UI_IMAGE_PULL_POLICY=Never
* EDA_IMAGE=localhost/eda-server:latest
* EDA_IMAGE_PULL_POLICY=Never

To run the minikube deployment run the following command
```
    task minikube:quay-deploy
```
 Once all the pods are up and running do a port forwarding

```
task minikube:fp:ui 
```
Now you should be able to access the running containers using the following URL **https://localhost:8443/**

To cleanup
```
task minikube:clean
```
Given that we might be switching to use the ansible-playbook deployment this is a short term solution.