### PR TITLE
ci: ensure run-e2e label always triggers workflow

### DIFF
--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -8,7 +8,9 @@ on:
         required: false
         default: 'main'
   pull_request_target:
-    types: [labeled]
+    types:
+      - labeled
+      - synchronize
 
 env:
   EDA_QA_PATH: "./eda-qa"


### PR DESCRIPTION
When you add the label run-e2e to run the private test-suite, only is executed the time that the label is added. If later there are new commits it is not executed, forcing you to remove and re-add the label again. This PR wants to fix that, executing the workflow for any new commit if the label is present. 