### PR TITLE
Add permission inheritance for managed roles

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -603,7 +603,7 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-ansible-base"
-version = "24.2.26.1.dev198+gaea97da"
+version = "24.2.28.1.dev205+g73eb54e"
 description = "A Django app used by ansible services"
 optional = false
 python-versions = ">=3.9"
@@ -611,7 +611,7 @@ files = []
 develop = false
 
 [package.dependencies]
-channels = {version = "*", optional = true, markers = "extra == \"channel_auth\""}
+channels = {version = "*", optional = true, markers = "extra == \"channel-auth\""}
 cryptography = "*"
 Django = ">=4.2.5,<4.3.0"
 django-auth-ldap = {version = "*", optional = true, markers = "extra == \"authentication\""}
@@ -636,7 +636,7 @@ testing = ["cryptography", "pytest", "pytest-django"]
 type = "git"
 url = "https://github.com/alancoding/django-ansible-base.git"
 reference = "django_permissions"
-resolved_reference = "aea97da3584f9934c778849d969f974ccf441f77"
+resolved_reference = "73eb54e1c1c16ca65e10ed12043df1b68a8cc322"
 
 [[package]]
 name = "django-auth-ldap"

--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -220,7 +220,6 @@ class ActivationInstanceSerializer(serializers.ModelSerializer):
             "git_hash",
             "status_message",
             "activation_id",
-            "organization_id",
             "started_at",
             "ended_at",
         ]

--- a/src/aap_eda/api/serializers/rulebook.py
+++ b/src/aap_eda/api/serializers/rulebook.py
@@ -34,7 +34,6 @@ class RulebookSerializer(serializers.ModelSerializer):
             "description",
             "rulesets",
             "project_id",
-            "organization_id",
             "created_at",
             "modified_at",
         ]
@@ -46,7 +45,7 @@ class RulebookRefSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Rulebook
-        fields = ["id", "name", "description", "organization_id"]
+        fields = ["id", "name", "description"]
         read_only_fields = ["id"]
 
 

--- a/src/aap_eda/core/management/commands/create_initial_data.py
+++ b/src/aap_eda/core/management/commands/create_initial_data.py
@@ -151,6 +151,11 @@ ORG_ROLES = [
 
 class Command(BaseCommand):
     help = "Seed database with initial roles."
+    parent_child_models = {
+        "project": "rulebook",
+        "activation": "rulebookprocess",
+        "activationinstance": "auditrule",
+    }
 
     @transaction.atomic
     def handle(self, *args, **options):
@@ -194,17 +199,36 @@ class Command(BaseCommand):
             )
         self.stdout.write(f"Added {len(ORG_ROLES)} roles.")
 
+    def _create_permissions_for_content_type(self, ct=None) -> list:
+        return [
+            p
+            for p in DABPermission.objects.filter(content_type=ct)
+            if not p.codename.startswith("add_")
+        ]
+
     def _create_obj_roles(self):
         for cls in permission_registry.all_registered_models:
             ct = ContentType.objects.get_for_model(cls)
-            if ct._meta.model_name == "organization":
-                continue  # covered by org roles
-            permissions = [
-                p
-                for p in DABPermission.objects.filter(content_type=ct)
-                if not p.codename.startswith("add_")
-            ]
+            model_name = cls._meta.model_name
+            # ignore if the model is organization, covered by org roles
+            # or child model, inherits permissions from parent model
+            if (
+                model_name == "organization"
+                or model_name in self.parent_child_models.values()
+            ):
+                continue
+            permissions = self._create_permissions_for_content_type(ct)
             desc = f"Has all permissions to a single {cls._meta.verbose_name}"
+            # parent model should add permissions related to its child models
+            if model_name in self.parent_child_models.keys():
+                child_model = permission_registry._name_to_model[
+                    self.parent_child_models[model_name]
+                ]
+                child_ct = ContentType.objects.get_for_model(child_model)
+                permissions.extend(
+                    self._create_permissions_for_content_type(child_ct)
+                )
+                desc += f" and its child resources - {child_model._meta.verbose_name}"  # noqa: E501
             role, created = RoleDefinition.objects.get_or_create(
                 name=f"{cls._meta.verbose_name.title()} Admin",
                 defaults={

--- a/src/aap_eda/core/migrations/0021_organization_team_and_more.py
+++ b/src/aap_eda/core/migrations/0021_organization_team_and_more.py
@@ -158,33 +158,6 @@ class Migration(migrations.Migration):
                 to="core.organization",
             ),
         ),
-        migrations.AddField(
-            model_name="rulebook",
-            name="organization",
-            field=models.ForeignKey(
-                null=True,
-                on_delete=django.db.models.deletion.CASCADE,
-                to="core.organization",
-            ),
-        ),
-        migrations.AddField(
-            model_name="rulebookprocess",
-            name="organization",
-            field=models.ForeignKey(
-                null=True,
-                on_delete=django.db.models.deletion.CASCADE,
-                to="core.organization",
-            ),
-        ),
-        migrations.AddField(
-            model_name="rulebookprocesslog",
-            name="organization",
-            field=models.ForeignKey(
-                null=True,
-                on_delete=django.db.models.deletion.CASCADE,
-                to="core.organization",
-            ),
-        ),
         migrations.CreateModel(
             name="Team",
             fields=[

--- a/src/aap_eda/core/migrations/0022_add_default_organization.py
+++ b/src/aap_eda/core/migrations/0022_add_default_organization.py
@@ -36,9 +36,6 @@ def add_resources_to_default_org(apps, schema_editor):
         "DecisionEnvironment",
         "ExtraVar",
         "Project",
-        "Rulebook",
-        "RulebookProcess",
-        "RulebookProcessLog",
     )
 
     Organization = apps.get_model("core", "Organization")  # noqa: N806
@@ -66,9 +63,6 @@ def remove_resources_from_default_org(apps, schema_editor):
         "ExtraVar",
         "Project",
         "Role",
-        "Rulebook",
-        "RulebookProcess",
-        "RulebookProcessLog",
     )
 
     Organization = apps.get_model("core", "Organization")  # noqa: N806

--- a/src/aap_eda/core/models/__init__.py
+++ b/src/aap_eda/core/models/__init__.py
@@ -77,14 +77,19 @@ permission_registry.register(
     Team,
     Organization,
     Credential,
-    Activation,
     DecisionEnvironment,
-    RulebookProcess,
     AuditRule,
     Project,
     ExtraVar,
-    Rulebook,
     parent_field_name="organization",
+)
+permission_registry.register(
+    Rulebook,
+    parent_field_name="project",
+)
+permission_registry.register(
+    RulebookProcess,
+    parent_field_name="activation",
 )
 permission_registry.register(
     EventStream,

--- a/src/aap_eda/core/models/__init__.py
+++ b/src/aap_eda/core/models/__init__.py
@@ -78,7 +78,6 @@ permission_registry.register(
     Organization,
     Credential,
     DecisionEnvironment,
-    AuditRule,
     Project,
     ExtraVar,
     parent_field_name="organization",
@@ -90,6 +89,9 @@ permission_registry.register(
 permission_registry.register(
     RulebookProcess,
     parent_field_name="activation",
+)
+permission_registry.register(
+    AuditRule, parent_field_name="activation_instance"
 )
 permission_registry.register(
     EventStream,

--- a/src/aap_eda/core/models/activation.py
+++ b/src/aap_eda/core/models/activation.py
@@ -142,9 +142,6 @@ class RulebookProcess(models.Model):
     )
     git_hash = models.TextField(null=False, default="")
     activation = models.ForeignKey("Activation", on_delete=models.CASCADE)
-    organization = models.ForeignKey(
-        "Organization", on_delete=models.CASCADE, null=True
-    )
     started_at = models.DateTimeField(auto_now_add=True, null=False)
     updated_at = models.DateTimeField(null=True)
     ended_at = models.DateTimeField(null=True)
@@ -188,10 +185,6 @@ class RulebookProcess(models.Model):
 
         super().save(*args, **kwargs)
         self.activation.save(update_fields=["latest_instance"])
-
-        if not self.organization:
-            self.organization = Organization.objects.get_default()
-            super().save(update_fields=["organization"])
 
     def _get_default_status_message(self):
         try:
@@ -242,15 +235,6 @@ class RulebookProcessLog(models.Model):
     activation_instance = models.ForeignKey(
         "RulebookProcess", on_delete=models.CASCADE
     )
-    organization = models.ForeignKey(
-        "Organization", on_delete=models.CASCADE, null=True
-    )
     line_number = models.IntegerField()
     log = models.TextField()
     log_timestamp = models.BigIntegerField(null=False, default=0)
-
-    def save(self, *args, **kwargs):
-        super().save(*args, **kwargs)
-        if not self.organization:
-            self.organization = Organization.objects.get_default()
-            super().save(update_fields=["organization"])

--- a/src/aap_eda/core/models/rulebook.py
+++ b/src/aap_eda/core/models/rulebook.py
@@ -43,9 +43,6 @@ class Rulebook(models.Model):
     # https://issues.redhat.com/browse/AAP-19202
     rulesets = models.TextField(null=False, default="")
     project = models.ForeignKey("Project", on_delete=models.CASCADE, null=True)
-    organization = models.ForeignKey(
-        "Organization", on_delete=models.CASCADE, null=True
-    )
     created_at = models.DateTimeField(auto_now_add=True, null=False)
     modified_at = models.DateTimeField(auto_now=True, null=False)
 
@@ -62,12 +59,6 @@ class Rulebook(models.Model):
                     f" {self.id} - {self.name}: Error: {e}"
                 )
             )
-
-    def save(self, *args, **kwargs):
-        super().save(*args, **kwargs)
-        if not self.organization:
-            self.organization = Organization.objects.get_default()
-            super().save(update_fields=["organization"])
 
 
 class Ruleset(models.Model):


### PR DESCRIPTION
This adds changes to managed roles in RBAC created by `create_initial_data` command to grant parent models to have permissions for their associated child models.
 
The models permission inheritance structure that are changed:

1. Activation -> Activation Instance -> Audit Rule
2. Project -> Rulebook
