### PR TITLE
fix: remove writing to auth json file when pulling image in podman

### DIFF
--- a/src/aap_eda/services/activation/engine/podman.py
+++ b/src/aap_eda/services/activation/engine/podman.py
@@ -12,8 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import base64
-import json
 import logging
 import os
 
@@ -31,7 +29,6 @@ from .common import (
     ContainerEngine,
     ContainerRequest,
     ContainerStatus,
-    Credential,
     LogHandler,
 )
 
@@ -73,7 +70,6 @@ class Engine(ContainerEngine):
                 self.client = get_podman_client()
             LOGGER.debug(self.client.version())
 
-            self.auth_file = None
         except APIError as e:
             LOGGER.error(f"Failed to initialize podman engine: f{e}")
             raise exceptions.ContainerEngineInitError(str(e))
@@ -113,7 +109,6 @@ class Engine(ContainerEngine):
             raise exceptions.ContainerStartError("Missing image url")
 
         try:
-            self._set_auth_json_file()
             self._login(request)
             LOGGER.info(f"Image URL is {request.image_url}")
             if request.pull_policy == "Always" or not self._image_exists(
@@ -326,44 +321,6 @@ class Engine(ContainerEngine):
             LOGGER.exception("Login failed: f{e}")
             raise exceptions.ContainerStartError(str(e))
 
-    def _write_auth_json(self, request: ContainerRequest) -> None:
-        if not self.auth_file:
-            LOGGER.debug("No auth file to create")
-            return
-
-        auth_dict = {}
-        if os.path.exists(self.auth_file):
-            with open(self.auth_file, encoding="utf-8") as f:
-                auth_dict = json.load(f)
-
-        if "auths" not in auth_dict:
-            auth_dict["auths"] = {}
-        registry = request.image_url.split("/")[0]
-        auth_dict["auths"][registry] = self._create_auth_key(
-            request.credential
-        )
-
-        with open(self.auth_file, mode="w", encoding="utf-8") as f:
-            json.dump(auth_dict, f, indent=6)
-
-    def _create_auth_key(self, credential: Credential) -> dict:
-        data = f"{credential.username}:{credential.secret}"
-        encoded_data = data.encode("ascii")
-        return {"auth": base64.b64encode(encoded_data).decode("ascii")}
-
-    def _set_auth_json_file(self) -> None:
-        xdg_runtime_dir = os.getenv(
-            "XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}"
-        )
-        auth_file = f"{xdg_runtime_dir}/containers/auth.json"
-        dir_name = os.path.dirname(auth_file)
-        if os.path.exists(dir_name):
-            self.auth_file = auth_file
-            LOGGER.debug("Will use auth file %s", auth_file)
-        else:
-            self.auth_file = None
-            LOGGER.debug("Will not use auth file")
-
     def _pull_image(
         self, request: ContainerRequest, log_handler: LogHandler
     ) -> Image:
@@ -376,7 +333,6 @@ class Engine(ContainerEngine):
                     "username": request.credential.username,
                     "password": request.credential.secret,
                 }
-                self._write_auth_json(request)
             image = self.client.images.pull(request.image_url, **kwargs)
 
             # https://github.com/containers/podman-py/issues/301

--- a/tests/integration/services/activation/engine/test_podman.py
+++ b/tests/integration/services/activation/engine/test_podman.py
@@ -587,27 +587,3 @@ def test_engine_update_logs_with_exception(init_data, podman_engine):
 
     with pytest.raises(ContainerUpdateLogsError, match="Not found"):
         engine.update_logs("100", log_handler)
-
-
-@pytest.mark.django_db
-def test_set_auth_json(podman_engine):
-    engine = podman_engine
-
-    with mock.patch("os.path.dirname"):
-        engine._set_auth_json_file()
-
-        xdg_runtime_dir = os.getenv(
-            "XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}"
-        )
-
-        assert engine.auth_file == f"{xdg_runtime_dir}/containers/auth.json"
-
-
-@pytest.mark.django_db
-def test_write_auth_json(init_data, podman_engine):
-    engine = podman_engine
-    engine.auth_file = f"{DATA_DIR}/auth.json"
-    request = get_request_with_credential(init_data)
-
-    engine._write_auth_json(request)
-    assert engine.auth_file is not None


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-21067

The pull image API has an additional keyword args that takes in the auth_config with the username and password.