### PR TITLE
fix: allowlist for source plugins with port forward

### DIFF
--- a/src/aap_eda/services/activation/engine/ports.py
+++ b/src/aap_eda/services/activation/engine/ports.py
@@ -3,6 +3,7 @@ import logging
 
 import jinja2
 import yaml
+from django.conf import settings
 from jinja2.exceptions import UndefinedError
 from jinja2.nativetypes import NativeTemplate
 
@@ -43,6 +44,10 @@ def find_ports(rulebook_text: str, context: dict = None) -> list[tuple]:
                 del source["name"]
             # The first remaining key is the type and the arguments
             source_plugin = list(source.keys())[0]
+
+            if source_plugin not in settings.SAFE_PLUGINS_FOR_PORT_FORWARD:
+                continue
+
             source_args = source[source_plugin]
             if source_args is None:
                 continue

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -527,3 +527,8 @@ _DEFAULT_PG_NOTIFY_DSN = (
 
 PG_NOTIFY_DSN = settings.get("PG_NOTIFY_DSN", _DEFAULT_PG_NOTIFY_DSN)
 PG_NOTIFY_TEMPLATE_RULEBOOK = settings.get("PG_NOTIFY_TEMPLATE_RULEBOOK", None)
+
+SAFE_PLUGINS_FOR_PORT_FORWARD = settings.get(
+    "SAFE_PLUGINS_FOR_PORT_FORWARD",
+    ["ansible.eda.webhook", "ansible.eda.alertmanager"],
+)

--- a/tests/integration/services/activation/engine/test_ports.py
+++ b/tests/integration/services/activation/engine/test_ports.py
@@ -57,10 +57,10 @@ def test_ports_with_multi_sources():
 - name: Run a webhook service
   hosts: all
   sources:
-    - ansible.eda.webhook1:
+    - ansible.eda.webhook:
         host: 0.0.0.0
         port: 5555
-    - ansible.eda.webhook2:
+    - ansible.eda.webhook:
         host: 127.0.0.1
         port: 8888
 """
@@ -173,3 +173,33 @@ def test_ports_with_extra_vars_without_default():
 
     with pytest.raises(exceptions.ActivationStartError):
         find_ports(rulebook, context)
+
+
+def test_ports_non_webhook_source():
+    rulebook = """
+---
+- name: Run a kafka source
+  hosts: all
+  sources:
+    - ansible.eda.kafka:
+        host: 0.0.0.0
+        port: 5555
+"""
+    ports = find_ports(rulebook, {})
+
+    assert not ports
+
+
+def test_ports_alertmanager_source():
+    rulebook = """
+---
+- name: Run a alertmanager source
+  hosts: all
+  sources:
+    - ansible.eda.alertmanager:
+        host: 0.0.0.0
+        port: 5555
+"""
+    ports = find_ports(rulebook, {})
+
+    assert ports == [("0.0.0.0", 5555)]


### PR DESCRIPTION
On the EDA Server side we try to open ports for port forwarding using the container engine (podman/k8s). We only allow a specific set of source plugins listed in the settings
**SAFE_PLUGINS_FOR_PORT_FORWARD** to be eligible for port forwarding. The default settings only supports the following source plugins

* ansible.eda.webhook
* ansible.eda.alertmanager

The user can augment this settings to include other source plugins

https://issues.redhat.com/browse/AAP-17416