### PR TITLE
ci: fix the ref used in run-e2e label

### DIFF
--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -27,6 +27,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: >-
+            ${{
+              github.event_name == 'pull_request_target' && github.event.pull_request.head.ref
+              || github.sha
+            }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2


### PR DESCRIPTION
run-e2e label was executing the tests against HEAD of main instead of the PR. This PR tries to fix that. 