### PR TITLE
rollback changes in run-e2e workflow

### DIFF
--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -27,12 +27,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: >-
-            ${{
-              github.event_name == 'pull_request_target' && github.event.pull_request.head.ref
-              || github.sha
-            }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2


### PR DESCRIPTION
It doesn't work, so for now I leave it as it is. I need to test it better before a real fix, I can not be merging PR's in a try-error way. 