### PR TITLE
ci: fix the ref used in run-e2e label

### DIFF
--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.repository }}
           ref: >-
             ${{
               github.event_name == 'pull_request_target' && github.event.pull_request.head.ref


### PR DESCRIPTION
Follow up https://github.com/ansible/eda-server/pull/723, tested in my fork.