### PR TITLE
fix: id, and date time fields should be readonly

### DIFF
--- a/src/aap_eda/api/serializers/eda_credential.py
+++ b/src/aap_eda/api/serializers/eda_credential.py
@@ -94,13 +94,10 @@ class EdaCredentialCreateSerializer(serializers.ModelSerializer):
             "modified_at",
         ]
         fields = [
-            "id",
             "name",
             "description",
             "inputs",
             "credential_type_id",
-            "created_at",
-            "modified_at",
         ]
 
 


### PR DESCRIPTION
We had duplicate sections where the id, modified_at and created_at where both read and write fields.