### PR TITLE
fix: upgrade django-rq and fix queue and worker params

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -634,13 +634,13 @@ Django = ">=3.2"
 
 [[package]]
 name = "django-rq"
-version = "2.7.0"
+version = "2.8.0"
 description = "An app that provides django integration for RQ (Redis Queue)"
 optional = false
 python-versions = "*"
 files = [
-    {file = "django-rq-2.7.0.tar.gz", hash = "sha256:50440be33c23427f3b34d206ff72025740b721b54b42976e7b18a0474174802b"},
-    {file = "django_rq-2.7.0-py2.py3-none-any.whl", hash = "sha256:5b09798a3d0b03d4c7b55dbba50409c16dcbb09d42c2839511b52c29744be8c8"},
+    {file = "django-rq-2.8.0.tar.gz", hash = "sha256:161fcd037aa837e047400db909d2efa2867294c5efe1c45bcaf8d888ad1839b4"},
+    {file = "django_rq-2.8.0-py2.py3-none-any.whl", hash = "sha256:2820ecefed024a7f14fe42ebc46b22f53bcd84639a79c0a379491c10d82bfaa3"},
 ]
 
 [package.dependencies]

--- a/src/aap_eda/core/tasking/__init__.py
+++ b/src/aap_eda/core/tasking/__init__.py
@@ -6,7 +6,8 @@ from datetime import datetime, timedelta
 from typing import Any, Callable, Iterable, Optional, Protocol, Type, Union
 
 from django_rq import enqueue, get_queue, get_scheduler, job
-from rq import Connection, Queue as _Queue, Worker as _Worker
+from django_rq.queues import Queue as _Queue
+from rq import Connection, Worker as _Worker
 from rq.defaults import (
     DEFAULT_JOB_MONITORING_INTERVAL,
     DEFAULT_RESULT_TTL,

--- a/src/aap_eda/core/tasking/__init__.py
+++ b/src/aap_eda/core/tasking/__init__.py
@@ -124,24 +124,22 @@ class DefaultWorker(_Worker):
             job_class = Job
         if queue_class is None:
             queue_class = Queue
-        if serializer is None:
-            serializer = JSONSerializer
 
         super().__init__(
-            queues,
-            name,
-            default_result_ttl,
-            connection,
-            exc_handler,
-            exception_handlers,
-            default_worker_ttl,
-            job_class,
-            queue_class,
-            log_job_description,
-            job_monitoring_interval,
-            disable_default_exception_handler,
-            prepare_for_work,
-            serializer,
+            queues=queues,
+            name=name,
+            default_result_ttl=default_result_ttl,
+            connection=connection,
+            exc_handler=exc_handler,
+            exception_handlers=exception_handlers,
+            default_worker_ttl=default_worker_ttl,
+            job_class=job_class,
+            queue_class=queue_class,
+            log_job_description=log_job_description,
+            job_monitoring_interval=job_monitoring_interval,
+            disable_default_exception_handler=disable_default_exception_handler,  # noqa: E501
+            prepare_for_work=prepare_for_work,
+            serializer=JSONSerializer,
         )
 
 
@@ -172,24 +170,22 @@ class ActivationWorker(_Worker):
             job_class = Job
         if queue_class is None:
             queue_class = Queue
-        if serializer is None:
-            serializer = JSONSerializer
 
         super().__init__(
-            [Queue(name="activation", connection=connection)],
-            name,
-            default_result_ttl,
-            connection,
-            exc_handler,
-            exception_handlers,
-            default_worker_ttl,
-            job_class,
-            queue_class,
-            log_job_description,
-            job_monitoring_interval,
-            disable_default_exception_handler,
-            prepare_for_work,
-            serializer,
+            queues=[Queue(name="activation", connection=connection)],
+            name=name,
+            default_result_ttl=default_result_ttl,
+            connection=connection,
+            exc_handler=exc_handler,
+            exception_handlers=exception_handlers,
+            default_worker_ttl=default_worker_ttl,
+            job_class=job_class,
+            queue_class=queue_class,
+            log_job_description=log_job_description,
+            job_monitoring_interval=job_monitoring_interval,
+            disable_default_exception_handler=disable_default_exception_handler,  # noqa: E501
+            prepare_for_work=prepare_for_work,
+            serializer=JSONSerializer,
         )
 
 


### PR DESCRIPTION
Fix errors when upgrade django-rq.
- Upgrade django-rq to 2.8
- Custom queue should inherit from django-rq. Ref: https://github.com/rq/django-rq?tab=readme-ov-file#custom-queue-classes
- Use named parameters at instantiation. 

Jira: https://issues.redhat.com/browse/AAP-21969

Probably rq can be upgraded as well with this change, but it's something that I want to test and change separately. 

Example error:
```Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:    utility.execute()
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:  File "/usr/lib/python3.11/site-packages/django/core/management/__init__.py", line 436, in execute
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:    self.fetch_command(subcommand).run_from_argv(self.argv)
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:  File "/usr/lib/python3.11/site-packages/django/core/management/base.py", line 412, in run_from_argv
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:    self.execute(*args, **cmd_options)
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:  File "/usr/lib/python3.11/site-packages/django/core/management/base.py", line 458, in execute
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:    output = self.handle(*args, **options)
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:  File "/usr/lib/python3.11/site-packages/django_rq/management/commands/rqworker.py", line 123, in handle
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:    w = get_worker(*args, **worker_kwargs)
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:  File "/usr/lib/python3.11/site-packages/django_rq/workers.py", line 50, in get_worker
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:    return worker_class(
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:           ^^^^^^^^^^^^^
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:  File "/usr/lib/python3.11/site-packages/aap_eda/core/tasking/__init__.py", line 178, in __init__
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:    super().__init__(
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:  File "/usr/lib/python3.11/site-packages/rq/worker.py", line 242, in __init__
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:    connection = self._set_connection(connection)
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:  File "/usr/lib/python3.11/site-packages/rq/worker.py", line 324, in _set_connection
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:    timeout_config = {"socket_timeout": self.connection_timeout}
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:                                        ^^^^^^^^^^^^^^^^^^^^^^^
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:  File "/usr/lib/python3.11/site-packages/rq/worker.py", line 389, in connection_timeout
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:    return self.dequeue_timeout + 10
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:           ^^^^^^^^^^^^^^^^^^^^
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:  File "/usr/lib/python3.11/site-packages/rq/worker.py", line 385, in dequeue_timeout
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:    return max(1, int(self.default_worker_ttl / 3))
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]:                      ^^^^^^^^^^^^^^^^^^^^^^^
Mar 20 15:56:23 ip-10-0-2-25 automation-eda-controller-activation-worker-4[110666]: AttributeError: 'ActivationWorker' object has no attribute 'default_worker_ttl'. Did you mean: 'default_result_ttl'?
```