### PR TITLE
fix: remove unneeded required fields in credential type's post body

### DIFF
--- a/src/aap_eda/api/serializers/credential_type.py
+++ b/src/aap_eda/api/serializers/credential_type.py
@@ -42,7 +42,7 @@ class CredentialTypeCreateSerializer(serializers.ModelSerializer):
     inputs = serializers.JSONField(
         required=True,
         allow_null=False,
-        help_text="Name of the project",
+        help_text="Name of the credential type",
         validators=[
             validators.check_if_schema_valid,
         ],
@@ -60,20 +60,11 @@ class CredentialTypeCreateSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.CredentialType
-        read_only_fields = [
-            "id",
-            "created_at",
-            "modified_at",
-            "managed",
-            "kind",
-            "namespace",
-        ]
         fields = [
             "name",
             "description",
             "inputs",
             "injectors",
-            *read_only_fields,
         ]
 
 

--- a/src/aap_eda/api/serializers/eda_credential.py
+++ b/src/aap_eda/api/serializers/eda_credential.py
@@ -117,12 +117,6 @@ class EdaCredentialCreateSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.EdaCredential
-        read_only_fields = [
-            "id",
-            "managed",
-            "created_at",
-            "modified_at",
-        ]
         fields = [
             "name",
             "description",

--- a/src/aap_eda/api/views/credential_type.py
+++ b/src/aap_eda/api/views/credential_type.py
@@ -76,7 +76,7 @@ class CredentialTypeViewSet(
 
     @extend_schema(
         description="Create a new credential type.",
-        request=serializers.CredentialTypeSerializer,
+        request=serializers.CredentialTypeCreateSerializer,
         responses={
             status.HTTP_201_CREATED: OpenApiResponse(
                 serializers.CredentialTypeSerializer,


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-22394

The post body is changed as:
```
            "CredentialTypeCreate": {
                "type": "object",
                "properties": {
                    "name": {
                        "type": "string"
                    },
                    "description": {
                        "type": "string"
                    },
                    "inputs": {
                        "type": "object",
                        "additionalProperties": {},
                        "description": "Name of the credential type"
                    },
                    "injectors": {
                        "type": "object",
                        "additionalProperties": {}
                    }
                },
                "required": [
                    "inputs",
                    "name"
                ]
            },
```