### PR TITLE
ci: fix failing docker-compose step

### DIFF
--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -52,8 +52,8 @@ jobs:
           DJANGO_SETTINGS_MODULE: aap_eda.settings.default
           EDA_DEBUG: "false"
         run: |
-          docker-compose -p eda -f docker-compose-dev.yaml build
-          docker-compose -p eda -f docker-compose-dev.yaml up -d
+          docker compose -p eda -f docker-compose-dev.yaml build
+          docker compose -p eda -f docker-compose-dev.yaml up -d
           while ! curl -s http://localhost:8000/_healthz | grep -q "OK"; do
             echo "Waiting for API to be ready..."
             sleep 1
@@ -93,5 +93,5 @@ jobs:
         if: always()
         working-directory: tools/docker
         run: |
-          docker-compose -p eda -f docker-compose-dev.yaml logs
+          docker compose -p eda -f docker-compose-dev.yaml logs
 

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Run api in background
         working-directory: tools/docker
         run: |
-          docker-compose -p eda -f docker-compose-stage.yaml pull
-          docker-compose -p eda -f docker-compose-stage.yaml up -d
+          docker compose -p eda -f docker-compose-stage.yaml pull
+          docker compose -p eda -f docker-compose-stage.yaml up -d
           while ! curl -s http://localhost:8000/_healthz | grep -q "OK"; do
             echo "Waiting for API to be ready..."
             sleep 1
@@ -65,7 +65,7 @@ jobs:
         if: always()
         working-directory: tools/docker
         run: |
-          docker-compose -p eda -f docker-compose-stage.yaml logs
+          docker compose -p eda -f docker-compose-stage.yaml logs
 
       - name: Notify to slack if failure
         if: ${{ failure() }}


### PR DESCRIPTION
- GH deprecated the V1 docker-compose in ubuntu-latest https://github.com/actions/runner-images/issues/9557
- Switched to explicitly use V2 docker compose plugin instead