### PR TITLE
Add user summary fields to be displayed in role_user_assignments

### DIFF
--- a/src/aap_eda/core/models/user.py
+++ b/src/aap_eda/core/models/user.py
@@ -33,6 +33,16 @@ class User(AbstractUser):
     modified_at = models.DateTimeField(auto_now=True, null=False)
     is_service_account = models.BooleanField(default=False)
 
+    def summary_fields(self):
+        return {
+            "id": self.id,
+            "username": self.username,
+            "email": self.email,
+            "first_name": self.first_name,
+            "last_name": self.last_login,
+            "is_superuser": self.is_superuser,
+        }
+
 
 class AwxToken(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE, null=False)


### PR DESCRIPTION
This change is needed to display user details in `summary_fields` in `/role_user_assignments/` endpoints as follows:
```
            "summary_fields": {
                "object_role": {
                    "id": 1
                },
                "role_definition": {
                    "id": 13,
                    "name": "Activation Admin",
                    "description": "Has all permissions to a single activation and its child resources - rulebook process, audit rule",
                    "managed": true
                },
                "user": {
                    "id": 3,
                    "username": "doston",
                    "email": "",
                    "first_name": "",
                    "last_name": null,
                    "is_superuser": false
                }
            },
```