### PR TITLE
chore: remove DELETE activation_instance endpoint

### DIFF
--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -339,20 +339,8 @@ class ActivationViewSet(
             ),
         },
     ),
-    destroy=extend_schema(
-        description="Delete an existing Activation Instance",
-        responses={
-            status.HTTP_204_NO_CONTENT: OpenApiResponse(
-                None,
-                description="The Activation Instance has been deleted.",
-            ),
-        },
-    ),
 )
-class ActivationInstanceViewSet(
-    viewsets.ReadOnlyModelViewSet,
-    mixins.DestroyModelMixin,
-):
+class ActivationInstanceViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.RulebookProcess.objects.all()
     serializer_class = serializers.ActivationInstanceSerializer
     filter_backends = (defaultfilters.DjangoFilterBackend,)

--- a/tests/integration/api/test_activation_instance.py
+++ b/tests/integration/api/test_activation_instance.py
@@ -169,22 +169,6 @@ def test_retrieve_activation_instance_not_exist(client: APIClient):
 
 
 @pytest.mark.django_db
-def test_delete_activation_instance(client: APIClient):
-    activation = prepare_init_data()
-    instance = models.RulebookProcess.objects.create(
-        name="activation-instance",
-        activation=activation,
-    )
-
-    response = client.delete(
-        f"{api_url_v1}/activation-instances/{instance.id}/"
-    )
-    assert response.status_code == status.HTTP_204_NO_CONTENT
-
-    assert models.RulebookProcess.objects.filter(pk=instance.id).count() == 0
-
-
-@pytest.mark.django_db
 def test_list_logs_from_activation_instance(client: APIClient):
     activation = prepare_init_data()
     instance = models.RulebookProcess.objects.create(


### PR DESCRIPTION
DELETE activation_instance endpoint was never needed and we have discussed several times to remove it but never got around to it. 
Jira: https://issues.redhat.com/browse/AAP-22555