### PR TITLE
[RBAC] Remove unused rbac_resource_type params

### DIFF
--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -31,12 +31,7 @@ from rest_framework.response import Response
 from aap_eda.api import exceptions as api_exc, filters, serializers
 from aap_eda.api.serializers.activation import is_activation_valid
 from aap_eda.core import models
-from aap_eda.core.enums import (
-    Action,
-    ActivationStatus,
-    ProcessParentType,
-    ResourceType,
-)
+from aap_eda.core.enums import Action, ActivationStatus, ProcessParentType
 from aap_eda.tasks.orchestrator import (
     delete_rulebook_process,
     restart_rulebook_process,
@@ -67,7 +62,6 @@ class ActivationViewSet(
     filter_backends = (defaultfilters.DjangoFilterBackend,)
     filterset_class = filters.ActivationFilter
 
-    rbac_resource_type = None
     rbac_action = None
 
     def filter_queryset(self, queryset):
@@ -173,7 +167,6 @@ class ActivationViewSet(
         detail=False,
         queryset=models.RulebookProcess.objects.order_by("id"),
         filterset_class=filters.ActivationInstanceFilter,
-        rbac_resource_type=ResourceType.ACTIVATION_INSTANCE,
         rbac_action=Action.READ,
         url_path="(?P<id>[^/.]+)/instances",
     )
@@ -378,7 +371,6 @@ class ActivationInstanceViewSet(
     serializer_class = serializers.ActivationInstanceSerializer
     filter_backends = (defaultfilters.DjangoFilterBackend,)
     filterset_class = filters.ActivationInstanceFilter
-    rbac_resource_type = ResourceType.ACTIVATION_INSTANCE
     rbac_action = None
 
     def filter_queryset(self, queryset):

--- a/src/aap_eda/api/views/decision_environment.py
+++ b/src/aap_eda/api/views/decision_environment.py
@@ -24,7 +24,6 @@ from rest_framework.response import Response
 
 from aap_eda.api import exceptions as api_exc, filters, serializers
 from aap_eda.core import models
-from aap_eda.core.enums import ResourceType
 
 from .mixins import (
     CreateModelMixin,
@@ -76,7 +75,6 @@ class DecisionEnvironmentViewSet(
     queryset = models.DecisionEnvironment.objects.order_by("id")
     filter_backends = (defaultfilters.DjangoFilterBackend,)
     filterset_class = filters.DecisionEnvironmentFilter
-    rbac_resource_type = ResourceType.DECISION_ENVIRONMENT
 
     def filter_queryset(self, queryset):
         return super().filter_queryset(

--- a/src/aap_eda/api/views/eda_credential.py
+++ b/src/aap_eda/api/views/eda_credential.py
@@ -31,7 +31,6 @@ from rest_framework.response import Response
 from aap_eda.api import exceptions, filters, serializers
 from aap_eda.api.serializers.eda_credential import get_references
 from aap_eda.core import models
-from aap_eda.core.enums import ResourceType
 from aap_eda.core.utils.credentials import inputs_to_store
 
 from .mixins import (
@@ -75,9 +74,6 @@ class EdaCredentialViewSet(
                 queryset.model.access_qs(self.request.user, queryset=queryset)
             )
         return super().filter_queryset(queryset)
-
-    rbac_resource_type = ResourceType.EDA_CREDENTIAL
-    rbac_action = None
 
     @extend_schema(
         description="Get EDA credential by id",

--- a/src/aap_eda/api/views/organization.py
+++ b/src/aap_eda/api/views/organization.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from django.shortcuts import get_object_or_404
 from django_filters import rest_framework as defaultfilters
 from drf_spectacular.utils import (
     OpenApiParameter,
@@ -25,7 +24,6 @@ from rest_framework.decorators import action
 
 from aap_eda.api import filters, serializers
 from aap_eda.core import models
-from aap_eda.core.enums import Action, ResourceType
 
 from .mixins import PartialUpdateOnlyModelMixin
 
@@ -72,7 +70,6 @@ class OrganizationViewSet(
     queryset = models.Organization.objects.order_by("id")
     filter_backends = (defaultfilters.DjangoFilterBackend,)
     filterset_class = filters.OrganizationFilter
-    rbac_resource_type = ResourceType.ORGANIZATION
     rbac_action = None
 
     def filter_queryset(self, queryset):
@@ -102,15 +99,13 @@ class OrganizationViewSet(
         ],
     )
     @action(
-        detail=False,
+        detail=True,
+        methods=["get"],
         queryset=models.Team.objects.order_by("id"),
         filterset_class=filters.OrganizationTeamFilter,
-        rbac_resource_type=ResourceType.TEAM,
-        rbac_action=Action.READ,
-        url_path="(?P<id>[^/.]+)/teams",
     )
-    def teams(self, request, id):
-        organization = get_object_or_404(models.Organization, pk=id)
+    def teams(self, request, pk):
+        organization = self.get_object()
 
         teams = models.Team.objects.filter(organization_id=organization.id)
         filtered_teams = self.filter_queryset(teams)

--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -28,7 +28,7 @@ from rest_framework.response import Response
 from aap_eda import tasks
 from aap_eda.api import exceptions as api_exc, filters, serializers
 from aap_eda.core import models
-from aap_eda.core.enums import Action, ResourceType
+from aap_eda.core.enums import Action
 
 from .mixins import CreateModelMixin, ResponseSerializerMixin
 
@@ -70,8 +70,6 @@ class ExtraVarViewSet(
     queryset = models.ExtraVar.objects.order_by("id")
     serializer_class = serializers.ExtraVarSerializer
     http_method_names = ["get", "post"]
-
-    rbac_resource_type = ResourceType.EXTRA_VAR
 
     def filter_queryset(self, queryset):
         return super().filter_queryset(

--- a/src/aap_eda/api/views/rulebook.py
+++ b/src/aap_eda/api/views/rulebook.py
@@ -28,7 +28,7 @@ from rest_framework.filters import OrderingFilter
 
 from aap_eda.api import filters, serializers
 from aap_eda.core import models
-from aap_eda.core.enums import Action, ResourceType
+from aap_eda.core.enums import Action
 
 
 @extend_schema_view(
@@ -71,9 +71,9 @@ class RulebookViewSet(
         request=None,
         responses={status.HTTP_200_OK: serializers.RulebookSerializer},
     )
-    @action(detail=True, rbac_action=Action.READ)
+    @action(detail=True)
     def json(self, request, pk):
-        rulebook = get_object_or_404(self.get_queryset(), pk=pk)
+        rulebook = self.get_object()
         data = serializers.RulebookSerializer(rulebook).data
         data["rulesets"] = yaml.safe_load(data["rulesets"])
 
@@ -132,7 +132,6 @@ class AuditRuleViewSet(
             return serializers.AuditEventSerializer
         return serializers.AuditRuleSerializer
 
-    rbac_resource_type = ResourceType.AUDIT_RULE
     rbac_action = None
 
     @extend_schema(

--- a/src/aap_eda/api/views/team.py
+++ b/src/aap_eda/api/views/team.py
@@ -28,7 +28,6 @@ from aap_eda.api.serializers import (
     TeamUpdateSerializer,
 )
 from aap_eda.core import models
-from aap_eda.core.enums import ResourceType
 
 from .mixins import CreateModelMixin, PartialUpdateOnlyModelMixin
 
@@ -83,7 +82,6 @@ class TeamViewSet(
     queryset = models.Team.objects.order_by("id")
     filter_backends = (defaultfilters.DjangoFilterBackend,)
     filterset_class = TeamFilter
-    rbac_resource_type = ResourceType.TEAM
 
     def filter_queryset(self, queryset):
         return super().filter_queryset(


### PR DESCRIPTION
- Remove `rbac_resource_type` params from views, since with the use of DAB RBAC library, `rbac_resource_type` param is no longer needed in views. 
- Replace `get_object_or_404` with `self.get_object` where necessary to make sure requests go through permission check. 
