### PR TITLE
fix: If the user doesn't provide a type use string as default

### DIFF
--- a/src/aap_eda/api/views/credential_type.py
+++ b/src/aap_eda/api/views/credential_type.py
@@ -91,6 +91,9 @@ class CredentialTypeViewSet(
 
         serializer.is_valid(raise_exception=True)
         serializer.validated_data["kind"] = "cloud"
+        for field in serializer.validated_data["inputs"]["fields"]:
+            if "type" not in field:
+                field["type"] = "string"
         credential_type = serializer.create(serializer.validated_data)
 
         return Response(


### PR DESCRIPTION
When defining the fields for a Credential Type inputs if the user doesn't provide a type, set the type to be string

https://issues.redhat.com/browse/AAP-22587