### PR TITLE
chore: fix the image build for e2e tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ dist
 .idea
 .venv
 venv
+.github

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -47,13 +47,13 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Run api in background
-        working-directory: tools/docker
+        working-directory: .
         env:
           DJANGO_SETTINGS_MODULE: aap_eda.settings.default
           EDA_DEBUG: "false"
         run: |
-          docker compose -p eda -f docker-compose-dev.yaml build
-          docker compose -p eda -f docker-compose-dev.yaml up -d
+          docker compose -p eda -f tools/docker/docker-compose-dev.yaml build
+          docker compose -p eda -f tools/docker/docker-compose-dev.yaml up -d
           while ! curl -s http://localhost:8000/_healthz | grep -q "OK"; do
             echo "Waiting for API to be ready..."
             sleep 1


### PR DESCRIPTION
The image was being built from the tools/docker directory which doesn't have the .dockerignore and the .git
directory was getting included in the image.
Moved the image build to be from the same directory that contains the .dockerignore