### PR TITLE
fix: enroute status path correctly

### DIFF
--- a/src/aap_eda/api/urls.py
+++ b/src/aap_eda/api/urls.py
@@ -24,6 +24,8 @@ from drf_spectacular.views import (
 from rest_framework import routers
 from rest_framework_simplejwt import views as jwt_views
 
+from aap_eda.core import views as core_views
+
 from . import views
 
 router = routers.SimpleRouter()
@@ -70,6 +72,7 @@ openapi_urls = [
 ]
 
 v1_urls = [
+    path("status/", core_views.StatusView.as_view()),
     path("", include(resource_api_urls)),
     path("", include(openapi_urls)),
     path("auth/session/login/", views.SessionLoginView.as_view()),

--- a/src/aap_eda/core/urls.py
+++ b/src/aap_eda/core/urls.py
@@ -3,6 +3,5 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("status/", views.StatusView.as_view()),
     path("_healthz", views.HealthView.as_view()),
 ]

--- a/tests/integration/core/test_views.py
+++ b/tests/integration/core/test_views.py
@@ -2,6 +2,8 @@ import pytest
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from tests.integration.constants import api_url_v1
+
 
 @pytest.mark.django_db
 def test_healthz_view():
@@ -16,6 +18,6 @@ def test_healthz_view():
 def test_status_view():
     client = APIClient()
     client.force_authenticate(user=None)
-    response = client.get("/status/")
+    response = client.get(f"{api_url_v1}/status/")
     assert response.status_code == status.HTTP_200_OK
     assert response.data == {"status": "OK"}


### PR DESCRIPTION
Expose status endpoint inside api/v1
Jira: https://issues.redhat.com/browse/AAP-22421