### PR TITLE
fix: preserve the order of the inputs

### DIFF
--- a/src/aap_eda/core/utils/credentials.py
+++ b/src/aap_eda/core/utils/credentials.py
@@ -64,7 +64,7 @@ def inputs_to_store(inputs: dict, old_inputs_str: str = None) -> str:
     old_inputs.update(
         (k, inputs[k]) for k, v in inputs.items() if v != ENCRYPTED_STRING
     )
-    return yaml.dump(old_inputs)
+    return yaml.dump(old_inputs, sort_keys=False)
 
 
 def inputs_from_store(inputs: str) -> dict:

--- a/tests/integration/api/test_eda_credential.py
+++ b/tests/integration/api/test_eda_credential.py
@@ -514,3 +514,5 @@ def test_retrieve_eda_credential_with_empty_encrypted_fields(
     assert response.status_code == status.HTTP_201_CREATED
     key_list = list(response.data["inputs"].keys())
     assert "ssh_key_unlock" not in key_list
+    assert key_list[0] == "username"
+    assert key_list[1] == "password"


### PR DESCRIPTION
We were using yaml dump which doesn't preserve the order of the keys by default. We have to pass in sort_keys=False so it can preserve the order of keys.

https://issues.redhat.com/browse/AAP-22638