### PR TITLE
Add Resource metadata to users, orgs and teams responses

### DIFF
--- a/src/aap_eda/api/serializers/fields/ansible_resource.py
+++ b/src/aap_eda/api/serializers/fields/ansible_resource.py
@@ -18,7 +18,7 @@ from rest_framework import serializers
 class AnsibleResourceField(serializers.Field):
     """Serializer for Ansible Resource Field."""
 
-    def to_representation(self, instance) -> str:
+    def to_representation(self, instance) -> dict:
         return {
             "ansible_id": instance.ansible_id,
             "resource_type": instance.resource_type,

--- a/src/aap_eda/api/serializers/fields/ansible_resource.py
+++ b/src/aap_eda/api/serializers/fields/ansible_resource.py
@@ -11,16 +11,15 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+#
+from rest_framework import serializers
 
-from ansible_base.lib.abstract_models import AbstractTeam
-from ansible_base.resource_registry.fields import AnsibleResourceField
 
+class AnsibleResourceField(serializers.Field):
+    """Serializer for Ansible Resource Field."""
 
-class Team(AbstractTeam):
-    resource = AnsibleResourceField(primary_key_field="id")
-
-    class Meta(AbstractTeam.Meta):
-        app_label = "core"
-        permissions = [
-            ("member_team", "Inherit all roles assigned to this team")
-        ]
+    def to_representation(self, instance) -> str:
+        return {
+            "ansible_id": instance.ansible_id,
+            "resource_type": instance.resource_type,
+        }

--- a/src/aap_eda/api/serializers/organization.py
+++ b/src/aap_eda/api/serializers/organization.py
@@ -16,9 +16,13 @@ from ansible_base.lib.serializers.common import NamedCommonModelSerializer
 
 from aap_eda.core.models import Organization
 
+from .fields.ansible_resource import AnsibleResourceField
+
 
 class OrganizationSerializer(NamedCommonModelSerializer):
     reverse_url_name = "organization-detail"
+
+    resource = AnsibleResourceField(read_only=True)
 
     class Meta:
         model = Organization
@@ -26,6 +30,7 @@ class OrganizationSerializer(NamedCommonModelSerializer):
             "id",
             "name",
             "description",
+            "resource",
             "created",
             "created_by",
             "modified",

--- a/src/aap_eda/api/serializers/team.py
+++ b/src/aap_eda/api/serializers/team.py
@@ -16,8 +16,12 @@ from rest_framework import serializers
 from aap_eda.api.serializers.organization import OrganizationRefSerializer
 from aap_eda.core import models
 
+from .fields.ansible_resource import AnsibleResourceField
+
 
 class TeamSerializer(serializers.ModelSerializer):
+    resource = AnsibleResourceField(read_only=True)
+
     class Meta:
         model = models.Team
         fields = [
@@ -25,6 +29,7 @@ class TeamSerializer(serializers.ModelSerializer):
             "name",
             "description",
             "organization_id",
+            "resource",
             "created",
             "created_by",
             "modified",
@@ -46,6 +51,7 @@ class TeamCreateSerializer(serializers.ModelSerializer):
 
 class TeamDetailSerializer(serializers.ModelSerializer):
     organization = OrganizationRefSerializer()
+    resource = AnsibleResourceField(read_only=True)
 
     class Meta:
         model = models.Team
@@ -54,6 +60,7 @@ class TeamDetailSerializer(serializers.ModelSerializer):
             "name",
             "description",
             "organization",
+            "resource",
             "created",
             "created_by",
             "modified",

--- a/src/aap_eda/api/serializers/user.py
+++ b/src/aap_eda/api/serializers/user.py
@@ -4,11 +4,22 @@ from rest_framework import serializers
 from aap_eda.api.exceptions import Conflict
 from aap_eda.core import models
 
+from .fields.ansible_resource import AnsibleResourceField
+
 
 class UserSerializer(serializers.ModelSerializer):
+    resource = AnsibleResourceField(read_only=True)
+
     class Meta:
         model = models.User
-        fields = "__all__"
+        fields = [
+            "id",
+            "username",
+            "first_name",
+            "last_name",
+            "is_superuser",
+            "resource",
+        ]
 
 
 class UserDetailSerializer(serializers.ModelSerializer):
@@ -16,6 +27,7 @@ class UserDetailSerializer(serializers.ModelSerializer):
         help_text="The user's log in name.",
     )
     created_at = serializers.DateTimeField(source="date_joined")
+    resource = AnsibleResourceField(read_only=True)
 
     class Meta:
         model = models.User
@@ -26,6 +38,7 @@ class UserDetailSerializer(serializers.ModelSerializer):
             "first_name",
             "last_name",
             "is_superuser",
+            "resource",
             "created_at",
             "modified_at",
         ]
@@ -55,6 +68,8 @@ class UserListSerializer(serializers.Serializer):
         required=True,
         help_text="The user is a superuser.",
     )
+
+    resource = AnsibleResourceField(read_only=True)
 
 
 class UserUpdateSerializerBase(serializers.ModelSerializer):

--- a/src/aap_eda/core/models/organization.py
+++ b/src/aap_eda/core/models/organization.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 from ansible_base.lib.abstract_models.organization import AbstractOrganization
+from ansible_base.resource_registry.fields import AnsibleResourceField
 from django.conf import settings
 from django.db import models
 
@@ -24,6 +25,8 @@ class OrganizationManager(models.Manager):
 
 class Organization(AbstractOrganization):
     objects = OrganizationManager()
+
+    resource = AnsibleResourceField(primary_key_field="id")
 
     class Meta:
         app_label = "core"

--- a/src/aap_eda/core/models/user.py
+++ b/src/aap_eda/core/models/user.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from ansible_base.resource_registry.fields import AnsibleResourceField
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 
@@ -31,6 +32,7 @@ class User(AbstractUser):
 
     modified_at = models.DateTimeField(auto_now=True, null=False)
     is_service_account = models.BooleanField(default=False)
+    resource = AnsibleResourceField(primary_key_field="id")
 
     def summary_fields(self):
         return {

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -28,6 +28,17 @@ DUMMY_UUID = "8472ff2c-6045-4418-8d4e-46f6cffc8557"
 
 
 @pytest.fixture
+def super_user():
+    """Return a user with is_superuser=True flag."""
+    return models.User.objects.create_user(
+        username="superuser",
+        password="superuser123",
+        email="superuser@localhost",
+        is_superuser=True,
+    )
+
+
+@pytest.fixture
 def admin_user(default_organization):
     user = models.User.objects.create_user(
         username=ADMIN_USERNAME,

--- a/tests/integration/api/test_organization.py
+++ b/tests/integration/api/test_organization.py
@@ -1,0 +1,132 @@
+#  Copyright 2024 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Any, Dict
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from aap_eda.core import models
+from tests.integration.constants import api_url_v1
+
+
+@pytest.mark.django_db
+def test_list_organizations(
+    default_organization: models.Organization, client: APIClient
+):
+    response = client.get(f"{api_url_v1}/organizations/")
+    assert response.status_code == status.HTTP_200_OK
+    result = response.data["results"][0]
+    assert_organization_data(result, default_organization)
+
+
+@pytest.mark.django_db
+def test_create_organization(
+    base_client: APIClient,
+    super_user: models.User,
+):
+    base_client.force_authenticate(user=super_user)
+    data_in = {
+        "name": "test-organization",
+        "description": "Test Organization",
+    }
+    response = base_client.post(f"{api_url_v1}/organizations/", data=data_in)
+    assert response.status_code == status.HTTP_201_CREATED
+    org_id = response.data["id"]
+    result = response.data
+    assert result["name"] == data_in["name"]
+    assert result["description"] == data_in["description"]
+    assert models.Organization.objects.filter(pk=org_id).exists()
+
+
+@pytest.mark.django_db
+def test_retrieve_organization(
+    default_organization: models.Organization, client: APIClient
+):
+    response = client.get(
+        f"{api_url_v1}/organizations/{default_organization.id}/"
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    assert_organization_data(response.data, default_organization)
+
+
+@pytest.mark.django_db
+def test_retrieve_organization_not_exist(client: APIClient):
+    response = client.get(f"{api_url_v1}/organizations/42/")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_partial_update_organization(
+    default_organization: models.Organization,
+    client: APIClient,
+):
+    new_data = {"name": "new-name", "description": "New Description"}
+    response = client.patch(
+        f"{api_url_v1}/organizations/{default_organization.id}/", data=new_data
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    default_organization.refresh_from_db()
+    assert_organization_data(response.data, default_organization)
+
+
+@pytest.mark.django_db
+def test_delete_organization_success(
+    default_organization: models.Organization, client: APIClient
+):
+    response = client.delete(
+        f"{api_url_v1}/organizations/{default_organization.id}/"
+    )
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    assert (
+        models.Organization.objects.filter(
+            pk=int(default_organization.id)
+        ).count()
+        == 0
+    )
+
+
+@pytest.mark.django_db
+def test_delete_organization_not_exist(client: APIClient):
+    response = client.delete(f"{api_url_v1}/organizations/100/")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+def assert_organization_data(
+    response: Dict[str, Any], expected: models.Organization
+):
+    assert response["id"] == expected.id
+    assert response["name"] == expected.name
+    assert response["description"] == expected.description
+    assert response["resource"] == {
+        "ansible_id": expected.resource.ansible_id,
+        "resource_type": expected.resource.resource_type,
+    }
+    assert response["created"] == expected.created.strftime(DATETIME_FORMAT)
+    if expected.created_by:
+        assert response["created_by"] == expected.created_by.id
+    else:
+        assert response["created_by"] == expected.created_by
+    assert response["modified"] == expected.modified.strftime(DATETIME_FORMAT)
+    if expected.modified_by:
+        assert response["modified_by"] == expected.modified_by.id
+    else:
+        assert response["modified_by"] == expected.modified_by

--- a/tests/integration/api/test_team.py
+++ b/tests/integration/api/test_team.py
@@ -1,0 +1,126 @@
+#  Copyright 2024 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Any, Dict
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from aap_eda.core import models
+from tests.integration.constants import api_url_v1
+
+
+@pytest.mark.django_db
+def test_list_teams(default_team: models.Team, client: APIClient):
+    response = client.get(f"{api_url_v1}/teams/")
+    assert response.status_code == status.HTTP_200_OK
+    result = response.data["results"][0]
+    assert_team_data(result, default_team)
+
+
+@pytest.mark.django_db
+def test_create_team(
+    default_organization: models.Organization,
+    client: APIClient,
+):
+    data_in = {
+        "name": "test-team",
+        "description": "Test Team",
+        "organization_id": default_organization.id,
+    }
+    response = client.post(f"{api_url_v1}/teams/", data=data_in)
+    assert response.status_code == status.HTTP_201_CREATED
+    team_id = response.data["id"]
+    result = response.data
+    assert result["name"] == data_in["name"]
+    assert result["description"] == data_in["description"]
+    assert result["organization_id"] == default_organization.id
+    assert models.Team.objects.filter(pk=team_id).exists()
+
+
+@pytest.mark.django_db
+def test_retrieve_team(default_team: models.Team, client: APIClient):
+    response = client.get(f"{api_url_v1}/teams/{default_team.id}/")
+    assert response.status_code == status.HTTP_200_OK
+
+    assert_team_data(response.data, default_team)
+
+
+@pytest.mark.django_db
+def test_retrieve_team_not_exist(client: APIClient):
+    response = client.get(f"{api_url_v1}/teams/42/")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_partial_update_team(
+    default_team: models.Team,
+    client: APIClient,
+):
+    new_data = {"name": "new-name", "description": "New Description"}
+    response = client.patch(
+        f"{api_url_v1}/teams/{default_team.id}/", data=new_data
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    default_team.refresh_from_db()
+    assert_team_data(response.data, default_team)
+
+
+@pytest.mark.django_db
+def test_delete_team_success(default_team: models.Team, client: APIClient):
+    response = client.delete(f"{api_url_v1}/teams/{default_team.id}/")
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    assert models.Team.objects.filter(pk=int(default_team.id)).count() == 0
+
+
+@pytest.mark.django_db
+def test_delete_team_not_exist(client: APIClient):
+    response = client.delete(f"{api_url_v1}/teams/100/")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+def assert_team_data(response: Dict[str, Any], expected: models.Team):
+    assert response["id"] == expected.id
+    assert response["name"] == expected.name
+    assert response["description"] == expected.description
+    if "organization_id" in response:
+        assert response["organization_id"] == expected.organization.id
+    elif "organization" in response:
+        assert response["organization"] == {
+            "id": expected.organization.id,
+            "name": expected.organization.name,
+            "description": expected.organization.description,
+        }
+    else:
+        AssertionError()  # fail if team has no organization
+    assert response["resource"] == {
+        "ansible_id": expected.resource.ansible_id,
+        "resource_type": expected.resource.resource_type,
+    }
+    assert response["created"] == expected.created.strftime(DATETIME_FORMAT)
+    if expected.created_by:
+        assert response["created_by"] == expected.created_by.id
+    else:
+        assert response["created_by"] == expected.created_by
+    assert response["modified"] == expected.modified.strftime(DATETIME_FORMAT)
+    if expected.modified_by:
+        assert response["modified_by"] == expected.modified_by.id
+    else:
+        assert response["modified_by"] == expected.modified_by

--- a/tests/integration/api/test_user.py
+++ b/tests/integration/api/test_user.py
@@ -37,6 +37,10 @@ def test_retrieve_current_user(client: APIClient, admin_user: models.User):
         "last_name": admin_user.last_name,
         "email": admin_user.email,
         "is_superuser": admin_user.is_superuser,
+        "resource": {
+            "ansible_id": str(admin_user.resource.ansible_id),
+            "resource_type": admin_user.resource.resource_type,
+        },
         "created_at": admin_user.date_joined.strftime(DATETIME_FORMAT),
         "modified_at": admin_user.modified_at.strftime(DATETIME_FORMAT),
     }
@@ -185,6 +189,10 @@ def test_list_users(
         "first_name": admin_user.first_name,
         "last_name": admin_user.last_name,
         "is_superuser": admin_user.is_superuser,
+        "resource": {
+            "ansible_id": str(admin_user.resource.ansible_id),
+            "resource_type": admin_user.resource.resource_type,
+        },
     }
 
 
@@ -206,6 +214,10 @@ def test_partial_update_user(
         "last_name": updated_user.last_name,
         "email": updated_user.email,
         "is_superuser": admin_user.is_superuser,
+        "resource": {
+            "ansible_id": str(admin_user.resource.ansible_id),
+            "resource_type": admin_user.resource.resource_type,
+        },
         "created_at": updated_user.date_joined.strftime(DATETIME_FORMAT),
         "modified_at": updated_user.modified_at.strftime(DATETIME_FORMAT),
     }
@@ -259,6 +271,10 @@ def test_list_users_filter_username(
         "first_name": admin_user.first_name,
         "last_name": admin_user.last_name,
         "is_superuser": admin_user.is_superuser,
+        "resource": {
+            "ansible_id": str(admin_user.resource.ansible_id),
+            "resource_type": admin_user.resource.resource_type,
+        },
     }
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -204,6 +204,16 @@ def default_organization() -> models.Organization:
 
 
 @pytest.fixture
+def default_team(default_organization: models.Organization) -> models.Team:
+    """Return a default team in default_organization."""
+    return models.Team.objects.create(
+        name="Default Team",
+        description="This is a default team.",
+        organization=default_organization,
+    )
+
+
+@pytest.fixture
 def preseed_credential_types(
     default_organization: models.Organization,
 ) -> list[models.CredentialType]:


### PR DESCRIPTION
This adds `resource` field in Users, Organizations and Teams responses from API endpoints which will have JSON object format similar to the following:
```
"resource": {
        "ansible_id": "f1434576-a0ec-4bff-b2eb-3da2a5ec18f3",
        "resource_type": "shared.team"
},
```
Sample data from shared resource responses
Users
```
{
    "id": 1,
    "username": "admin",
    "first_name": "admin",
    "last_name": "",
    "is_superuser": true,
    "resource": {
        "ansible_id": "d9ef64a5-524c-45bc-be86-f8c43196cc31",
        "resource_type": "shared.user"
    }
}
```
Organizations
```
{
    "id": 1,
    "name": "Default",
    "description": "The default organization",
    "resource": {
        "ansible_id": "088eb81c-ba52-466f-be26-cb474e6e466d",
        "resource_type": "shared.organization"
    },
    "created": "2024-04-11T15:59:54.744499Z",
    "created_by": null,
    "modified": "2024-04-11T15:59:54.744505Z",
    "modified_by": null
}
```
Teams
```
{
    "id": 1,
    "name": "Team A",
    "description": "",
    "organization_id": 1,
    "resource": {
        "ansible_id": "f1434576-a0ec-4bff-b2eb-3da2a5ec18f3",
        "resource_type": "shared.team"
    },
    "created": "2024-04-11T21:08:41.492602Z",
    "created_by": 1,
    "modified": "2024-04-12T01:28:24.834454Z",
    "modified_by": 1
}
```

In addition, added missing tests modules for teams and organizations views.

JIRA: [AAP-21101](https://issues.redhat.com/browse/AAP-21101)