### PR TITLE
refactor: move out status management into StatusManager

### DIFF
--- a/src/aap_eda/services/activation/manager.py
+++ b/src/aap_eda/services/activation/manager.py
@@ -76,7 +76,58 @@ def run_with_lock(func: tp.Callable) -> tp.Callable:
     return _run_with_lock
 
 
-class ActivationManager:
+class StatusManager:
+    """Status Manager manages the status of a process parent.
+
+    The Status Manager is responsible for updating the status
+    of the process parent and its latest instance.
+    """
+
+    def __init__(
+        self,
+        db_instance: tp.Union[models.Activation, models.EventStream],
+    ):
+        """Initialize the Process Parent Status Manager.
+
+        Args:
+            db_instance: The database instance of the process parent.
+        """
+        self.db_instance = db_instance
+        if isinstance(db_instance, models.Activation):
+            self.db_instance_type = ProcessParentType.ACTIVATION
+        else:
+            self.db_instance_type = ProcessParentType.EVENT_STREAM
+
+    @property
+    def latest_instance(self) -> tp.Optional[models.RulebookProcess]:
+        """Return the latest instance of the activation."""
+        return self.db_instance.latest_instance
+
+    def set_latest_instance_status(
+        self,
+        status: ActivationStatus,
+        status_message: tp.Optional[str] = None,
+    ):
+        """Set the status of the process parent instance from the manager."""
+        kwargs = {"status": status}
+        if status_message:
+            kwargs["status_message"] = status_message
+        self.latest_instance.update_status(**kwargs)
+
+    @run_with_lock
+    def set_status(
+        self,
+        status: ActivationStatus,
+        status_message: tp.Optional[str] = None,
+    ) -> None:
+        """Set the status from the manager."""
+        kwargs = {"status": status}
+        if status_message:
+            kwargs["status_message"] = status_message
+        self.db_instance.update_status(**kwargs)
+
+
+class ActivationManager(StatusManager):
     """Activation Manager manages the lifecycle of an activation.
 
     The Activation Manager is responsible for starting, stopping, restarting
@@ -99,11 +150,7 @@ class ActivationManager:
             db_instance: The database instance of the activation.
             container_engine: The container engine to use.
         """
-        self.db_instance = db_instance
-        if isinstance(db_instance, models.Activation):
-            self.db_instance_type = ProcessParentType.ACTIVATION
-        else:
-            self.db_instance_type = ProcessParentType.EVENT_STREAM
+        super().__init__(db_instance)
         if container_engine:
             self.container_engine = container_engine
         else:
@@ -113,28 +160,11 @@ class ActivationManager:
 
         self.container_logger_class = container_logger_class
 
-    @property
-    def latest_instance(self) -> tp.Optional[models.RulebookProcess]:
-        """Return the latest instance of the activation."""
-        return self.db_instance.latest_instance
-
     def _set_activation_pod_id(self, pod_id: tp.Optional[str]) -> None:
         """Set the pod id of the activation instance."""
         # TODO: implement db locking?
         self.latest_instance.activation_pod_id = pod_id
         self.latest_instance.save(update_fields=["activation_pod_id"])
-
-    def _set_latest_instance_status(
-        self,
-        status: ActivationStatus,
-        status_message: tp.Optional[str] = None,
-    ):
-        """Set the status of the activation instance from the manager."""
-        # TODO: implement db locking?
-        kwargs = {"status": status}
-        if status_message:
-            kwargs["status_message"] = status_message
-        self.latest_instance.update_status(**kwargs)
 
     @run_with_lock
     def _increase_failure_count(self):
@@ -153,18 +183,6 @@ class ActivationManager:
         """Increase the restart count of the activation."""
         self.db_instance.restart_count += 1
         self.db_instance.save(update_fields=["restart_count", "modified_at"])
-
-    @run_with_lock
-    def _set_activation_status(
-        self,
-        status: ActivationStatus,
-        status_message: tp.Optional[str] = None,
-    ) -> None:
-        """Set the status from the manager."""
-        kwargs = {"status": status}
-        if status_message:
-            kwargs["status_message"] = status_message
-        self.db_instance.update_status(**kwargs)
 
     @run_with_lock
     def _check_start_prerequirements(self) -> None:
@@ -199,7 +217,7 @@ class ActivationManager:
                 f"Reason: {error}"
             )
             LOGGER.error(msg)
-            self._set_activation_status(ActivationStatus.ERROR, msg)
+            self.set_status(ActivationStatus.ERROR, msg)
             raise exceptions.ActivationStartError(msg)
 
     def _check_latest_instance(self) -> None:
@@ -238,7 +256,7 @@ class ActivationManager:
                 )
                 LOGGER.warning(msg)
                 self._cleanup()
-                self._set_latest_instance_status(ActivationStatus.STOPPED)
+                self.set_latest_instance_status(ActivationStatus.STOPPED)
                 self._set_activation_pod_id(pod_id=None)
 
     def _start_activation_instance(self):
@@ -247,7 +265,7 @@ class ActivationManager:
         Update the status of the activation, latest instance, logs,
         counters and pod id.
         """
-        self._set_activation_status(ActivationStatus.STARTING)
+        self.set_status(ActivationStatus.STARTING)
 
         # Ensure status of previous instances
         # For consistency, we should not have previous instances in
@@ -312,8 +330,8 @@ class ActivationManager:
             raise exceptions.ActivationStartError(msg) from exc
 
         # update status
-        self._set_activation_status(ActivationStatus.RUNNING)
-        self._set_latest_instance_status(ActivationStatus.RUNNING)
+        self.set_status(ActivationStatus.RUNNING)
+        self.set_latest_instance_status(ActivationStatus.RUNNING)
         self._set_activation_pod_id(pod_id=container_id)
         self._reset_failure_count()
 
@@ -446,7 +464,7 @@ class ActivationManager:
             )
             container_logger.write(user_msg, flush=True)
             self._fail_instance(user_msg)
-            self._set_activation_status(
+            self.set_status(
                 ActivationStatus.FAILED,
                 user_msg,
             )
@@ -464,7 +482,7 @@ class ActivationManager:
             )
             container_logger.write(user_msg, flush=True)
             self._fail_instance(msg=user_msg)
-            self._set_activation_status(
+            self.set_status(
                 ActivationStatus.FAILED,
                 user_msg,
             )
@@ -488,7 +506,7 @@ class ActivationManager:
             )
             LOGGER.error(msg)
             # Alex: Not sure if we want to change the status here.
-            self._set_activation_status(ActivationStatus.ERROR, msg)
+            self.set_status(ActivationStatus.ERROR, msg)
             raise exceptions.ActivationMonitorError(msg) from exc
 
         if self.db_instance.restart_policy == RestartPolicy.NEVER:
@@ -499,7 +517,7 @@ class ActivationManager:
                 self.db_instance_type, self.db_instance.id, delay_seconds=1
             )
 
-        self._set_activation_status(
+        self.set_status(
             ActivationStatus.FAILED,
             msg,
         )
@@ -530,11 +548,11 @@ class ActivationManager:
             if container_msg:
                 user_msg = f"{container_msg} {user_msg}"
             container_logger.write(user_msg, flush=True)
-            self._set_latest_instance_status(
+            self.set_latest_instance_status(
                 ActivationStatus.COMPLETED,
                 user_msg,
             )
-            self._set_activation_status(
+            self.set_status(
                 ActivationStatus.COMPLETED,
                 user_msg,
             )
@@ -555,11 +573,11 @@ class ActivationManager:
             )
             if container_msg:
                 user_msg = f"{container_msg} {user_msg}"
-            self._set_latest_instance_status(
+            self.set_latest_instance_status(
                 ActivationStatus.COMPLETED,
                 user_msg,
             )
-            self._set_activation_status(
+            self.set_status(
                 ActivationStatus.COMPLETED,
                 user_msg,
             )
@@ -584,7 +602,7 @@ class ActivationManager:
             container_logger.write(user_msg, flush=True)
             try:
                 self._fail_instance(user_msg)
-                self._set_activation_status(
+                self.set_status(
                     ActivationStatus.FAILED,
                     user_msg,
                 )
@@ -596,7 +614,7 @@ class ActivationManager:
                 LOGGER.error(msg)
                 # Alex: Not sure if we want to change the status here.
                 self._error_instance(msg)
-                self._set_activation_status(ActivationStatus.ERROR, msg)
+                self.set_status(ActivationStatus.ERROR, msg)
                 raise exceptions.ActivationMonitorError(msg) from exc
 
         # No restart if it has reached the maximum number of restarts
@@ -619,7 +637,7 @@ class ActivationManager:
             container_logger.write(user_msg, flush=True)
             try:
                 self._fail_instance(user_msg)
-                self._set_activation_status(
+                self.set_status(
                     ActivationStatus.FAILED,
                     user_msg,
                 )
@@ -631,7 +649,7 @@ class ActivationManager:
                 LOGGER.error(msg)
                 # Alex: Not sure if we want to change the status here.
                 self._error_instance(msg)
-                self._set_activation_status(ActivationStatus.ERROR, msg)
+                self.set_status(ActivationStatus.ERROR, msg)
                 raise exceptions.ActivationMonitorError(msg) from exc
         # Restart
         else:
@@ -651,7 +669,7 @@ class ActivationManager:
             container_logger.write(user_msg, flush=True)
             try:
                 self._fail_instance(user_msg)
-                self._set_activation_status(
+                self.set_status(
                     ActivationStatus.FAILED,
                     user_msg,
                 )
@@ -662,8 +680,8 @@ class ActivationManager:
                 )
                 LOGGER.error(msg)
                 # Alex: Not sure if we want to change the status here.
-                self._set_activation_status(ActivationStatus.ERROR, msg)
-                self._set_latest_instance_status(
+                self.set_status(ActivationStatus.ERROR, msg)
+                self.set_latest_instance_status(
                     ActivationStatus.ERROR,
                     msg,
                 )
@@ -686,7 +704,7 @@ class ActivationManager:
         if msg:
             kwargs["status_message"] = msg
         self._cleanup()
-        self._set_latest_instance_status(ActivationStatus.FAILED, **kwargs)
+        self.set_latest_instance_status(ActivationStatus.FAILED, **kwargs)
         self._set_activation_pod_id(pod_id=None)
         self._increase_failure_count()
 
@@ -696,19 +714,19 @@ class ActivationManager:
         if msg:
             kwargs["status_message"] = msg
         self._cleanup()
-        self._set_latest_instance_status(ActivationStatus.ERROR, **kwargs)
+        self.set_latest_instance_status(ActivationStatus.ERROR, **kwargs)
         self._set_activation_pod_id(pod_id=None)
 
     def _stop_instance(self):
         """Stop the latest activation instance."""
-        self._set_latest_instance_status(ActivationStatus.STOPPING)
+        self.set_latest_instance_status(ActivationStatus.STOPPING)
         self._cleanup()
-        self._set_latest_instance_status(ActivationStatus.STOPPED)
+        self.set_latest_instance_status(ActivationStatus.STOPPED)
         self._set_activation_pod_id(pod_id=None)
 
     def _error_activation(self, msg: str):
         LOGGER.error(msg)
-        self._set_activation_status(ActivationStatus.ERROR, msg)
+        self.set_status(ActivationStatus.ERROR, msg)
 
     def start(self, is_restart: bool = False):
         """Start an activation.
@@ -773,11 +791,11 @@ class ActivationManager:
                 f"Stop operation activation id: {self.db_instance.id} "
                 "No instance found.",
             )
-            self._set_activation_status(ActivationStatus.STOPPED)
+            self.set_status(ActivationStatus.STOPPED)
             return
 
         try:
-            self._set_activation_status(ActivationStatus.STOPPING)
+            self.set_status(ActivationStatus.STOPPING)
             self._stop_instance()
 
         except engine_exceptions.ContainerEngineError as exc:
@@ -789,7 +807,7 @@ class ActivationManager:
             self._error_activation(msg)
             raise exceptions.ActivationStopError(msg) from exc
         user_msg = "Stop requested by user."
-        self._set_activation_status(ActivationStatus.STOPPED, user_msg)
+        self.set_status(ActivationStatus.STOPPED, user_msg)
         container_logger = self.container_logger_class(self.latest_instance.id)
         container_logger.write(user_msg, flush=True)
         LOGGER.info(
@@ -812,7 +830,7 @@ class ActivationManager:
             "Activation restart scheduled for 1 second.",
         )
         user_msg = "Restart requested by user. "
-        self._set_activation_status(ActivationStatus.PENDING, user_msg)
+        self.set_status(ActivationStatus.PENDING, user_msg)
         container_logger.write(user_msg, flush=True)
         system_restart_activation(
             self.db_instance_type, self.db_instance.id, delay_seconds=1
@@ -972,8 +990,8 @@ class ActivationManager:
                     "Activation is in WORKERS_OFFLINE state. "
                     "Setting activation and instance status to running.",
                 )
-                self._set_activation_status(ActivationStatus.RUNNING)
-                self._set_latest_instance_status(ActivationStatus.RUNNING)
+                self.set_status(ActivationStatus.RUNNING)
+                self.set_latest_instance_status(ActivationStatus.RUNNING)
             msg = (
                 f"Monitor operation: activation id: {self.db_instance.id} "
                 "Container is running. "
@@ -1102,6 +1120,6 @@ class ActivationManager:
                 f"{self.db_instance_type} {self.db_instance.id} is postponed"
             )
             LOGGER.info(msg)
-            self._set_activation_status(ActivationStatus.PENDING, msg)
+            self.set_status(ActivationStatus.PENDING, msg)
             return False
         return True

--- a/src/aap_eda/services/activation/status_manager.py
+++ b/src/aap_eda/services/activation/status_manager.py
@@ -1,0 +1,104 @@
+#  Copyright 2024 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Module for Activation Manager."""
+
+import logging
+import typing as tp
+from functools import wraps
+
+from django.db import transaction
+
+from aap_eda.core import models
+from aap_eda.core.enums import ActivationStatus, ProcessParentType
+
+LOGGER = logging.getLogger(__name__)
+
+
+class HasDbInstance(tp.Protocol):
+    db_instance: tp.Any
+
+
+def run_with_lock(func: tp.Callable) -> tp.Callable:
+    """Run a method with a lock on the database instance."""
+
+    @wraps(func)
+    def _run_with_lock(self: HasDbInstance, *args, **kwargs):
+        with transaction.atomic():
+            locked_instance = (
+                type(self.db_instance)
+                .objects.select_for_update()
+                .get(pk=self.db_instance.pk)
+            )
+
+            original_instance = self.db_instance
+            self.db_instance = locked_instance
+
+            try:
+                return func(self, *args, **kwargs)
+            finally:
+                self.db_instance = original_instance
+                self.db_instance.refresh_from_db()
+
+    return _run_with_lock
+
+
+class StatusManager:
+    """Status Manager manages the status of a process parent.
+
+    The Status Manager is responsible for updating the status
+    of the process parent and its latest instance.
+    """
+
+    def __init__(
+        self,
+        db_instance: tp.Union[models.Activation, models.EventStream],
+    ):
+        """Initialize the Process Parent Status Manager.
+
+        Args:
+            db_instance: The database instance of the process parent.
+        """
+        self.db_instance = db_instance
+        if isinstance(db_instance, models.Activation):
+            self.db_instance_type = ProcessParentType.ACTIVATION
+        else:
+            self.db_instance_type = ProcessParentType.EVENT_STREAM
+
+    @property
+    def latest_instance(self) -> tp.Optional[models.RulebookProcess]:
+        """Return the latest instance of the activation."""
+        return self.db_instance.latest_instance
+
+    def set_latest_instance_status(
+        self,
+        status: ActivationStatus,
+        status_message: tp.Optional[str] = None,
+    ):
+        """Set the status of the process parent instance from the manager."""
+        kwargs = {"status": status}
+        if status_message:
+            kwargs["status_message"] = status_message
+        self.latest_instance.update_status(**kwargs)
+
+    @run_with_lock
+    def set_status(
+        self,
+        status: ActivationStatus,
+        status_message: tp.Optional[str] = None,
+    ) -> None:
+        """Set the status from the manager."""
+        kwargs = {"status": status}
+        if status_message:
+            kwargs["status_message"] = status_message
+        self.db_instance.update_status(**kwargs)

--- a/src/aap_eda/tasks/orchestrator.py
+++ b/src/aap_eda/tasks/orchestrator.py
@@ -32,7 +32,10 @@ from aap_eda.core.enums import (
 from aap_eda.core.models import Activation, ActivationRequestQueue, EventStream
 from aap_eda.core.tasking import unique_enqueue
 from aap_eda.services.activation import exceptions
-from aap_eda.services.activation.manager import ActivationManager
+from aap_eda.services.activation.manager import (
+    ActivationManager,
+    StatusManager,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -206,19 +209,14 @@ def dispatch(
                 "There might be a problem in the node, please contact "
                 "the administrator."
             )
-            # TODO: I use an empty container engine because it's not
-            # used to update the status of this case. This is a workaround
-            # Refactor the ActivationManager to avoid this.
-            # jira: https://issues.redhat.com/browse/AAP-22423
-            manager = ActivationManager(
+            status_manager = StatusManager(
                 get_process_parent(process_parent_type, process_parent_id),
-                container_engine=object(),
             )
-            manager._set_activation_status(
+            status_manager.set_status(
                 ActivationStatus.WORKERS_OFFLINE,
                 msg,
             )
-            manager._set_latest_instance_status(
+            status_manager.set_latest_instance_status(
                 ActivationStatus.WORKERS_OFFLINE,
                 msg,
             )

--- a/src/aap_eda/tasks/orchestrator.py
+++ b/src/aap_eda/tasks/orchestrator.py
@@ -32,7 +32,7 @@ from aap_eda.core.enums import (
 from aap_eda.core.models import Activation, ActivationRequestQueue, EventStream
 from aap_eda.core.tasking import unique_enqueue
 from aap_eda.services.activation import exceptions
-from aap_eda.services.activation.manager import (
+from aap_eda.services.activation.activation_manager import (
     ActivationManager,
     StatusManager,
 )

--- a/tests/integration/services/activation/test_manager.py
+++ b/tests/integration/services/activation/test_manager.py
@@ -23,17 +23,17 @@ from pytest_django.fixtures import SettingsWrapper
 from pytest_lazyfixture import lazy_fixture
 
 from aap_eda.core import enums, models
+from aap_eda.services.activation.activation_manager import (
+    LOGGER,
+    ActivationManager,
+    exceptions,
+)
 from aap_eda.services.activation.engine import exceptions as engine_exceptions
 from aap_eda.services.activation.engine.common import (
     ContainerEngine,
     ContainerRequest,
 )
-from aap_eda.services.activation.manager import (
-    LOGGER,
-    ActivationManager,
-    StatusManager,
-    exceptions,
-)
+from aap_eda.services.activation.status_manager import StatusManager
 
 
 def apply_settings(settings: SettingsWrapper, **kwargs):
@@ -298,7 +298,7 @@ def test_start_first_run(
     )
     container_engine_mock.start.return_value = "test-pod-id"
     with mock.patch(
-        "aap_eda.services.activation.manager.get_current_job",
+        "aap_eda.services.activation.activation_manager.get_current_job",
         return_value=job_mock,
     ):
         activation_manager.start()
@@ -334,7 +334,7 @@ def test_start_restart(
     )
     container_engine_mock.start.return_value = "test-pod-id"
     with mock.patch(
-        "aap_eda.services.activation.manager.get_current_job",
+        "aap_eda.services.activation.activation_manager.get_current_job",
         return_value=job_mock,
     ):
         activation_manager.start(is_restart=True)
@@ -662,7 +662,7 @@ def test_start_max_running_activations(
     activation_manager = ActivationManager(basic_activation)
 
     with pytest.raises(exceptions.MaxRunningProcessesError), mock.patch(
-        "aap_eda.services.activation.manager.get_current_job",
+        "aap_eda.services.activation.activation_manager.get_current_job",
         return_value=job_mock,
     ):
         activation_manager.start()

--- a/tests/integration/services/activation/test_manager.py
+++ b/tests/integration/services/activation/test_manager.py
@@ -31,6 +31,7 @@ from aap_eda.services.activation.engine.common import (
 from aap_eda.services.activation.manager import (
     LOGGER,
     ActivationManager,
+    StatusManager,
     exceptions,
 )
 
@@ -136,6 +137,28 @@ def new_activation_with_instance(
         queue_name="queue_name_test",
     )
     return activation
+
+
+@pytest.fixture
+def new_event_stream_with_instance(
+    default_user: models.User,
+    default_decision_environment: models.DecisionEnvironment,
+    default_rulebook: models.Rulebook,
+) -> models.EventStream:
+    """Return an event stream with an instance."""
+    event_stream = models.EventStream.objects.create(
+        name="new_event_stream_with_instance",
+        user=default_user,
+        decision_environment=default_decision_environment,
+        rulebook=default_rulebook,
+        # rulebook_rulesets is populated by the serializer
+        rulebook_rulesets=default_rulebook.rulesets,
+    )
+    models.RulebookProcess.objects.create(
+        event_stream=event_stream,
+        status=enums.ActivationStatus.RUNNING,
+    )
+    return event_stream
 
 
 @pytest.fixture
@@ -644,3 +667,74 @@ def test_start_max_running_activations(
     ):
         activation_manager.start()
     assert "No capacity to start a new rulebook process" in eda_caplog.text
+
+
+@pytest.mark.django_db
+def test_init_status_manager_with_activation(basic_activation):
+    status_manager = StatusManager(basic_activation)
+    assert status_manager.db_instance == basic_activation
+    assert status_manager.latest_instance == basic_activation.latest_instance
+    assert (
+        status_manager.db_instance_type == enums.ProcessParentType.ACTIVATION
+    )
+
+
+@pytest.mark.django_db
+def test_init_status_manager_with_event_stream(new_event_stream_with_instance):
+    status_manager = StatusManager(new_event_stream_with_instance)
+    assert status_manager.db_instance == new_event_stream_with_instance
+    assert (
+        status_manager.latest_instance
+        == new_event_stream_with_instance.latest_instance
+    )
+    assert (
+        status_manager.db_instance_type == enums.ProcessParentType.EVENT_STREAM
+    )
+
+
+@pytest.mark.parametrize(
+    "process_parent",
+    [
+        pytest.param(
+            lazy_fixture("new_activation_with_instance"),
+        ),
+        pytest.param(
+            lazy_fixture("new_event_stream_with_instance"),
+        ),
+    ],
+)
+@pytest.mark.django_db
+def test_status_manager_set_latest_instance_status(process_parent):
+    status_manager = StatusManager(process_parent)
+    status_manager.set_latest_instance_status(
+        status=enums.ActivationStatus.PENDING,
+        status_message="Instance is pending",
+    )
+    assert (
+        process_parent.latest_instance.status == enums.ActivationStatus.PENDING
+    )
+    assert (
+        process_parent.latest_instance.status_message == "Instance is pending"
+    )
+
+
+@pytest.mark.parametrize(
+    "process_parent",
+    [
+        pytest.param(
+            lazy_fixture("new_activation_with_instance"),
+        ),
+        pytest.param(
+            lazy_fixture("new_event_stream_with_instance"),
+        ),
+    ],
+)
+@pytest.mark.django_db
+def test_status_manager_set_status(process_parent):
+    status_manager = StatusManager(process_parent)
+    status_manager.set_status(
+        status=enums.ActivationStatus.PENDING,
+        status_message="Activation is pending",
+    )
+    assert process_parent.status == enums.ActivationStatus.PENDING
+    assert process_parent.status_message == "Activation is pending"

--- a/tests/integration/tasks/test_orchestrator.py
+++ b/tests/integration/tasks/test_orchestrator.py
@@ -160,7 +160,7 @@ def test_manage_not_start(
     )
 
     with mock.patch(
-        "aap_eda.services.activation.manager.get_current_job",
+        "aap_eda.services.activation.activation_manager.get_current_job",
         return_value=job_mock,
     ):
         orchestrator._manage(ProcessParentType.ACTIVATION, activation.id)
@@ -277,7 +277,7 @@ def test_max_running_activation_after_start_job(
         ProcessParentType.ACTIVATION, activation.id, ActivationRequest.START
     )
     with mock.patch(
-        "aap_eda.services.activation.manager.get_current_job",
+        "aap_eda.services.activation.activation_manager.get_current_job",
         return_value=job_mock,
     ):
         orchestrator._manage(ProcessParentType.ACTIVATION, activation.id)


### PR DESCRIPTION
Refactor the activation manager to move out the status management into a parent class "StatusManager". This is used when we want to change the status of activations in the orchestrator prior to the container livecycle. 

Jira: https://issues.redhat.com/browse/AAP-22452