### PR TITLE
fix: add missing default status msg for workers_offline

### DIFF
--- a/src/aap_eda/core/enums.py
+++ b/src/aap_eda/core/enums.py
@@ -112,6 +112,7 @@ ACTIVATION_STATUS_MESSAGE_MAP = {
     ActivationStatus.STOPPED: "Activation has stopped",
     ActivationStatus.UNRESPONSIVE: "Activation is not responsive",
     ActivationStatus.ERROR: "Activation is in an error state",
+    ActivationStatus.WORKERS_OFFLINE: "All workers in the node are offline",
 }
 
 

--- a/tests/integration/core/test_status_handler.py
+++ b/tests/integration/core/test_status_handler.py
@@ -95,19 +95,8 @@ def test_save(instance):
         == ACTIVATION_STATUS_MESSAGE_MAP[instance.status]
     )
 
-    for status in [
-        ActivationStatus.STARTING,
-        ActivationStatus.RUNNING,
-        ActivationStatus.STOPPING,
-        ActivationStatus.DELETING,
-        ActivationStatus.COMPLETED,
-        ActivationStatus.FAILED,
-        ActivationStatus.STOPPED,
-        ActivationStatus.UNRESPONSIVE,
-        ActivationStatus.ERROR,
-        ActivationStatus.PENDING,
-    ]:
-        instance.status = status
+    for status in ActivationStatus:
+        instance.status = status.value
         instance.save(update_fields=["status"])
 
         instance.refresh_from_db()
@@ -121,6 +110,7 @@ def test_save(instance):
     instance.refresh_from_db()
     assert instance.is_enabled is False
 
+    instance.status = ActivationStatus.PENDING
     instance.save(update_fields=["status"])
     instance.refresh_from_db()
     assert instance.status_message == "Activation is marked as disabled"


### PR DESCRIPTION
The implementation of the `workers offline` status always set a status_message, but a default message must be defined for consistency. It updates the test to ensure always we have a default status message per each status. 