### PR TITLE
fix: move validated error message under the right field

### DIFF
--- a/src/aap_eda/core/utils/credentials.py
+++ b/src/aap_eda/core/utils/credentials.py
@@ -25,6 +25,9 @@ from aap_eda.core.utils.awx import validate_ssh_private_key
 ENCRYPTED_STRING = "$encrypted$"
 EDA_PREFIX = "EDA_"
 SUPPORTED_KEYS_IN_INJECTORS = ["extra_vars"]
+PROTECTED_PASSPHRASE_ERROR = (
+    "The key is passphrase protected, please provide passphrase."
+)
 
 
 class InjectorMissingKeyException(Exception):
@@ -108,7 +111,10 @@ def validate_inputs(schema: dict, inputs: dict) -> dict:
                 inputs=inputs,
             )
             if bool(result):
-                errors[display_field] = result
+                if PROTECTED_PASSPHRASE_ERROR in result:
+                    errors["inputs.ssh_key_unlock"] = result
+                else:
+                    errors[display_field] = result
 
         if data.get("type") == "boolean":
             if user_input and not isinstance(user_input, bool):
@@ -331,10 +337,7 @@ def _validate_ssh_key(schema: dict, data: str, inputs: dict) -> list[str]:
 
         if "ssh_key_unlock" in id_fields and "ssh_key_data" in id_fields:
             if results[0]["key_enc"] and not inputs.get("ssh_key_unlock"):
-                errors.append(
-                    "The key is passphrase protected, please "
-                    "provide passphrase."
-                )
+                errors.append(PROTECTED_PASSPHRASE_ERROR)
     except ValidationError as e:
         errors.append(str(e))
 


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-23311

The missing passphrase key error message is moved from the `SCM Private Key` field to the `Private Key Passphrase` field:

![image](https://github.com/ansible/eda-server/assets/12900250/a8bb1b9e-eec4-4fc9-9d5a-451a65a3fdac)
