### PR TITLE
chore: add a test case for filter on eda credentials

### DIFF
--- a/tests/integration/api/test_eda_credential.py
+++ b/tests/integration/api/test_eda_credential.py
@@ -134,6 +134,13 @@ def test_list_eda_credentials_with_kind_filter(
     )
     assert len(response.data["results"]) == 2
 
+    name_prefix = default_eda_credential.name[0]
+    response = client.get(
+        f"{api_url_v1}/eda-credentials/?credential_type__kind=scm"
+        f"&credential_type__kind=registry&name={name_prefix}",
+    )
+    assert len(response.data["results"]) == 1
+
 
 @pytest.mark.django_db
 def test_list_eda_credentials_filter_credential_type_id(


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-23330

The issue comes from a typo on the UI side, here just add a test case.