### PR TITLE
feat: add queue_name field to process instance views

### DIFF
--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -436,6 +436,13 @@ class ActivationCreateSerializer(serializers.ModelSerializer):
 class ActivationInstanceSerializer(serializers.ModelSerializer):
     """Serializer for the Activation Instance model."""
 
+    queue_name = serializers.CharField(
+        source="rulebookprocessqueue.queue_name",
+        read_only=True,
+        allow_null=True,
+        default=None,
+    )
+
     class Meta:
         model = models.RulebookProcess
         fields = [
@@ -449,6 +456,7 @@ class ActivationInstanceSerializer(serializers.ModelSerializer):
             "organization_id",
             "started_at",
             "ended_at",
+            "queue_name",
         ]
         read_only_fields = ["id", "started_at", "ended_at"]
 

--- a/src/aap_eda/api/serializers/event_stream.py
+++ b/src/aap_eda/api/serializers/event_stream.py
@@ -110,6 +110,12 @@ class EventStreamSerializer(serializers.ModelSerializer):
     )
     user = serializers.SerializerMethodField()
     source_args = YAMLSerializerField(required=False, allow_null=True)
+    queue_name = serializers.CharField(
+        source="rulebookprocessqueue.queue_name",
+        read_only=True,
+        allow_null=True,
+        default=None,
+    )
 
     class Meta:
         model = models.EventStream
@@ -130,6 +136,7 @@ class EventStreamSerializer(serializers.ModelSerializer):
             "user",
             "log_level",
             "k8s_service_name",
+            "queue_name",
             *read_only_fields,
         ]
 

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -355,7 +355,9 @@ class ActivationViewSet(
     ),
 )
 class ActivationInstanceViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = models.RulebookProcess.objects.all()
+    queryset = models.RulebookProcess.objects.all().select_related(
+        "rulebookprocessqueue",
+    )
     serializer_class = serializers.ActivationInstanceSerializer
     filter_backends = (defaultfilters.DjangoFilterBackend,)
     filterset_class = filters.ActivationInstanceFilter

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -355,7 +355,7 @@ class ActivationViewSet(
     ),
 )
 class ActivationInstanceViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = models.RulebookProcess.objects.all().select_related(
+    queryset = models.RulebookProcess.objects.select_related(
         "rulebookprocessqueue",
     )
     serializer_class = serializers.ActivationInstanceSerializer

--- a/src/aap_eda/api/views/event_stream.py
+++ b/src/aap_eda/api/views/event_stream.py
@@ -60,7 +60,7 @@ class EventStreamViewSet(
     mixins.DestroyModelMixin,
     viewsets.GenericViewSet,
 ):
-    queryset = models.EventStream.objects.all().select_related(
+    queryset = models.EventStream.objects.select_related(
         "rulebookprocessqueue",
     )
     serializer_class = serializers.EventStreamSerializer

--- a/src/aap_eda/api/views/event_stream.py
+++ b/src/aap_eda/api/views/event_stream.py
@@ -60,7 +60,9 @@ class EventStreamViewSet(
     mixins.DestroyModelMixin,
     viewsets.GenericViewSet,
 ):
-    queryset = models.EventStream.objects.all()
+    queryset = models.EventStream.objects.all().select_related(
+        "rulebookprocessqueue",
+    )
     serializer_class = serializers.EventStreamSerializer
     filter_backends = (defaultfilters.DjangoFilterBackend,)
     filterset_class = filters.EventStreamFilter

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -565,7 +565,7 @@ def default_activation_instances(
     default_activation: models.Activation, default_project: models.Project
 ) -> models.RulebookProcess:
     """Return a list of Activation Instances"""
-    return models.RulebookProcess.objects.bulk_create(
+    instances = models.RulebookProcess.objects.bulk_create(
         [
             models.RulebookProcess(
                 name="default-activation-instance-1",
@@ -587,6 +587,14 @@ def default_activation_instances(
             ),
         ]
     )
+
+    for instance in instances:
+        models.RulebookProcessQueue.objects.create(
+            process=instance,
+            queue_name="activation",
+        )
+
+    return instances
 
 
 @pytest.fixture

--- a/tests/integration/api/test_activation_instance.py
+++ b/tests/integration/api/test_activation_instance.py
@@ -166,4 +166,5 @@ def assert_activation_instance_data(
         "ended_at": instance.ended_at,
         "status_message": enums.ACTIVATION_STATUS_MESSAGE_MAP[instance.status],
         "event_stream_id": None,
+        "queue_name": instance.rulebookprocessqueue.queue_name,
     }

--- a/tests/integration/api/test_event_stream.py
+++ b/tests/integration/api/test_event_stream.py
@@ -455,6 +455,10 @@ def test_list_event_stream_instances(
             ),
         ]
     )
+    models.RulebookProcessQueue.objects.create(
+        process=instances[0],
+        queue_name="activation",
+    )
     response = client.get(
         f"{api_url_v1}/event-streams/{event_stream.id}/instances/"
     )
@@ -463,3 +467,41 @@ def test_list_event_stream_instances(
     assert len(data) == len(instances)
     assert data[0]["name"] == instances[0].name
     assert data[1]["name"] == instances[1].name
+    assert data[0]["queue_name"] == "activation"
+    assert data[1]["queue_name"] is None
+
+
+@pytest.mark.django_db
+def test_retrieve_event_stream_instance(
+    client: APIClient,
+    default_de: models.DecisionEnvironment,
+    default_user: models.User,
+):
+    args = {"limit": 5, "delay": 1}
+    event_stream = models.EventStream.objects.create(
+        name="test-event_stream-1",
+        source_type="ansible.eda.range",
+        source_args=args,
+        user=default_user,
+        decision_environment_id=default_de.id,
+    )
+
+    instance = models.RulebookProcess.objects.create(
+        name="test-activation-instance-1",
+        event_stream=event_stream,
+        parent_type=ProcessParentType.EVENT_STREAM,
+    )
+    models.RulebookProcessQueue.objects.create(
+        process=instance,
+        queue_name="activation",
+    )
+    response = client.get(
+        (
+            f"{api_url_v1}/event-streams/{event_stream.id}"
+            f"/instances/{instance.id}/"
+        ),
+    )
+    data = response.data
+    assert response.status_code == status.HTTP_200_OK
+    assert data["name"] == instance.name
+    assert data["queue_name"] == "activation"


### PR DESCRIPTION
Expose the queue name for the rulebook process, requested by QE. 
Jira: https://issues.redhat.com/browse/AAP-23289