### PR TITLE
chore: upgrade djangorestframework

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -697,18 +697,17 @@ files = [
 
 [[package]]
 name = "djangorestframework"
-version = "3.14.0"
+version = "3.15.1"
 description = "Web APIs for Django, made easy."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "djangorestframework-3.14.0-py3-none-any.whl", hash = "sha256:eb63f58c9f218e1a7d064d17a70751f528ed4e1d35547fdade9aaf4cd103fd08"},
-    {file = "djangorestframework-3.14.0.tar.gz", hash = "sha256:579a333e6256b09489cbe0a067e66abe55c6595d8926be6b99423786334350c8"},
+    {file = "djangorestframework-3.15.1-py3-none-any.whl", hash = "sha256:3ccc0475bce968608cf30d07fb17d8e52d1d7fc8bfe779c905463200750cbca6"},
+    {file = "djangorestframework-3.15.1.tar.gz", hash = "sha256:f88fad74183dfc7144b2756d0d2ac716ea5b4c7c9840995ac3bfd8ec034333c1"},
 ]
 
 [package.dependencies]
 django = ">=3.0"
-pytz = "*"
 
 [[package]]
 name = "djangorestframework-simplejwt"
@@ -1885,17 +1884,6 @@ files = [
 six = ">=1.5"
 
 [[package]]
-name = "pytz"
-version = "2023.3"
-description = "World timezone definitions, modern and historical"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pytz-2023.3-py2.py3-none-any.whl", hash = "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"},
-    {file = "pytz-2023.3.tar.gz", hash = "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588"},
-]
-
-[[package]]
 name = "pyxdg"
 version = "0.28"
 description = "PyXDG contains implementations of freedesktop.org standards in python."
@@ -2406,4 +2394,4 @@ dev = ["psycopg2-binary"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "7d0a4305c73bf85e986333cf3a4a43e4c41b943299c9960ba8ef295e25583051"
+content-hash = "c48f0fc50e0674b4bcb8f99770985bbd92c0ffead3fd3630f788c4d69d2136df"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dev = ["psycopg2-binary"]
 [tool.poetry.dependencies]
 python = ">=3.11,<3.12"
 django = ">=4.2,<4.3"
-djangorestframework = "3.14.*"
+djangorestframework = "3.15.*"
 djangorestframework_simplejwt = "5.3.*"
 dynaconf = ">=3.1.12,<3.3"
 drf-spectacular = ">=0.26.5,<0.27"


### PR DESCRIPTION
To be aligned with DAB, to bring this fix: https://github.com/encode/django-rest-framework/pull/8684