### PR TITLE
fix: remove unneeded created_by selector from K8S service

### DIFF
--- a/src/aap_eda/services/activation/engine/kubernetes.py
+++ b/src/aap_eda/services/activation/engine/kubernetes.py
@@ -364,7 +364,6 @@ class Engine(ContainerEngine):
                         selector={
                             "app": "eda",
                             "job-name": self.job_name,
-                            "created-by": "eda",
                         },
                         ports=[
                             k8sclient.V1ServicePort(


### PR DESCRIPTION
https://github.com/ansible/eda-server/issues/858

Remove the unneeded `created-by: eda` selector from the created service, so it has valid endpoints in the list, like:

```
» kubectl get endpoints -n aap-eda
NAME           ENDPOINTS                             AGE
aaa            10.244.0.153:5555,10.244.0.153:4444   4h59m
bbb            10.244.0.164:5555                     8m22s
eda-api        10.244.0.159:8000                     5h9m
eda-postgres   10.244.0.151:5432                     5h9m
eda-redis      10.244.0.152:6379                     5h9m
eda-ui         10.244.0.150:443                      5h9m
```