### PR TITLE
test: connect the credentials to correct objects

### DIFF
--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -100,14 +100,14 @@ def check_permission_mock():
 @pytest.fixture
 def default_de(
     default_organization: models.Organization,
-    default_eda_credential: models.EdaCredential,
+    default_registry_credential: models.EdaCredential,
 ) -> models.DecisionEnvironment:
     """Return a default DE."""
     return models.DecisionEnvironment.objects.create(
         name="default_de",
         image_url="quay.io/ansible/ansible-rulebook:latest",
         description="Default DE",
-        eda_credential=default_eda_credential,
+        eda_credential=default_registry_credential,
         organization=default_organization,
     )
 
@@ -135,8 +135,8 @@ def default_user_awx_token(default_user: models.User):
 
 @pytest.fixture
 def default_project(
-    default_vault_credential: models.EdaCredential,
-    default_eda_credential: models.EdaCredential,
+    default_gpg_credential: models.EdaCredential,
+    default_scm_credential: models.EdaCredential,
     default_organization: models.Organization,
 ) -> models.Project:
     """Return a default Project."""
@@ -145,8 +145,8 @@ def default_project(
         description="Default Project",
         url="https://git.example.com/acme/project-01",
         git_hash="684f62df18ce5f8d5c428e53203b9b975426eed0",
-        eda_credential=default_eda_credential,
-        signature_validation_credential=default_vault_credential,
+        eda_credential=default_scm_credential,
+        signature_validation_credential=default_gpg_credential,
         scm_branch="main",
         proxy="http://user:secret@myproxy.com",
         organization=default_organization,
@@ -508,7 +508,7 @@ def default_activation(
     default_extra_var_data: str,
     default_organization: models.Organization,
     default_user: models.User,
-    default_eda_credential: models.EdaCredential,
+    default_vault_credential: models.EdaCredential,
 ) -> models.Activation:
     """Return a default Activation"""
     activation = models.Activation.objects.create(
@@ -522,7 +522,7 @@ def default_activation(
         user=default_user,
         log_level="debug",
     )
-    activation.eda_credentials.add(default_eda_credential)
+    activation.eda_credentials.add(default_vault_credential)
     return activation
 
 

--- a/tests/integration/api/test_decision_environment.py
+++ b/tests/integration/api/test_decision_environment.py
@@ -21,7 +21,7 @@ def test_list_decision_environments(
 
 @pytest.mark.django_db
 def test_create_decision_environment(
-    default_eda_credential: models.EdaCredential,
+    default_registry_credential: models.EdaCredential,
     default_organization: models.Organization,
     client: APIClient,
 ):
@@ -30,7 +30,7 @@ def test_create_decision_environment(
         "description": "desc here",
         "image_url": "registry.com/img1:tag1",
         "organization_id": default_organization.id,
-        "eda_credential_id": default_eda_credential.id,
+        "eda_credential_id": default_registry_credential.id,
     }
     response = client.post(
         f"{api_url_v1}/decision-environments/", data=data_in

--- a/tests/integration/api/test_eda_credential.py
+++ b/tests/integration/api/test_eda_credential.py
@@ -148,21 +148,21 @@ def test_retrieve_eda_credential(
 @pytest.mark.django_db
 def test_list_eda_credentials(
     client: APIClient,
-    default_eda_credential: models.EdaCredential,
+    default_scm_credential: models.EdaCredential,
     default_vault_credential: models.EdaCredential,
-    managed_eda_credential: models.EdaCredential,
+    managed_registry_credential: models.EdaCredential,
 ):
     response = client.get(f"{api_url_v1}/eda-credentials/")
     assert response.status_code == status.HTTP_200_OK
     assert len(response.data["results"]) == 2
-    assert response.data["results"][0]["name"] == default_eda_credential.name
+    assert response.data["results"][0]["name"] == default_scm_credential.name
     assert response.data["results"][1]["name"] == default_vault_credential.name
 
 
 @pytest.mark.django_db
 def test_list_eda_credentials_with_kind_filter(
     client: APIClient,
-    default_eda_credential: models.EdaCredential,
+    default_registry_credential: models.EdaCredential,
     default_scm_credential: models.EdaCredential,
 ):
     response = client.get(
@@ -192,7 +192,7 @@ def test_list_eda_credentials_with_kind_filter(
     )
     assert len(response.data["results"]) == 2
 
-    name_prefix = default_eda_credential.name[0]
+    name_prefix = default_registry_credential.name[0]
     response = client.get(
         f"{api_url_v1}/eda-credentials/?credential_type__kind=scm"
         f"&credential_type__kind=registry&name={name_prefix}",
@@ -202,7 +202,7 @@ def test_list_eda_credentials_with_kind_filter(
 
 @pytest.mark.django_db
 def test_list_eda_credentials_filter_credential_type_id(
-    default_eda_credential: models.EdaCredential,
+    default_registry_credential: models.EdaCredential,
     default_scm_credential: models.EdaCredential,
     client: APIClient,
     preseed_credential_types,
@@ -238,17 +238,20 @@ def test_list_eda_credentials_filter_credential_type_id(
 
 @pytest.mark.django_db
 def test_list_eda_credentials_filter_name(
-    default_eda_credential: models.EdaCredential,
+    default_registry_credential: models.EdaCredential,
     default_scm_credential: models.EdaCredential,
     client: APIClient,
     preseed_credential_types,
 ):
     response = client.get(
-        f"{api_url_v1}/eda-credentials/?name={default_eda_credential.name}"
+        f"{api_url_v1}/eda-credentials/"
+        f"?name={default_registry_credential.name}"
     )
     assert response.status_code == status.HTTP_200_OK
     assert len(response.data["results"]) == 1
-    assert response.data["results"][0]["name"] == default_eda_credential.name
+    assert (
+        response.data["results"][0]["name"] == default_registry_credential.name
+    )
 
     response = client.get(
         f"{api_url_v1}/eda-credentials/?name={default_scm_credential.name}"
@@ -449,29 +452,12 @@ def test_retrieve_eda_credential_with_refs(
         assert response.data["references"] is not None
         references = response.data["references"]
 
-        assert len(references) == 3
+        assert len(references) == 1
         references[0] = {
             "type": "Activation",
             "id": default_activation.id,
             "name": default_activation.name,
             "url": f"api/eda/v1/activations/{default_activation.id}/",
-        }
-        references[1] = (
-            {
-                "type": "DecisionEnvironment",
-                "id": default_activation.decision_environment.id,
-                "name": default_activation.decision_environment.name,
-                "url": (
-                    "api/eda/v1/decision_environments/"
-                    f"{default_activation.decision_environment.id}/"
-                ),
-            },
-        )
-        references[1] = {
-            "type": "Project",
-            "id": default_activation.project.id,
-            "name": default_activation.project.name,
-            "url": (f"api/eda/v1/projects/{default_activation.project.id}/"),
         }
     else:
         assert response.data["references"] is None

--- a/tests/integration/api/test_project.py
+++ b/tests/integration/api/test_project.py
@@ -352,7 +352,8 @@ def test_update_project_with_400(
 @pytest.mark.django_db
 def test_partial_update_project(
     new_project: models.Project,
-    default_eda_credential: models.EdaCredential,
+    default_scm_credential: models.EdaCredential,
+    default_gpg_credential: models.EdaCredential,
     client: APIClient,
 ):
     assert new_project.eda_credential_id is None
@@ -361,8 +362,8 @@ def test_partial_update_project(
 
     new_data = {
         "name": "new-project-updated",
-        "eda_credential_id": default_eda_credential.id,
-        "signature_validation_credential_id": default_eda_credential.id,
+        "eda_credential_id": default_scm_credential.id,
+        "signature_validation_credential_id": default_gpg_credential.id,
         "scm_branch": "main",
         "scm_refspec": "ref1",
         "verify_ssl": True,
@@ -379,7 +380,7 @@ def test_partial_update_project(
     assert new_project.eda_credential.id == new_data["eda_credential_id"]
     assert (
         new_project.signature_validation_credential.id
-        == new_data["eda_credential_id"]
+        == new_data["signature_validation_credential_id"]
     )
     assert new_project.verify_ssl is new_data["verify_ssl"]
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -55,6 +55,38 @@ INPUTS = {
     ]
 }
 
+DUMMY_GPG_KEY = """
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBGYxK8IBEACzO/jIqIvEPsIE4xUCRC2WKiyzlD2rEmS/MYg9TMBYTVISrkGF
+WfcQE0hPYU5qFeBzsr3qa/AfQobK+sv545QblAbNLINRdoaWnDMwVO+gLeVhrhbv
+V2c7kwBe6ahQNy7cK/fh0OilNOwTC9V+HyHO/ZpUm5dniny+R4ScNiVtkegfg7mh
+dDiFgAKOLgxElPUJiD/crnIqAWn2OAAqKb1LDGFOdHMJCwI1KH6XRjtmGxy5XX22
+NC8zsE0TXfx4Oa8I7cxumZdh9Kw2wWxitSbpQnCT+8LapCwz36BjOjuEVw1c9AxN
+UbFuVks1XhBG08SBnkFkAYD5ogTx2hs12PhWCIB2XneHBR7LmgaZzJiYtYoeehQ2
+j6JPtIjdPEFgoVxYmSe74+VD/hIYg70Z0tpOpbB/xfvyvVZII/G2hha4l7YCCbN8
+a14mN7HLTkaBx2NG7UtcZ5V1ahHznvtSVVqzkJQQqyJyD0sr8oivU3Aq0Cf8pqwL
+PIg0Z2h7xCZ0pfxceMB4xFxJGosV+oq25QpasrbDWBhhQw91XpYnRvATYWn3ucU/
+20Mn8ZeJOLQxGZLhOfV8rrzGan1czIURlsfnrCC81md3Q3mQTBVhrhTqXrrp7a1f
+8ca6xL4d0yAntDudCPEpAOvYYbLsEwqRNNLu1/4uYgCDPsfXNGcTX8Ld9QARAQAB
+tCN1c2VyQGFuc2libGUuY29tIDx1c2VyQGFuc2libGUuY29tPokCVAQTAQgAPhYh
+BApWMhVpMJ19gBJOItYYZlMrZT/sBQJmMSvCAhsDBQkDwmcABQsJCAcCBhUKCQgL
+AgQWAgMBAh4BAheAAAoJENYYZlMrZT/s56wP/1lvAntBZSCMZmTQ3AvpoIyGr2Hc
+XwjUlDajYI9A/CdJuOTx/FEZCsfy64K3QCyE9fshozIjiLyuoFb9DPAQ6FKagV0b
+Q1sCSSPk+ahaqSUGMQ7Lx8v+Xj0px9qYveeX1s5TisYBFZZPoiZcyhiJxdVZxP0D
+kkN+frIfndtzCCEqnYG9XZMDe4LpAmQUExMhp/SvNnuLtEofnIau0ZFyrT+ZG2vm
+KAIHyk2yE+N0fn+PzxYJJz77t8htOj/g+4XQZq/U4MhnMdge2raI7fCvh+OixFb0
+7QGQpvxlAB0lO5vHf48PPYAgxgjXyiGWG0gpYAcx+t35BJRYlUWOzkjQYDzUvYfs
+zGuOVnZbmlX4vtDaU27bMP0575IDtgRYa/p7J1M4BqNUicyelzbeCeSBd6NEyraU
+c/deAZFD1MviBzFnbA5yXmxycbiEBmfpypfrsN8k/i4OU+bgZ2GgTLV3TcQcVulh
+Z9yJGOc2CcGW9+bCPWOtxzb6ENAv4CmMyL9BmaXKYKXrKKOFnFgjVZU/SqsURoOD
+FejSpTMyKeMS174YVm0qh7xw7nX1ph5mibHsS7sCfZCNywQfl91/hpalty7OeXqY
+drC6WsDeShPiZlJT47AJgRfEMkZlA6DumlLikkbdCb4Mty2EhaGJ13WCGOzJ3z3k
+RMVE39lIPjN2AKyK
+=MlEN
+-----END PGP PUBLIC KEY BLOCK-----
+"""
+
 
 # fixture for a running redis server
 @pytest.fixture
@@ -122,17 +154,17 @@ def user_credential_type(
 
 
 @pytest.fixture
-def default_eda_credential(
+def default_registry_credential(
     default_organization: models.Organization,
     preseed_credential_types,
 ) -> models.EdaCredential:
-    """Return a default Credential"""
+    """Return a default Container Registry Credential"""
     registry_credential_type = models.CredentialType.objects.get(
         name=enums.DefaultCredentialType.REGISTRY
     )
     return models.EdaCredential.objects.create(
         name="default-eda-credential",
-        description="Default EDA Credential",
+        description="Default Registry Credential",
         credential_type=registry_credential_type,
         inputs=inputs_to_store(
             {"username": "dummy-user", "password": "dummy-password"}
@@ -171,8 +203,8 @@ def default_scm_credential(
         name=enums.DefaultCredentialType.SOURCE_CONTROL
     )
     return models.EdaCredential.objects.create(
-        name="managed-eda-credential",
-        description="Default EDA Credential",
+        name="managed-scm-credential",
+        description="Default SCM Credential",
         credential_type=scm_credential_type,
         inputs=inputs_to_store(
             {"username": "dummy-user", "password": "dummy-password"}
@@ -182,7 +214,7 @@ def default_scm_credential(
 
 
 @pytest.fixture
-def managed_eda_credential(
+def managed_registry_credential(
     default_organization: models.Organization,
     preseed_credential_types,
 ) -> models.EdaCredential:
@@ -192,7 +224,7 @@ def managed_eda_credential(
     )
     return models.EdaCredential.objects.create(
         name="managed-eda-credential",
-        description="Managed EDA Credential",
+        description="Managed Registry Credential",
         credential_type=scm_credential_type,
         inputs=inputs_to_store(
             {"username": "dummy-user", "password": "dummy-password"}
@@ -264,3 +296,21 @@ def preseed_credential_types(
 ) -> list[models.CredentialType]:
     """Preseed Credential Types."""
     return populate_credential_types(CREDENTIAL_TYPES)
+
+
+@pytest.fixture
+def default_gpg_credential(
+    default_organization: models.Organization,
+    preseed_credential_types,
+) -> models.EdaCredential:
+    """Return a default GPG Credential"""
+    gpg_credential_type = models.CredentialType.objects.get(
+        name=enums.DefaultCredentialType.GPG
+    )
+    return models.EdaCredential.objects.create(
+        name="default-gpg-credential",
+        description="Default GPG Credential",
+        credential_type=gpg_credential_type,
+        inputs=inputs_to_store({"gpg_public_key": DUMMY_GPG_KEY}),
+        organization=default_organization,
+    )


### PR DESCRIPTION
We need to have our tests connect the correct type of credentials to correct objects
* RH AAP and Vault types can only be connected to Activation
* Source Control and GPG Public key can only be connected to Project
* Container Registry can only be connected to Decision Environment
* Custom Credential types can only be connected to Activation