### PR TITLE
Show PATCH in OPTIONS

### DIFF
--- a/src/aap_eda/api/metadata.py
+++ b/src/aap_eda/api/metadata.py
@@ -1,0 +1,35 @@
+from django.core.exceptions import PermissionDenied
+from django.http import Http404
+from rest_framework import exceptions, metadata
+from rest_framework.request import clone_request
+
+
+class EDAMetadata(metadata.SimpleMetadata):
+    """Overwritten to show PATCH in OPTIONS."""
+
+    def determine_actions(self, request, view):
+        """For generic class based views we return information about.
+
+        the fields that are accepted for 'PUT' and 'POST' methods.
+        """
+        actions = {}
+        for method in {"PUT", "PATCH", "POST"} & set(view.allowed_methods):
+            view.request = clone_request(request, method)
+            try:
+                # Test global permissions
+                if hasattr(view, "check_permissions"):
+                    view.check_permissions(view.request)
+                # Test object permissions
+                if method in ("PUT", "PATCH") and hasattr(view, "get_object"):
+                    view.get_object()
+            except (exceptions.APIException, PermissionDenied, Http404):
+                pass
+            else:
+                # If user has appropriate permissions for the view, include
+                # appropriate metadata about the fields that should be supplied
+                serializer = view.get_serializer()
+                actions[method] = self.get_serializer_info(serializer)
+            finally:
+                view.request = request
+
+        return actions

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -308,6 +308,7 @@ REST_FRAMEWORK = {
         "ansible_base.rbac.api.permissions.AnsibleBaseObjectPermissions",
     ],
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
+    "DEFAULT_METADATA_CLASS": "aap_eda.api.metadata.EDAMetadata",
     "EXCEPTION_HANDLER": "aap_eda.api.exceptions.api_fallback_handler",
 }
 

--- a/tests/integration/dab_rbac/test_crud_permissions.py
+++ b/tests/integration/dab_rbac/test_crud_permissions.py
@@ -160,10 +160,21 @@ def test_change_permissions(
     response = user_api_client.patch(url, data={})
     assert response.status_code == 403, response.data
 
+    # Test OPTIONS without sufficient permissions
+    response = user_api_client.options(url)
+    assert response.status_code == 200
+    assert "actions" not in response.data  # no PATCH or PUT
+
     # Give object change permission
     give_obj_perm(user, obj, "change")
     response = user_api_client.patch(url, data={})
     assert response.status_code == 200, response.data
+
+    # Test OPTIONS
+    response = user_api_client.options(url)
+    assert response.status_code == 200
+    assert "actions" in response.data  # no PATCH or PUT
+    assert "PATCH" in response.data["actions"]
 
 
 @pytest.mark.django_db

--- a/tests/integration/dab_rbac/test_crud_permissions.py
+++ b/tests/integration/dab_rbac/test_crud_permissions.py
@@ -173,7 +173,7 @@ def test_change_permissions(
     # Test OPTIONS
     response = user_api_client.options(url)
     assert response.status_code == 200
-    assert "actions" in response.data  # no PATCH or PUT
+    assert "actions" in response.data
     assert "PATCH" in response.data["actions"]
 
 


### PR DESCRIPTION
This is for what @Dostonbek1 and @vidyanambiar and I have been working on.

The UI is planning to carry-forward a practice used in AWX, which is to hide/disable thing based on data from OPTIONS. If a user has permissions to edit an object, PUT/PATCH will be shown, but if the user lacks those permissions, OPTIONS will not show those methods. Thus, if the actions are not present, the UI may disable editing certain things.

The problem with eda-server is that OPTIONS never returned any actions for detail views. This is self-apparent if you understand the intent of `PartialUpdateOnlyModelMixin` which means PATCH by "PartialUpdate". In other words, a full update (which is PUT) is excluded, and gives 405, method-not-allowed.

This partial-update-only behavior of EDA-server conflicts with DRF logic considers PUT _but not PATCH_ for OPTIONS.

AWX customized the metadata class in a similar way to what is proposed here, adding the GET method:

https://github.com/ansible/awx/blob/20f054d600689c8c016bce83f8445f3c9b5cffb3/awx/api/metadata.py#L192

So for QE, @dhaustein, this is expected to show a change in OPTIONS response so that PATCH is shown in "actions" in the response data. Then the UI will use this, combined with other updates, to determine permissions in advance of actually making an edit.