### PR TITLE
fix: handle HealthyQueueNotFoundError exception

### DIFF
--- a/src/aap_eda/tasks/orchestrator.py
+++ b/src/aap_eda/tasks/orchestrator.py
@@ -158,9 +158,10 @@ def dispatch(
     job_id = _manage_process_job_id(process_parent_type, process_parent_id)
     LOGGER.info(
         f"Dispatching request type {request_type} for {process_parent_type} "
-        "{process_parent_id}",
+        f"{process_parent_id}",
     )
 
+    queue_name = None
     # new processes
     if request_type in [
         ActivationRequest.START,
@@ -170,8 +171,6 @@ def dispatch(
             f"Dispatching {process_parent_type} "
             f"{process_parent_id} as new process.",
         )
-
-        queue_name = get_least_busy_queue_name()
     else:
         queue_name = get_queue_name_by_parent_id(
             process_parent_type,
@@ -186,28 +185,57 @@ def dispatch(
         ):
             if not queue_name:
                 LOGGER.info(
-                    f"Scheduling {process_parent_type} {process_parent_id} "
+                    f"Scheduling request {request_type} for "
+                    f"{process_parent_type} {process_parent_id} "
                     "to the least busy queue; it is not currently associated "
                     " with a queue.",
                 )
             else:
                 LOGGER.info(
-                    f"Scheduling {process_parent_type} {process_parent_id} "
+                    f"Scheduling request {request_type} for "
+                    f"{process_parent_type} {process_parent_id} "
                     f"to the least busy queue; its associated queue "
                     "'{queue_name}' is from previous configuation settings.",
                 )
+            queue_name = None
+
+    if queue_name and (not check_rulebook_queue_health(queue_name)):
+        # The queue is unhealthy; log this fact.
+        # We'll try to find another queue on which to run.
+        msg = (
+            f"{process_parent_type} {process_parent_id} is in an "
+            "unknown state. The workers of its associated queue "
+            f"'{queue_name}' are failing liveness checks. "
+            "There may be an issue with the node; please contact "
+            "the administrator."
+        )
+        LOGGER.warning(
+            f"Request {request_type} for "
+            f"{process_parent_type} {process_parent_id} will be run on the "
+            "least busy queue."
+        )
+        queue_name = None
+
+    if not queue_name:
+        try:
             queue_name = get_least_busy_queue_name()
-        elif not check_rulebook_queue_health(queue_name):
-            # The queue is unhealthy.  If we're not restarting it there's
-            # nothing we can do except update its status.
-            if request_type != ActivationRequest.RESTART:
-                msg = (
-                    f"{process_parent_type} {process_parent_id} is in an "
-                    "unknown state. The workers of its associated queue "
-                    f"'{queue_name}' are failing liveness checks. "
-                    "There may be an issue with the node; please contact "
-                    "the administrator."
-                )
+        except HealthyQueueNotFoundError:
+            # The are no healthy queues on which to run the request. For any
+            # request that isn't a restart set its status to "workers offline."
+            msg = (
+                "There are no healthy queues on which to run "
+                f"request {request_type} for {process_parent_type} "
+                f"{process_parent_id}. "
+                "There may be an issue with the node; please contact "
+                "the administrator."
+            )
+            LOGGER.warning(
+                msg,
+            )
+
+            if request_type not in [
+                ActivationRequest.RESTART,
+            ]:
                 status_manager = StatusManager(
                     get_process_parent(process_parent_type, process_parent_id),
                 )
@@ -215,32 +243,21 @@ def dispatch(
                     ActivationStatus.WORKERS_OFFLINE,
                     msg,
                 )
-                status_manager.set_latest_instance_status(
-                    ActivationStatus.WORKERS_OFFLINE,
-                    msg,
-                )
-                LOGGER.warning(msg)
-                return
+                # There may not be a latest instance.
+                if status_manager.latest_instance:
+                    status_manager.set_latest_instance_status(
+                        ActivationStatus.WORKERS_OFFLINE,
+                        msg,
+                    )
 
-            # The queue is unhealthy, but this is a restart.
-            # The priority is to adhere to the restart policy and
-            # execute the task.
-            LOGGER.warning(
-                f"Restarting {process_parent_type} {process_parent_id} "
-                "on the least busy queue; The workers of its associated queue "
-                f"'{queue_name}' are failing liveness checks. "
-                "There may be an issue with the node; please contact "
-                "the administrator.",
-            )
-            queue_name = get_least_busy_queue_name()
-
-    unique_enqueue(
-        queue_name,
-        job_id,
-        _manage,
-        process_parent_type,
-        process_parent_id,
-    )
+    if queue_name:
+        unique_enqueue(
+            queue_name,
+            job_id,
+            _manage,
+            process_parent_type,
+            process_parent_id,
+        )
 
 
 def get_least_busy_queue_name() -> str:


### PR DESCRIPTION
This addresses the 500 error return described in AAP-23378 allowing the activation state to be, as expected, "workers offline".