### PR TITLE
fix: force a line end when recreate the ssh key file

### DIFF
--- a/src/aap_eda/services/project/scm.py
+++ b/src/aap_eda/services/project/scm.py
@@ -158,6 +158,7 @@ class ScmRepository:
             if key_data:  # ssh
                 key_file = tempfile.NamedTemporaryFile("w+t")
                 key_file.write(key_data)
+                key_file.write("\n")
                 key_file.flush()
                 extra_vars["key_file"] = key_file.name
                 key_password = inputs.get("ssh_key_unlock")
@@ -171,6 +172,7 @@ class ScmRepository:
             gpg_key = gpg_inputs.get("gpg_public_key")
             gpg_key_file = tempfile.NamedTemporaryFile("w+t")
             gpg_key_file.write(gpg_key)
+            gpg_key_file.write("\n")
             gpg_key_file.flush()
             extra_vars["verify_commit"] = "true"
             cls.add_gpg_key(gpg_key_file.name)
@@ -199,6 +201,7 @@ class ScmRepository:
             msg = str(e)
             if secret:
                 msg = msg.replace(secret, "****", 1)
+                msg = msg.replace(quote(secret), "****", 1)
             logger.warning("SCM clone failed: %s", msg)
             raise ScmError(msg) from None
         finally:


### PR DESCRIPTION
AAP-23633: SCM credentials without a newline at the end of the private key do not work