### PR TITLE
Make debug setting true for tests

### DIFF
--- a/tests/integration/api/test_fallback_handler.py
+++ b/tests/integration/api/test_fallback_handler.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -20,9 +21,9 @@ def raise_exception(self, request):
     "aap_eda.api.views.project.ProjectViewSet.list", new=raise_exception
 )
 def test_debug_unexpected_exception(admin_client: APIClient, settings):
-    settings.DEBUG = True
-    with pytest.raises(FallbackException):
-        admin_client.get(f"{api_url_v1}/projects/")
+    with override_settings(DEBUG=True):
+        with pytest.raises(FallbackException):
+            admin_client.get(f"{api_url_v1}/projects/")
 
 
 @pytest.mark.django_db
@@ -30,9 +31,9 @@ def test_debug_unexpected_exception(admin_client: APIClient, settings):
     "aap_eda.api.views.project.ProjectViewSet.list", new=raise_exception
 )
 def test_non_debug_unexpected_exception(admin_client: APIClient, settings):
-    settings.DEBUG = False
-    response = admin_client.get(f"{api_url_v1}/projects/")
-    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    with override_settings(DEBUG=False):
+        response = admin_client.get(f"{api_url_v1}/projects/")
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
 
-    data = response.json()
-    assert data["detail"].startswith("Unexpected server error")
+        data = response.json()
+        assert data["detail"].startswith("Unexpected server error")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,6 +23,7 @@ import redis
 from ansible_base.rbac.models import DABPermission, RoleDefinition
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+from django.test import override_settings
 from rest_framework.test import APIClient
 
 from aap_eda.core import enums, models
@@ -770,6 +771,13 @@ RMVE39lIPjN2AKyK
 """
 
 
+@pytest.fixture(autouse=True)
+def use_debug_setting():
+    with override_settings(DEBUG=True):
+        yield
+
+
+# fixture for a running redis server
 @pytest.fixture
 def default_credential_type() -> models.CredentialType:
     """Return a default Credential Type."""

--- a/tests/integration/dab_rbac/test_crud_permissions.py
+++ b/tests/integration/dab_rbac/test_crud_permissions.py
@@ -16,7 +16,6 @@ import pytest
 from ansible_base.rbac import permission_registry
 from ansible_base.rbac.models import DABPermission, RoleDefinition
 from django.contrib.contenttypes.models import ContentType
-from django.test import override_settings
 from django.urls.exceptions import NoReverseMatch
 from rest_framework.reverse import reverse
 
@@ -39,7 +38,6 @@ def get_detail_url(obj, skip_if_not_found=False):
         raise
 
 
-@override_settings(DEBUG=True)
 @pytest.mark.django_db
 @pytest.mark.parametrize("model", permission_registry.all_registered_models)
 def test_add_permissions(
@@ -125,7 +123,6 @@ def test_add_permissions(
     assert default_user.has_obj_perm(obj, "view")
 
 
-@override_settings(DEBUG=True)
 @pytest.mark.django_db
 @pytest.mark.parametrize("model", permission_registry.all_registered_models)
 def test_view_permissions(
@@ -147,7 +144,6 @@ def test_view_permissions(
     assert response.status_code == 200, response.data
 
 
-@override_settings(DEBUG=True)
 @pytest.mark.django_db
 @pytest.mark.parametrize("model", permission_registry.all_registered_models)
 def test_change_permissions(

--- a/tests/integration/dab_rbac/test_organization.py
+++ b/tests/integration/dab_rbac/test_organization.py
@@ -15,7 +15,6 @@
 import pytest
 from django.apps import apps
 from django.core.exceptions import FieldDoesNotExist
-from django.test import override_settings
 from django.urls.exceptions import NoReverseMatch
 from rest_framework.reverse import reverse
 
@@ -35,7 +34,6 @@ ORG_MODELS = [
 ]
 
 
-@override_settings(DEBUG=True)
 @pytest.mark.django_db
 @pytest.mark.parametrize("model", ORG_MODELS)
 def test_create_with_default_org(cls_factory, model, admin_client, request):
@@ -72,7 +70,6 @@ def test_create_with_default_org(cls_factory, model, admin_client, request):
     assert obj.organization.name == "Default"
 
 
-@override_settings(DEBUG=True)
 @pytest.mark.django_db
 @pytest.mark.parametrize("model", ORG_MODELS)
 def test_create_with_custom_org(

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def test_debug_enabled_for_testing():
+    assert settings.DEBUG is True


### PR DESCRIPTION
Fixes https://github.com/ansible/eda-server/issues/881

Example test command:

```
py.test tests/integration/dab_rbac/ -k test_project_credential_access
```

Apply diff

```diff
diff --git a/src/aap_eda/api/views/project.py b/src/aap_eda/api/views/project.py
index 73e8e7a..a4b0d0f 100644
--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -169,6 +169,7 @@ class ProjectViewSet(
         },
     )
     def partial_update(self, request, pk):
+        raise Exception('alan!')
         project = self.get_object()
         if "proxy" in request.data:
             new_proxy = request.data["proxy"]
```

Now run test

```
================================================================================ test session starts ================================================================================
platform linux -- Python 3.11.9, pytest-7.3.1, pluggy-1.0.0
django: settings: aap_eda.settings.development (from ini)
rootdir: /home/alancoding/repos/eda-server
configfile: pytest.ini
plugins: lazy-fixture-0.6.3, asyncio-0.21.0, cov-4.1.0, django-4.5.2
asyncio: mode=Mode.AUTO
collected 85 items / 84 deselected / 1 selected                                                                                                                                     

tests/integration/dab_rbac/test_related_permissions.py F                                                                                                                      [100%]

===================================================================================== FAILURES ======================================================================================
__________________________________________________________________________ test_project_credential_access ___________________________________________________________________________

cls_factory = <conftest.ModelFactory object at 0x7ffbd1730710>, user = <User: ordinary-user>, user_api_client = <rest_framework.test.APIClient object at 0x7ffbd145fc90>
give_obj_perm = <function give_obj_perm.<locals>._rf at 0x7ffbd161b420>

    @pytest.mark.django_db
    def test_project_credential_access(
        cls_factory, user, user_api_client, give_obj_perm
    ):
        project = cls_factory.create(models.Project)
        give_obj_perm(user, project, "change")
        url = reverse("project-detail", kwargs={"pk": project.pk})
    
        credential = cls_factory.create(models.EdaCredential)
        assert project.eda_credential_id != credential.pk  # sanity
    
        # User can not view provided credential
        response = user_api_client.patch(
            url, data={"eda_credential_id": credential.pk}
        )
        # NOTE: the ideal would probably be 400, but still a matter of discussion
>       assert response.status_code in (403, 400), response.data
E       AssertionError: {'detail': 'Unexpected server error; contact your system administrator'}
E       assert 500 in (403, 400)
E        +  where 500 = <Response status_code=500, "application/json">.status_code

tests/integration/dab_rbac/test_related_permissions.py:70: AssertionError
------------------------------------------------------------------------------- Captured stdout setup -------------------------------------------------------------------------------
Adding content type 'core | user'
Adding content type 'core | activation'
Adding content type 'core | activationinstancejobinstance'
Adding content type 'core | auditaction'
Adding content type 'core | auditevent'
Adding content type 'core | auditrule'
Adding content type 'core | awxtoken'
Adding content type 'core | credential'
Adding content type 'core | decisionenvironment'
Adding content type 'core | extravar'
Adding content type 'core | job'
Adding content type 'core | jobinstance'
Adding content type 'core | jobinstanceevent'
Adding content type 'core | jobinstancehost'
Adding content type 'core | permission'
Adding content type 'core | project'
Adding content type 'core | rulebook'
Adding content type 'core | ruleset'
Adding content type 'core | rule'
Adding content type 'core | role'
Adding content type 'core | activationrequestqueue'
Adding content type 'core | rulebookprocess'
Adding content type 'core | rulebookprocesslog'
Adding content type 'core | eventstream'
Adding content type 'core | credentialtype'
Adding content type 'core | edacredential'
Adding content type 'core | rulebookprocessqueue'
Adding content type 'core | organization'
Adding content type 'core | team'
------------------------------------------------------------------------------- Captured stderr setup -------------------------------------------------------------------------------
2024-05-02 18:29:01,763 ansible_base.resource_registry.apps INFO     updating resource types
2024-05-02 18:29:01,775 ansible_base.resource_registry.apps INFO     adding unmigrated resources for shared.user
2024-05-02 18:29:01,780 ansible_base.resource_registry.apps INFO     adding unmigrated resources for shared.team
2024-05-02 18:29:01,784 ansible_base.resource_registry.apps INFO     adding unmigrated resources for shared.organization
------------------------------------------------------------------------------- Captured stderr call --------------------------------------------------------------------------------
2024-05-02 18:29:01,851 ansible_base.rbac.caching INFO     Adding 2 object-permission records
2024-05-02 18:29:01,867 django.request ERROR    Internal Server Error: /api/eda/v1/projects/1/
================================================================================= warnings summary ==================================================================================
../../venvs/eda/lib64/python3.11/site-packages/twisted/web/http.py:103
  /home/alancoding/venvs/eda/lib64/python3.11/site-packages/twisted/web/http.py:103: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================== short test summary info ==============================================================================
FAILED tests/integration/dab_rbac/test_related_permissions.py::test_project_credential_access - AssertionError: {'detail': 'Unexpected server error; contact your system administrator'}
==================================================================== 1 failed, 84 deselected, 1 warning in 3.79s ====================================================================
```

^ frustrating output!!!

Now apply this patch

```
================================================================================ test session starts ================================================================================
platform linux -- Python 3.11.9, pytest-7.3.1, pluggy-1.0.0
django: settings: aap_eda.settings.development (from ini)
rootdir: /home/alancoding/repos/eda-server
configfile: pytest.ini
plugins: lazy-fixture-0.6.3, asyncio-0.21.0, cov-4.1.0, django-4.5.2
asyncio: mode=Mode.AUTO
collected 85 items / 84 deselected / 1 selected                                                                                                                                     

tests/integration/dab_rbac/test_related_permissions.py F                                                                                                                      [100%]

===================================================================================== FAILURES ======================================================================================
__________________________________________________________________________ test_project_credential_access ___________________________________________________________________________

cls_factory = <conftest.ModelFactory object at 0x7f19e7829d10>, user = <User: ordinary-user>, user_api_client = <rest_framework.test.APIClient object at 0x7f19e7873250>
give_obj_perm = <function give_obj_perm.<locals>._rf at 0x7f19e76d1440>

    @pytest.mark.django_db
    def test_project_credential_access(
        cls_factory, user, user_api_client, give_obj_perm
    ):
        project = cls_factory.create(models.Project)
        give_obj_perm(user, project, "change")
        url = reverse("project-detail", kwargs={"pk": project.pk})
    
        credential = cls_factory.create(models.EdaCredential)
        assert project.eda_credential_id != credential.pk  # sanity
    
        # User can not view provided credential
>       response = user_api_client.patch(
            url, data={"eda_credential_id": credential.pk}
        )

tests/integration/dab_rbac/test_related_permissions.py:66: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../venvs/eda/lib64/python3.11/site-packages/rest_framework/test.py:312: in patch
    response = super().patch(
../../venvs/eda/lib64/python3.11/site-packages/rest_framework/test.py:218: in patch
    return self.generic('PATCH', path, data, content_type, **extra)
../../venvs/eda/lib64/python3.11/site-packages/rest_framework/test.py:234: in generic
    return super().generic(
../../venvs/eda/lib64/python3.11/site-packages/django/test/client.py:609: in generic
    return self.request(**r)
../../venvs/eda/lib64/python3.11/site-packages/rest_framework/test.py:286: in request
    return super().request(**kwargs)
../../venvs/eda/lib64/python3.11/site-packages/rest_framework/test.py:238: in request
    request = super().request(**kwargs)
../../venvs/eda/lib64/python3.11/site-packages/django/test/client.py:891: in request
    self.check_exception(response)
../../venvs/eda/lib64/python3.11/site-packages/django/test/client.py:738: in check_exception
    raise exc_value
../../venvs/eda/lib64/python3.11/site-packages/django/core/handlers/exception.py:55: in inner
    response = get_response(request)
../../venvs/eda/lib64/python3.11/site-packages/django/core/handlers/base.py:197: in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
../../venvs/eda/lib64/python3.11/site-packages/django/views/decorators/csrf.py:56: in wrapper_view
    return view_func(*args, **kwargs)
../../venvs/eda/lib64/python3.11/site-packages/rest_framework/viewsets.py:124: in view
    return self.dispatch(request, *args, **kwargs)
../../venvs/eda/lib64/python3.11/site-packages/rest_framework/views.py:509: in dispatch
    response = self.handle_exception(exc)
../../venvs/eda/lib64/python3.11/site-packages/rest_framework/views.py:469: in handle_exception
    self.raise_uncaught_exception(exc)
../../venvs/eda/lib64/python3.11/site-packages/rest_framework/views.py:480: in raise_uncaught_exception
    raise exc
../../venvs/eda/lib64/python3.11/site-packages/rest_framework/views.py:506: in dispatch
    response = handler(request, *args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <aap_eda.api.views.project.ProjectViewSet object at 0x7f19e7247ed0>, request = <rest_framework.request.Request: PATCH '/api/eda/v1/projects/1/'>, pk = '1'

    @extend_schema(
        description="Partial update of a project",
        request=serializers.ProjectUpdateRequestSerializer,
        responses={
            status.HTTP_200_OK: OpenApiResponse(
                serializers.ProjectSerializer,
                description="Update successful. Return an updated project.",
            ),
            status.HTTP_400_BAD_REQUEST: OpenApiResponse(
                None,
                description="Update failed with bad request.",
            ),
            status.HTTP_409_CONFLICT: OpenApiResponse(
                None,
                description="Update failed with integrity checking.",
            ),
        },
    )
    def partial_update(self, request, pk):
>       raise Exception('alan!')
E       Exception: alan!

src/aap_eda/api/views/project.py:172: Exception
------------------------------------------------------------------------------- Captured stdout setup -------------------------------------------------------------------------------
Adding content type 'core | user'
Adding content type 'core | activation'
Adding content type 'core | activationinstancejobinstance'
Adding content type 'core | auditaction'
Adding content type 'core | auditevent'
Adding content type 'core | auditrule'
Adding content type 'core | awxtoken'
Adding content type 'core | credential'
Adding content type 'core | decisionenvironment'
Adding content type 'core | extravar'
Adding content type 'core | job'
Adding content type 'core | jobinstance'
Adding content type 'core | jobinstanceevent'
Adding content type 'core | jobinstancehost'
Adding content type 'core | permission'
Adding content type 'core | project'
Adding content type 'core | rulebook'
Adding content type 'core | ruleset'
Adding content type 'core | rule'
Adding content type 'core | role'
Adding content type 'core | activationrequestqueue'
Adding content type 'core | rulebookprocess'
Adding content type 'core | rulebookprocesslog'
Adding content type 'core | eventstream'
Adding content type 'core | credentialtype'
Adding content type 'core | edacredential'
Adding content type 'core | rulebookprocessqueue'
Adding content type 'core | organization'
Adding content type 'core | team'
------------------------------------------------------------------------------- Captured stderr setup -------------------------------------------------------------------------------
2024-05-02 18:31:04,097 ansible_base.resource_registry.apps INFO     updating resource types
2024-05-02 18:31:04,122 ansible_base.resource_registry.apps INFO     adding unmigrated resources for shared.user
2024-05-02 18:31:04,131 ansible_base.resource_registry.apps INFO     adding unmigrated resources for shared.team
2024-05-02 18:31:04,141 ansible_base.resource_registry.apps INFO     adding unmigrated resources for shared.organization
------------------------------------------------------------------------------- Captured stderr call --------------------------------------------------------------------------------
2024-05-02 18:31:04,270 ansible_base.rbac.caching INFO     Adding 2 object-permission records
2024-05-02 18:31:04,299 django.request ERROR    Internal Server Error: /api/eda/v1/projects/1/
Traceback (most recent call last):
  File "/home/alancoding/venvs/eda/lib64/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/eda/lib64/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/eda/lib64/python3.11/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/eda/lib64/python3.11/site-packages/rest_framework/viewsets.py", line 124, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/eda/lib64/python3.11/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/eda/lib64/python3.11/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/home/alancoding/venvs/eda/lib64/python3.11/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/home/alancoding/venvs/eda/lib64/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/repos/eda-server/src/aap_eda/api/views/project.py", line 172, in partial_update
    raise Exception('alan!')
Exception: alan!
================================================================================= warnings summary ==================================================================================
../../venvs/eda/lib64/python3.11/site-packages/twisted/web/http.py:103
  /home/alancoding/venvs/eda/lib64/python3.11/site-packages/twisted/web/http.py:103: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================== short test summary info ==============================================================================
FAILED tests/integration/dab_rbac/test_related_permissions.py::test_project_credential_access - Exception: alan!
==================================================================== 1 failed, 84 deselected, 1 warning in 4.00s ====================================================================

```

:tada: 