### PR TITLE
fix: validate inputs/injectors when creating/updating credential types

### DIFF
--- a/src/aap_eda/api/serializers/credential_type.py
+++ b/src/aap_eda/api/serializers/credential_type.py
@@ -53,10 +53,36 @@ class CredentialTypeCreateSerializer(serializers.ModelSerializer):
     )
 
     def validate(self, data):
-        if data.get("injectors") and data.get("inputs"):
-            errors = validate_injectors(
-                data.get("inputs"), data.get("injectors")
-            )
+        injectors = data.get("injectors")
+        inputs = data.get("inputs")
+
+        if self.partial:
+            # updating allow injectors/inputs be None, but not empty dict
+            if injectors is not None and not bool(injectors):
+                raise serializers.ValidationError(
+                    "Injectors field cannot be empty"
+                )
+
+            if inputs is not None and not bool(inputs):
+                raise serializers.ValidationError(
+                    "inputs field cannot be empty"
+                )
+
+            injectors = injectors or self.instance.injectors
+            inputs = inputs or self.instance.inputs
+        else:
+            if not bool(injectors):
+                raise serializers.ValidationError(
+                    "Injectors field cannot be empty"
+                )
+
+            if not bool(inputs):
+                raise serializers.ValidationError(
+                    "Inputs field cannot be empty"
+                )
+
+        if injectors and inputs:
+            errors = validate_injectors(inputs, injectors)
             if bool(errors):
                 raise serializers.ValidationError(errors)
 

--- a/src/aap_eda/api/serializers/credential_type.py
+++ b/src/aap_eda/api/serializers/credential_type.py
@@ -43,8 +43,13 @@ class CredentialTypeCreateSerializer(serializers.ModelSerializer):
     inputs = serializers.JSONField(
         required=True,
         allow_null=False,
-        help_text="Name of the credential type",
+        help_text="Inputs of the credential type",
         validators=[validators.check_if_schema_valid],
+    )
+    injectors = serializers.JSONField(
+        required=True,
+        allow_null=False,
+        help_text="Injectors of the credential type",
     )
     organization_id = serializers.IntegerField(
         required=False,
@@ -57,31 +62,9 @@ class CredentialTypeCreateSerializer(serializers.ModelSerializer):
         inputs = data.get("inputs")
 
         if self.partial:
-            # updating allow injectors/inputs be None, but not empty dict
-            if injectors is not None and not bool(injectors):
-                raise serializers.ValidationError(
-                    "Injectors field cannot be empty"
-                )
-
-            if inputs is not None and not bool(inputs):
-                raise serializers.ValidationError(
-                    "inputs field cannot be empty"
-                )
-
-            injectors = injectors or self.instance.injectors
             inputs = inputs or self.instance.inputs
-        else:
-            if not bool(injectors):
-                raise serializers.ValidationError(
-                    "Injectors field cannot be empty"
-                )
 
-            if not bool(inputs):
-                raise serializers.ValidationError(
-                    "Inputs field cannot be empty"
-                )
-
-        if injectors and inputs:
+        if injectors or injectors == {}:
             errors = validate_injectors(inputs, injectors)
             if bool(errors):
                 raise serializers.ValidationError(errors)

--- a/src/aap_eda/core/utils/credentials.py
+++ b/src/aap_eda/core/utils/credentials.py
@@ -236,13 +236,9 @@ def validate_schema(schema: dict) -> list[str]:
 
 def validate_injectors(schema: dict, injectors: dict) -> dict:
     errors = []
-    context = _default_context(schema)
 
     if not isinstance(injectors, dict):
-        errors.append(
-            "Injectors must be a dict type and defines keys"
-            f" in {SUPPORTED_KEYS_IN_INJECTORS}"
-        )
+        errors.append("Injectors must be in Key-Value pairs format")
 
     if not any(
         support_key in injectors.keys()
@@ -252,6 +248,8 @@ def validate_injectors(schema: dict, injectors: dict) -> dict:
             "Injectors must have keys defined in"
             f" {SUPPORTED_KEYS_IN_INJECTORS}"
         )
+
+    context = _default_context(schema)
 
     for field in SUPPORTED_KEYS_IN_INJECTORS:
         input_data = injectors.get(field)
@@ -284,7 +282,7 @@ def _get_id_fields(schema: dict) -> list[str]:
 def _default_context(schema: dict) -> dict:
     results = {}
 
-    fields = schema.get("fields")
+    fields = schema.get("fields", [])
 
     for field in fields:
         field_type = field.get("type")

--- a/tests/integration/api/test_credential_type.py
+++ b/tests/integration/api/test_credential_type.py
@@ -98,6 +98,30 @@ def test_create_credential_type(admin_client: APIClient):
     assert response.status_code == status.HTTP_201_CREATED
     assert response.data["name"] == "credential_type_1"
 
+    data_in = {
+        "name": "credential_type_2",
+        "description": "desc here",
+        "inputs": INPUT,
+    }
+
+    response = admin_client.post(
+        f"{api_url_v1}/credential-types/", data=data_in
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "This field is required." in response.data["injectors"]
+
+    data_in = {
+        "name": "credential_type_3",
+        "description": "desc here",
+        "injectors": injectors,
+    }
+
+    response = admin_client.post(
+        f"{api_url_v1}/credential-types/", data=data_in
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "This field is required." in response.data["inputs"]
+
 
 @pytest.mark.django_db
 def test_create_credential_type_sans_type(admin_client: APIClient):
@@ -309,8 +333,8 @@ def test_partial_update_inputs_credential_type(
         (
             {},
             status.HTTP_400_BAD_REQUEST,
-            "non_field_errors",
-            "Injectors field cannot be empty",
+            "injectors",
+            "Injectors must have keys defined in ['extra_vars']",
         ),
         (
             {"c": "d"},

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -731,7 +731,7 @@ INPUTS = {
         },
     ]
 }
-INJECTORS = {"extra_vars": {"username": "Fred"}}
+INJECTORS = {"extra_vars": {"password": "{{ password }}"}}
 
 DUMMY_GPG_KEY = """
 -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -729,22 +729,9 @@ INPUTS = {
             "type": "string",
             "secret": True,
         },
-        {
-            "id": "ssh_key_data",
-            "label": "SCM Private Key",
-            "type": "string",
-            "format": "ssh_private_key",
-            "secret": True,
-            "multiline": True,
-        },
-        {
-            "id": "ssh_key_unlock",
-            "label": "Private Key Passphrase",
-            "type": "string",
-            "secret": True,
-        },
     ]
 }
+INJECTORS = {"extra_vars": {"username": "Fred"}}
 
 DUMMY_GPG_KEY = """
 -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -790,7 +777,7 @@ def use_debug_setting():
 def default_credential_type() -> models.CredentialType:
     """Return a default Credential Type."""
     credential_type = models.CredentialType.objects.create(
-        name="default_credential_type", inputs=INPUTS, injectors={}
+        name="default_credential_type", inputs=INPUTS, injectors=INJECTORS
     )
 
     return credential_type
@@ -800,7 +787,7 @@ def default_credential_type() -> models.CredentialType:
 def credential_type() -> models.CredentialType:
     """Return a default Credential Type."""
     credential_type = models.CredentialType.objects.create(
-        name="default_credential_type", inputs=INPUTS, injectors={}
+        name="default_credential_type", inputs=INPUTS, injectors=INJECTORS
     )
 
     return credential_type


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-23687

Raise 400 error if inputs/injectors payload are empty when creating/updating credential types.