### PR TITLE
chore: add remove-orphans on docker-purge task

### DIFF
--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -178,7 +178,7 @@ tasks:
     cmds:
       - task: docker
         vars:
-          CLI_ARGS: down --volumes
+          CLI_ARGS: down --volumes --remove-orphans
 
   docker:psql:
     desc: "Open PostgreSQL console."


### PR DESCRIPTION
To fix:

❯ task docker:up
task: [docker] docker-compose -p eda -f tools/docker/docker-compose-dev.yaml up --detach
WARN[0000] Found orphan containers ([eda-podman-1 eda-eda-activation-worker-2 eda-eda-activation-worker-1 eda-podman-pre-setup-1]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.