### PR TITLE
feat: allow WEBSOCKET_TOKEN_BASE_URL setting

### DIFF
--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -319,9 +319,11 @@ REST_FRAMEWORK = {
 DEPLOYMENT_TYPE = settings.get("DEPLOYMENT_TYPE", "podman")
 WEBSOCKET_BASE_URL = settings.get("WEBSOCKET_BASE_URL", "ws://localhost:8000")
 WEBSOCKET_SSL_VERIFY = settings.get("WEBSOCKET_SSL_VERIFY", "yes")
-WEBSOCKET_TOKEN_BASE_URL = WEBSOCKET_BASE_URL.replace(
-    "ws://", "http://"
-).replace("wss://", "https://")
+WEBSOCKET_TOKEN_BASE_URL = settings.get("WEBSOCKET_TOKEN_BASE_URL", None)
+if WEBSOCKET_TOKEN_BASE_URL is None:
+    WEBSOCKET_TOKEN_BASE_URL = WEBSOCKET_BASE_URL.replace(
+        "ws://", "http://"
+    ).replace("wss://", "https://")
 PODMAN_SOCKET_URL = settings.get("PODMAN_SOCKET_URL", None)
 PODMAN_MEM_LIMIT = settings.get("PODMAN_MEM_LIMIT", "200m")
 PODMAN_ENV_VARS = settings.get("PODMAN_ENV_VARS", {})


### PR DESCRIPTION
There may be deployments where the WEBSOCKET_TOKEN_BASE_URL doesn't coincide with WEBSOCKET_BASE_URL. 
This PR allows to set a different value for WEBSOCKET_TOKEN_BASE_URL. 