### PR TITLE
chore: enforce boolean type for settings.debug

### DIFF
--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -127,6 +127,10 @@ def _get_secret_key() -> str:
 SECRET_KEY = _get_secret_key()
 
 DEBUG = settings.get("DEBUG", False)
+if isinstance(DEBUG, str):
+    DEBUG = DEBUG.lower() in ["true", "yes", "1"]
+if not isinstance(DEBUG, bool):
+    raise ImproperlyConfigured("DEBUG setting must be a boolean value.")
 
 ALLOWED_HOSTS = settings.get("ALLOWED_HOSTS", [])
 ALLOWED_HOSTS = (


### PR DESCRIPTION
As per internal discussions, DEBUG setting can expose sensitive data, and we want to make sure it is correctly set. Support common strings and prevent to enable it accidentally. 