### PR TITLE
chore: fix services.redis.command.4 must be a string

### DIFF
--- a/tools/docker/docker-compose-dev-redis-tls.yaml
+++ b/tools/docker/docker-compose-dev-redis-tls.yaml
@@ -193,7 +193,7 @@ services:
       - --bind
       - 0.0.0.0
       - --port
-      - 0
+      - "0"
       - --tls-port
       - "${EDA_MQ_PORT:-6379}"
       - --tls-cert-file


### PR DESCRIPTION
Fix: 

❯ docker-compose -f docker-compose-dev-redis-tls.yaml start
validating /home/mmagnani/Workspace/redhat/ansible/eda/eda-server/tools/docker/docker-compose-dev-redis-tls.yaml: services.redis.command.4 must be a string