### PR TITLE
Declare parameters of only 2 sublists we get from DAB

### DIFF
--- a/src/aap_eda/api/views/dab_decorate.py
+++ b/src/aap_eda/api/views/dab_decorate.py
@@ -14,11 +14,14 @@
 
 from ansible_base.rbac.api import views
 from drf_spectacular.utils import (
+    OpenApiParameter,
     OpenApiResponse,
     extend_schema,
     extend_schema_view,
 )
 from rest_framework import status
+
+from ansible_base.rbac.api.router import router as rbac_router
 
 from aap_eda.api.views.dab_base import convert_to_create_serializer
 
@@ -40,3 +43,20 @@ for viewset_cls in [
             },
         ),
     )(viewset_cls)
+
+
+for url, viewset, view_name in rbac_router.registry:
+    if view_name in ('roledefinition-user_assignments', 'roledefinition-team_assignments'):
+        extend_schema_view(
+            list=extend_schema(
+                request=None,
+                parameters=[
+                    OpenApiParameter(
+                        name="id",
+                        type=int,
+                        location=OpenApiParameter.PATH,
+                        description="A unique integer value identifying this assignment.",  # noqa: E501
+                    )
+                ],
+            )
+        )(viewset)


### PR DESCRIPTION
Depends on https://github.com/ansible/django-ansible-base/pull/410, this patch does not yet update the version so you'll probably see errors until then.

AAP-24205

This changes the behavior from

```json
        "/role_definitions/{id}/team_assignments/": {
            "get": {
                "operationId": "role_definitions_team_assignments_list",
                "description": "Mixin used for related viewsets which contain a sub-list, like /organizations/N/teams/",
                "parameters": [
                    {
                        "in": "path",
                        "name": "id",
                        "schema": {
                            "type": "string",
                            "pattern": "^[0-9]+$"
                        },
                        "required": true
                    },
```

to 

```json
        "/role_definitions/{id}/user_assignments/": {
            "get": {
                "operationId": "role_definitions_user_assignments_list",
                "description": "Mixin used for related viewsets which contain a sub-list, like /organizations/N/teams/",
                "parameters": [
                    {
                        "in": "path",
                        "name": "id",
                        "schema": {
                            "type": "integer"
                        },
                        "description": "A unique integer value identifying this assignment.",
                        "required": true
                    },
```