### PR TITLE
fix: change request body of update to role_definition_create

### DIFF
--- a/src/aap_eda/api/views/dab_decorate.py
+++ b/src/aap_eda/api/views/dab_decorate.py
@@ -41,6 +41,16 @@ for viewset_cls in [
                 ),
             },
         ),
+        update=extend_schema(
+            description=f"Update a {cls_name}.",
+            request=convert_to_create_serializer(viewset_cls.serializer_class),
+            responses={
+                status.HTTP_200_OK: OpenApiResponse(
+                    viewset_cls.serializer_class,
+                    description=f"Return an updated {cls_name}.",
+                ),
+            },
+        ),
     )(viewset_cls)
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-22846

This PR changes the request body of PUT action for `/role_definitions/:id/` from RoleDefinitionDetail to RoleDefintionCreate. 

![image](https://github.com/ansible/eda-server/assets/12900250/84c0480c-a90c-4e5d-9188-920f49757131)
