### PR TITLE
WIP fix: add delay to prevent starting parallel activations

### DIFF
--- a/src/aap_eda/tasks/orchestrator.py
+++ b/src/aap_eda/tasks/orchestrator.py
@@ -14,6 +14,7 @@
 
 import logging
 import random
+import time
 from collections import Counter
 from datetime import datetime, timedelta
 from typing import Optional, Union
@@ -463,7 +464,16 @@ def monitor_rulebook_processes() -> None:
     activation.
     """
     # run pending user requests
+    add_delay = False
     for request in requests_queue.list_requests():
+        if request.request in [
+            ActivationRequest.START,
+            ActivationRequest.AUTO_START,
+        ]:
+            if add_delay:
+                time.sleep(random.randint(2, 5))
+            else:
+                add_delay = True
         dispatch(
             request.process_parent_type,
             request.process_parent_id,


### PR DESCRIPTION
When we have multiple workers (the usual scenario) and we create or enable a batch of activations, the activations are scheduled and processed in parallel causing sometimes a race condition. The race condition has two potential effects:
- If all the nodes are idle, the dispatcher can schedule the activations in the same node, reaching the "max_activations_limit" and postponing some of them. This loop can happen multiple times depending on the amount of activations and workers. 
- We create more activations than the allowed by the max_limit_activations. 

As per internal discussions, add a random delay when scheduling start operation to break the potential parallelism. 