### PR TITLE
Add wait-for-migrations script to be used in eda-server container on k8s

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -11,6 +11,9 @@ RUN mkdir -p /var/lib/eda/redis-tls \
     && chmod 0775 /var/lib/eda/redis-tls
 COPY ./tools/docker/redis-tls /var/lib/eda/redis-tls
 
+
+COPY ./tools/docker/assets/wait-for-migrations /var/lib/eda/wait-for-migrations
+
 RUN DNF=dnf \
     INSTALL_PACKAGES="python3.11 \
     python3.11-devel \

--- a/tools/docker/assets/wait-for-migrations
+++ b/tools/docker/assets/wait-for-migrations
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+readonly CMDNAME=$(basename "$0")
+
+readonly MIN_SLEEP=0.5
+readonly MAX_SLEEP=30
+readonly TIMEOUT=60
+
+log_message() { echo "[${CMDNAME}]" "$@" >&2; }
+log_error() { echo "[${CMDNAME}] ERROR:" "$@" >&2; }
+
+# Args: last_sleep
+next_sleep() {
+    awk "BEGIN {ns = ${1} * 2; ns = ns > ${MAX_SLEEP} ? ${MAX_SLEEP} : ns; print(ns)}"
+}
+
+wait_for() {
+    local rc=1
+    local attempt=1
+    local next_sleep="${MIN_SLEEP}"
+    local check=1
+
+    while true; do
+        log_message "Attempt ${attempt}"
+
+        timeout "${TIMEOUT}" \
+                /bin/bash -c "aap-eda-manage check" &>/dev/null
+        check=$?
+
+        if [ $check -eq 0 ]; then
+            timeout "${TIMEOUT}" \
+                    /bin/bash -c "! aap-eda-manage showmigrations | grep '\[ \]'" &>/dev/null \
+                && return || rc=$?
+        fi
+
+        attempt=$((attempt + 1))
+        log_message "Waiting ${next_sleep} seconds before next attempt"
+        sleep "${next_sleep}"
+        next_sleep=$(next_sleep ${next_sleep})
+    done
+
+    return $rc
+}
+
+main() {
+    log_message "Waiting for database migrations..."
+    if ! wait_for "$@"; then
+        log_message "ERROR: Database migrations not applied"
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
Add wait-for-migrations script to be used in eda-server container on k8s.

This will allow us to wait until migrations are complete before fully starting the scheduler and worker pods.  It will be run in an initContainer for those deployments.  