### PR TITLE
fix: fix wrong atomic operation when create activation instance. 

### DIFF
--- a/src/aap_eda/services/activation/activation_manager.py
+++ b/src/aap_eda/services/activation/activation_manager.py
@@ -195,6 +195,8 @@ class ActivationManager(StatusManager):
             "Creating a new activation instance for "
             f"activation: {self.db_instance.id}",
         )
+        if not self.check_new_process_allowed():
+            raise exceptions.MaxRunningProcessesError
         self._create_activation_instance()
 
         self.db_instance.refresh_from_db()
@@ -982,9 +984,6 @@ class ActivationManager(StatusManager):
             if hasattr(self.db_instance, "git_hash")
             else ""
         )
-
-        if not self.check_new_process_allowed():
-            raise exceptions.MaxRunningProcessesError
         args = {
             "name": self.db_instance.name,
             "status": ActivationStatus.STARTING,


### PR DESCRIPTION
In https://github.com/ansible/eda-server/pull/916 I introduced a bug making the creation of the activation instance an atomic operation, we call inside the operation the "set_status" as part of the check for new processes and raise an exception, so when the check is true, the transaction is undone and the activation remains in "starting" status. 

Jira: https://issues.redhat.com/browse/AAP-25010