### PR TITLE
feat(dispatcher): return random queue with multiple candidates

### DIFF
--- a/src/aap_eda/tasks/orchestrator.py
+++ b/src/aap_eda/tasks/orchestrator.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import logging
+import random
 from collections import Counter
 from datetime import datetime, timedelta
 from typing import Optional, Union
@@ -333,7 +334,13 @@ def get_least_busy_queue_name() -> str:
             "No healthy queue found to dispatch the request",
         )
 
-    return queue_counter.most_common()[-1][0]
+    min_count = queue_counter.most_common()[-1][1]
+    least_common = [
+        queue for queue, count in queue_counter.items() if count == min_count
+    ]
+    if len(least_common) == 1:
+        return least_common[0]
+    return random.choice(least_common)
 
 
 def get_queue_name_by_parent_id(

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -274,10 +274,8 @@ def test_get_least_busy_queue_name_multiple_queues(
         "queue1",
         "queue2",
     ]
-    unexpected_queue = "queue3"
     queue = get_least_busy_queue_name()
     assert queue in expected_queues
-    assert queue != unexpected_queue
 
 
 @pytest.fixture

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -213,6 +213,33 @@ def two_queues_neither_responsive(monkeypatch):
     )
 
 
+@pytest.fixture
+def three_queues_two_candidates(monkeypatch):
+    return _mock_up_queues(
+        monkeypatch,
+        {
+            "queue1": {
+                "workers": {
+                    "worker1_1": {"responsive": True},
+                },
+                "process_count": 1,
+            },
+            "queue2": {
+                "workers": {
+                    "worker2_1": {"responsive": True},
+                },
+                "process_count": 1,
+            },
+            "queue3": {
+                "workers": {
+                    "worker3_1": {"responsive": True},
+                },
+                "process_count": 2,
+            },
+        },
+    )
+
+
 @pytest.mark.parametrize(
     "fixture",
     [
@@ -238,6 +265,19 @@ def test_get_least_busy_queue_name(fixture, request):
     else:
         with pytest.raises(HealthyQueueNotFoundError):
             get_least_busy_queue_name()
+
+
+def test_get_least_busy_queue_name_multiple_queues(
+    three_queues_two_candidates,
+):
+    expected_queues = [
+        "queue1",
+        "queue2",
+    ]
+    unexpected_queue = "queue3"
+    queue = get_least_busy_queue_name()
+    assert queue in expected_queues
+    assert queue != unexpected_queue
 
 
 @pytest.fixture


### PR DESCRIPTION
The current implementation always gives priority to the first queue configured. 
If there are multiple candidates, returns one randomly. 