### PR TITLE
fix: set job id for scheduled jobs

### DIFF
--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -442,14 +442,22 @@ RQ_QUEUES = get_rq_queues()
 RULEBOOK_QUEUE_NAME = settings.get("RULEBOOK_QUEUE_NAME", "activation")
 
 RQ_STARTUP_JOBS = []
+
+# Id of the scheduler job it's required when we have multiple instances of
+# the scheduler running to avoid duplicate jobs
 RQ_PERIODIC_JOBS = [
     {
         "func": (
             "aap_eda.tasks.orchestrator.enqueue_monitor_rulebook_processes"
         ),
         "interval": 5,
+        "id": "enqueue_monitor_rulebook_processes",
     },
-    {"func": "aap_eda.tasks.project.monitor_project_tasks", "interval": 30},
+    {
+        "func": "aap_eda.tasks.project.monitor_project_tasks",
+        "interval": 30,
+        "id": "monitor_project_tasks",
+    },
 ]
 RQ_CRON_JOBS = []
 RQ_SCHEDULER_JOB_INTERVAL = settings.get("SCHEDULER_JOB_INTERVAL", 5)


### PR DESCRIPTION
We have noticed that the lock mechanism in the scheduler is not 100% reliable and when multiple schedulers are executed at the exact same time they can duplicate the jobs. Set the job_id to a static value so we can make sure we schedule always only one job. 

Jira: https://issues.redhat.com/browse/AAP-25019