### PR TITLE
Creating a new Team with the same name should not propagate IntegrityError

### DIFF
--- a/src/aap_eda/api/serializers/team.py
+++ b/src/aap_eda/api/serializers/team.py
@@ -57,6 +57,9 @@ class TeamCreateSerializer(
 
     def validate(self, data):
         self.validate_shared_resource()
+        validators.check_if_team_name_exists(
+            data["name"], data["organization_id"]
+        )
         return data
 
 

--- a/src/aap_eda/core/validators.py
+++ b/src/aap_eda/core/validators.py
@@ -235,3 +235,16 @@ def check_credential_types(
         raise serializers.ValidationError(
             f"The type of credential can only be one of {names}"
         )
+
+
+def check_if_team_name_exists(name: str, organization_id: int):
+    if models.Team.objects.filter(
+        name=name, organization_id=organization_id
+    ).exists():
+        raise serializers.ValidationError(
+            {
+                "name": [
+                    "A team with this name already exists in the organization."
+                ]
+            }
+        )


### PR DESCRIPTION
When attempting to create a team with the same name as an existing team within the same organization, the API currently returns a HTTP 500 error. While this correctly identifies this, the error handling can be improved to provide a more user-friendly response.
