### PR TITLE
Allow using go-task instead of task

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 repos:
   - repo: local
     hooks:
-      # This allows using either task or go-task, depending on what is installed
+      # This allows using task or go-task, depending on what is installed
       - id: black
         name: black
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,28 +6,28 @@ repos:
         name: black
         language: system
         types: [python]
-        entry: task lint:black --
+        entry: command -v task > /dev/null && CMD=task || CMD=go-task; ${CMD} lint:black --
       - id: isort
         name: isort
         language: system
         types: [python]
-        entry: task lint:isort --
+        entry: command -v task > /dev/null && CMD=task || CMD=go-task; ${CMD} lint:isort --
       - id: ruff
         name: ruff
         language: system
         types: [python]
-        entry: task lint:ruff --
+        entry: command -v task > /dev/null && CMD=task || CMD=go-task; ${CMD} lint:ruff --
       - id: flake8
         name: flake8
         language: system
         types: [python]
-        entry: task lint:flake8 --
+        entry: command -v task > /dev/null && CMD=task || CMD=go-task; ${CMD} lint:flake8 --
       - id: migrations
         name: migrations
         language: system
         types: [python]
         pass_filenames: false
-        entry: task lint:migrations
+        entry: command -v task > /dev/null && CMD=task || CMD=go-task; ${CMD} lint:migrations
   - repo: https://github.com/python-poetry/poetry
     rev: '1.4.0'
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@
 repos:
   - repo: local
     hooks:
+      # This allows using either task or go-task, depending on what is installed
       - id: black
         name: black
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 repos:
   - repo: local
     hooks:
-      # This allows using task or go-task, depending on what is installed
+      # CMD logic allows using task or go-task, depending on what is installed
       - id: black
         name: black
         language: system

--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -15,7 +15,7 @@ tasks:
   default:
     desc: "Show this message and exit"
     cmds:
-      - task -l
+      - command -v task > /dev/null && CMD=task || CMD=go-task; ${CMD} -l
     silent: true
 
   dev:init:


### PR DESCRIPTION
Related to https://github.com/ansible/aap-gateway/pull/422

This changes things so that you can use `go-task` within the normal development flow. I wound up disabling this stuff locally to get by. Most things still work like `go-task docker:up:minimal`, but the pre-commit stuff is probably the most painful item here with no other obvious solution without code changes.