### PR TITLE
chore: the redis image should match the architecture

### DIFF
--- a/tools/docker/docker-compose-mac.yml
+++ b/tools/docker/docker-compose-mac.yml
@@ -170,7 +170,7 @@ services:
       start_period: 5s
 
   redis:
-    image: 'quay.io/fedora/redis-6:latest'
+    image: 'docker.io/library/redis:6.2.14'
     ports:
       - '${EDA_REDIS_PORT:-6379}:6379'
     healthcheck:


### PR DESCRIPTION
The current redis image doesn't match the chip architecture on M1 Macs and uses amd64 instead of arm64. Also we are seeing periodic shutting down of redis.