### PR TITLE
fix: make redis_prefix static config

### DIFF
--- a/src/aap_eda/core/tasking/__init__.py
+++ b/src/aap_eda/core/tasking/__init__.py
@@ -2,17 +2,13 @@
 from __future__ import annotations
 
 import logging
-import sys
-import uuid
 from datetime import datetime, timedelta
 from types import MethodType
 from typing import Any, Callable, Iterable, Optional, Protocol, Type, Union
 
 import rq
 import rq_scheduler
-from ansible_base.resource_registry.models.service_identifier import service_id
 from django.conf import settings
-from django.db.utils import ProgrammingError
 from django_rq import enqueue, get_queue, get_scheduler, job
 from django_rq.queues import Queue as _Queue
 from rq import Connection, Worker as _Worker, results
@@ -48,34 +44,8 @@ _ErrorHandlersArgType = Union[
 ]
 
 
-class NoServiceIdError(Exception):
-    ...
-
-
-def get_redis_prefix():
-    try:
-        return f"EDA-{service_id()[0:8]}-rq"
-    except ProgrammingError:
-        # service_id() will fail at the first migration when
-        # dab_resource_registry_serviceid has not been created
-        if any(
-            arg in sys.argv for arg in ["runserver", "scheduler", "rqworker"]
-        ):
-            raise NoServiceIdError(
-                "service_id is required to start the service"
-            )
-        logger.info("Failed ot get service_id. Continue")
-        return ""
-
-
 def enable_redis_prefix():
-    if rq.worker_registration.REDIS_WORKER_KEYS != "rq:workers":
-        # changes have been made
-        return
-
-    redis_prefix = get_redis_prefix()
-    if not redis_prefix:
-        return
+    redis_prefix = settings.REDIS_PREFIX
 
     rq.worker_registration.REDIS_WORKER_KEYS = f"{redis_prefix}:workers"
     rq.worker_registration.WORKERS_BY_QUEUE_KEY = f"{redis_prefix}:workers:%s"

--- a/src/aap_eda/core/tasking/__init__.py
+++ b/src/aap_eda/core/tasking/__init__.py
@@ -45,7 +45,7 @@ _ErrorHandlersArgType = Union[
 
 
 def enable_redis_prefix():
-    redis_prefix = settings.REDIS_PREFIX
+    redis_prefix = settings.RQ_REDIS_PREFIX
 
     rq.worker_registration.REDIS_WORKER_KEYS = f"{redis_prefix}:workers"
     rq.worker_registration.WORKERS_BY_QUEUE_KEY = f"{redis_prefix}:workers:%s"

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -369,7 +369,7 @@ REDIS_CLIENT_CACERT_PATH = settings.get("MQ_CLIENT_CACERT_PATH", None)
 REDIS_CLIENT_CERT_PATH = settings.get("MQ_CLIENT_CERT_PATH", None)
 REDIS_CLIENT_KEY_PATH = settings.get("MQ_CLIENT_KEY_PATH", None)
 REDIS_DB = settings.get("MQ_DB", 0)
-REDIS_PREFIX = settings.get("REDIS_PREFIX", "eda-rq")
+RQ_REDIS_PREFIX = settings.get("RQ_REDIS_PREFIX", "eda-rq")
 
 
 def _rq_common_parameters():

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -369,6 +369,7 @@ REDIS_CLIENT_CACERT_PATH = settings.get("MQ_CLIENT_CACERT_PATH", None)
 REDIS_CLIENT_CERT_PATH = settings.get("MQ_CLIENT_CERT_PATH", None)
 REDIS_CLIENT_KEY_PATH = settings.get("MQ_CLIENT_KEY_PATH", None)
 REDIS_DB = settings.get("MQ_DB", 0)
+REDIS_PREFIX = settings.get("REDIS_PREFIX", "eda")
 
 
 def _rq_common_parameters():

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -369,7 +369,7 @@ REDIS_CLIENT_CACERT_PATH = settings.get("MQ_CLIENT_CACERT_PATH", None)
 REDIS_CLIENT_CERT_PATH = settings.get("MQ_CLIENT_CERT_PATH", None)
 REDIS_CLIENT_KEY_PATH = settings.get("MQ_CLIENT_KEY_PATH", None)
 REDIS_DB = settings.get("MQ_DB", 0)
-REDIS_PREFIX = settings.get("REDIS_PREFIX", "eda")
+REDIS_PREFIX = settings.get("REDIS_PREFIX", "eda-rq")
 
 
 def _rq_common_parameters():


### PR DESCRIPTION
Follow up https://github.com/ansible/eda-server/pull/897
and https://github.com/ansible/eda-server/pull/926

As per internal discussions, we agreed to make the redis_prefix a static configuration. Using the service_id as the redis_prefix is problematic because the value is obtained from the database after migrations, but we need it during the early initialization of the application. This reverses the expected order of startup dependencies and causes problems with commands that should not require a DB connection, such as "collectstatic". Additionally, a meaningless prefix makes debugging much more difficult.

EDA is the only component following this pattern, with this PR it is in line with other components where the prefix is a static setting. 

Internal ref: https://redhat-internal.slack.com/archives/C06S8Q06AB0/p1718889268198969?thread_ts=1717425927.035389&cid=C06S8Q06AB0
