### PR TITLE
fix: add router_basename for models with compound words

### DIFF
--- a/src/aap_eda/core/models/credential_type.py
+++ b/src/aap_eda/core/models/credential_type.py
@@ -20,6 +20,8 @@ __all__ = ("CredentialType",)
 
 
 class CredentialType(BaseOrgModel, UniqueNamedModel):
+    router_basename = "credentialtype"
+
     class Meta:
         db_table = "core_credential_type"
         constraints = [

--- a/src/aap_eda/core/models/decision_environment.py
+++ b/src/aap_eda/core/models/decision_environment.py
@@ -20,6 +20,8 @@ __all__ = ("DecisionEnvironment",)
 
 
 class DecisionEnvironment(BaseOrgModel, UniqueNamedModel):
+    router_basename = "decisionenvironment"
+
     class Meta:
         db_table = "core_decision_environment"
         constraints = [

--- a/src/aap_eda/core/models/eda_credential.py
+++ b/src/aap_eda/core/models/eda_credential.py
@@ -22,6 +22,8 @@ __all__ = ("EdaCredential",)
 
 
 class EdaCredential(BaseOrgModel, UniqueNamedModel):
+    router_basename = "edacredential"
+
     class Meta:
         db_table = "core_eda_credential"
         constraints = [

--- a/src/aap_eda/core/models/event_stream.py
+++ b/src/aap_eda/core/models/event_stream.py
@@ -35,6 +35,8 @@ class EventStream(
 ):
     """Model representing an event stream."""
 
+    router_basename = "eventstream"
+
     description = models.TextField(default="", blank=True)
     is_enabled = models.BooleanField(default=True)
     decision_environment = models.ForeignKey(

--- a/src/aap_eda/core/models/rulebook.py
+++ b/src/aap_eda/core/models/rulebook.py
@@ -87,6 +87,8 @@ class Rule(models.Model):
 
 
 class AuditRule(BaseOrgModel):
+    router_basename = "auditrule"
+
     class Meta:
         db_table = "core_audit_rule"
         indexes = [


### PR DESCRIPTION
It helps to reverse the url to access the resource

Needed by https://github.com/ansible/django-ansible-base/blob/devel/ansible_base/lib/abstract_models/common.py#L21

AAP-25487: Role user assignment response missing content_object except for Activations