### PR TITLE
fix: add router-basename for RulebookProcess

### DIFF
--- a/src/aap_eda/core/models/rulebook_process.py
+++ b/src/aap_eda/core/models/rulebook_process.py
@@ -43,6 +43,8 @@ class RulebookProcess(BaseOrgModel):
     that is created when an activation or event stream is started.
     """
 
+    router_basename = "activationinstance"
+
     name = models.TextField(null=False, default="")
     status = models.TextField(
         choices=ActivationStatus.choices(),


### PR DESCRIPTION
Follow up #949. It does not affect AAP-25487, but nice to point RuleBookProcess to its correct basename