### PR TITLE
fix: add setting to enable global roles for users

### DIFF
--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -645,6 +645,8 @@ ANSIBLE_BASE_ORGANIZATION_MODEL = "core.Organization"
 # Organization and object roles will come from create_initial_data
 ANSIBLE_BASE_ROLE_PRECREATE = {}
 
+ANSIBLE_BASE_ALLOW_SINGLETON_USER_ROLES = True
+
 # --------------------------------------------------------
 # DJANGO ANSIBLE BASE RESOURCE API CLIENT
 # --------------------------------------------------------


### PR DESCRIPTION
This PR aims to resolve the following error when logging in as a user with global roles, such as system auditor. 

![Screenshot 2024-06-27 at 1 25 45 PM](https://github.com/ansible/eda-server/assets/31990136/ea5afdd4-182e-4440-8c72-c94b2d0eaf40)


JIRA: [AAP-25834](https://issues.redhat.com/browse/AAP-25834)