### PR TITLE
ci: increase timeout for multinode tests

### DIFF
--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -149,5 +149,8 @@ jobs:
           EDAQA_FERNET_PASSWORD: ${{ secrets.EDAQA_FERNET_PASSWORD }}
           EDAQA_ENV: default
           EDAQA_MULTINODE_EDA_SERVER_PATH: "../"
+          # multinode-upstream tests require a longer timeout
+          # to allow for the time it takes to start the workers inside the tests
+          EDAQA_DEFAULT_TIMEOUT: 120
         run: |
           pytest -vv -s eda_qa/tests/multinode-upstream


### PR DESCRIPTION
We have issues with multinode pipeline because the workers are not ready in time and the test suite reaches the timeout when importing the project. The issue has become more frequent after https://github.com/ansible/eda-server/pull/957

Increase the timeout for this pipeline to avoid false negatives. With ~60 seconds could be good enough but with 120 we get protected when the GH performance is particularly bad. 