### PR TITLE
feat: add filtering for superusers in users list view

### DIFF
--- a/src/aap_eda/api/views/user.py
+++ b/src/aap_eda/api/views/user.py
@@ -252,7 +252,7 @@ class UserViewSet(
         return serializers.UserDetailSerializer
 
     @extend_schema(
-        description="List all users",
+        description="List users",
         request=None,
         responses={
             status.HTTP_200_OK: OpenApiResponse(

--- a/tests/integration/api/test_user.py
+++ b/tests/integration/api/test_user.py
@@ -353,6 +353,34 @@ def test_list_users(
 
 
 @pytest.mark.django_db
+def test_list_users_filter_superuser(
+    admin_client: APIClient,
+    admin_user: models.User,
+    super_user: models.User,
+):
+    response = admin_client.get(f"{api_url_v1}/users/")
+    assert response.status_code == status.HTTP_200_OK
+    results = response.json()["results"]
+    assert len(results) == 2
+
+    # retrieve only superusers
+    response = admin_client.get(f"{api_url_v1}/users/?is_superuser=true")
+    assert response.status_code == status.HTTP_200_OK
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == super_user.id
+    assert results[0]["is_superuser"] is True
+
+    # retrieve only non-superusers
+    response = admin_client.get(f"{api_url_v1}/users/?is_superuser=false")
+    assert response.status_code == status.HTTP_200_OK
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == admin_user.id
+    assert results[0]["is_superuser"] is False
+
+
+@pytest.mark.django_db
 def test_partial_update_user(
     admin_client: APIClient,
     admin_user: models.User,


### PR DESCRIPTION
This PR considers the following 3 new cases in users list view:

1. `?is_superuser=true` - returns only superusers
2. `?is_superuser=false` - returns only non-superusers
3. no query param - returns all the users 