### PR TITLE
fix: install ansible_base.jwt_consumer app

### DIFF
--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -198,6 +198,7 @@ INSTALLED_APPS = [
     "django_filters",
     "ansible_base.rbac",
     "ansible_base.resource_registry",
+    "ansible_base.jwt_consumer",
     # Local apps
     "aap_eda.api",
     "aap_eda.core",


### PR DESCRIPTION
Fix error:
```
Bad API request: 500 Server Error: Internal Server Error for url: https://service-provider:443/api/eda/v1/service-index/metadata/
```
Caused by:
```
rest_framework.request.WrappedAttributeError: 'Settings' object has no attribute 'ANSIBLE_BASE_JWT_MANAGED_ROLES'
```

We use `ansible_base.jwt_consumer` as [auth class](https://github.com/ansible/eda-server/blob/main/src/aap_eda/settings/default.py#L324) but is not installed the app. DAB requires it since [this commit](https://github.com/ansible/django-ansible-base/commit/6b80ced7506ebb3b7c2dafb48a018159dee997a8#diff-13662d6a6c68265823b74106f51995610e9f4157b5c4bfb3af3a7678e478e89dR155). 

Jira: https://issues.redhat.com/browse/AAP-26954
