### PR TITLE
chore: undo the migration check

### DIFF
--- a/tools/docker/docker-compose-dev-redis-tls.yaml
+++ b/tools/docker/docker-compose-dev-redis-tls.yaml
@@ -110,7 +110,6 @@ services:
       - /bin/bash
       - -c
       - >-
-        aap-eda-manage wait_for_migrations -t ${EDA_WAIT_FOR_MIGRATIONS_TIMEOUT:-30};
         aap-eda-manage runserver 0.0.0.0:8000
     ports:
       - "${EDA_WS_PORT:-8001}:8000"
@@ -127,7 +126,6 @@ services:
       - /bin/bash
       - -c
       - >-
-        aap-eda-manage wait_for_migrations -t ${EDA_WAIT_FOR_MIGRATIONS_TIMEOUT:-30};
         aap-eda-manage scheduler
     depends_on:
       eda-api:
@@ -148,7 +146,6 @@ services:
       - /bin/bash
       - -c
       - >-
-        aap-eda-manage wait_for_migrations -t ${EDA_WAIT_FOR_MIGRATIONS_TIMEOUT:-30};
         aap-eda-manage rqworker
         --worker-class aap_eda.core.tasking.DefaultWorker
     depends_on:
@@ -170,7 +167,6 @@ services:
       - /bin/bash
       - -c
       - >-
-        aap-eda-manage wait_for_migrations -t ${EDA_WAIT_FOR_MIGRATIONS_TIMEOUT:-30};
         aap-eda-manage rqworker
         --worker-class aap_eda.core.tasking.ActivationWorker
     environment: *common-env

--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -129,7 +129,6 @@ services:
       - /bin/bash
       - -c
       - >-
-        aap-eda-manage wait_for_migrations -t ${EDA_WAIT_FOR_MIGRATIONS_TIMEOUT:-30};
         aap-eda-manage runserver 0.0.0.0:8000
     ports:
       - "${EDA_WS_PORT:-8001}:8000"
@@ -148,7 +147,6 @@ services:
       - /bin/bash
       - -c
       - >-
-        aap-eda-manage wait_for_migrations -t ${EDA_WAIT_FOR_MIGRATIONS_TIMEOUT:-30};
         aap-eda-manage scheduler
     depends_on:
       eda-api:
@@ -169,7 +167,6 @@ services:
       - /bin/bash
       - -c
       - >-
-        aap-eda-manage wait_for_migrations -t ${EDA_WAIT_FOR_MIGRATIONS_TIMEOUT:-30};
         aap-eda-manage rqworker
         --worker-class aap_eda.core.tasking.DefaultWorker
     depends_on:
@@ -195,7 +192,6 @@ services:
       - /bin/bash
       - -c
       - >-
-        aap-eda-manage wait_for_migrations -t ${EDA_WAIT_FOR_MIGRATIONS_TIMEOUT:-30};
         aap-eda-manage rqworker
         --worker-class aap_eda.core.tasking.ActivationWorker
     depends_on:
@@ -221,7 +217,6 @@ services:
       - /bin/bash
       - -c
       - >-
-        aap-eda-manage wait_for_migrations -t ${EDA_WAIT_FOR_MIGRATIONS_TIMEOUT:-30};
         aap-eda-manage rqworker
         --worker-class aap_eda.core.tasking.ActivationWorker
     depends_on:

--- a/tools/docker/docker-compose-mac.yml
+++ b/tools/docker/docker-compose-mac.yml
@@ -80,7 +80,6 @@ services:
       - /bin/bash
       - -c
       - >-
-        aap-eda-manage wait_for_migrations -t ${EDA_WAIT_FOR_MIGRATIONS_TIMEOUT:-30};
         aap-eda-manage runserver 0.0.0.0:8000
     ports:
       - '${EDA_WS_PORT:-8001}:8000'
@@ -100,7 +99,6 @@ services:
       - /bin/bash
       - -c
       - >-
-        aap-eda-manage wait_for_migrations -t ${EDA_WAIT_FOR_MIGRATIONS_TIMEOUT:-30};
         aap-eda-manage rqworker
         --worker-class aap_eda.core.tasking.DefaultWorker
     depends_on:
@@ -126,7 +124,6 @@ services:
       - /bin/bash
       - -c
       - >-
-        aap-eda-manage wait_for_migrations -t ${EDA_WAIT_FOR_MIGRATIONS_TIMEOUT:-30};
         aap-eda-manage rqworker
         --worker-class aap_eda.core.tasking.ActivationWorker
     depends_on:
@@ -147,7 +144,6 @@ services:
       - /bin/bash
       - -c
       - >-
-        aap-eda-manage wait_for_migrations -t ${EDA_WAIT_FOR_MIGRATIONS_TIMEOUT:-30};
         aap-eda-manage scheduler
     depends_on:
       eda-api:

--- a/tools/docker/docker-compose-stage.yaml
+++ b/tools/docker/docker-compose-stage.yaml
@@ -96,7 +96,6 @@ services:
       - /bin/bash
       - -c
       - >-
-        aap-eda-manage wait_for_migrations -t ${EDA_WAIT_FOR_MIGRATIONS_TIMEOUT:-30};
         daphne -b 0.0.0.0 -p 8000 aap_eda.asgi:application
     ports:
       - '${EDA_WS_PORT:-8001}:8000'
@@ -111,7 +110,6 @@ services:
       - /bin/bash
       - -c
       - >-
-        aap-eda-manage wait_for_migrations -t ${EDA_WAIT_FOR_MIGRATIONS_TIMEOUT:-30};
         aap-eda-manage scheduler
     depends_on:
       eda-api:
@@ -131,7 +129,6 @@ services:
       - /bin/bash
       - -c
       - >-
-        aap-eda-manage wait_for_migrations -t ${EDA_WAIT_FOR_MIGRATIONS_TIMEOUT:-30};
         aap-eda-manage rqworker
         --worker-class aap_eda.core.tasking.DefaultWorker
     depends_on:
@@ -153,7 +150,6 @@ services:
       - /bin/bash
       - -c
       - >-
-        aap-eda-manage wait_for_migrations -t ${EDA_WAIT_FOR_MIGRATIONS_TIMEOUT:-30};
         aap-eda-manage rqworker
         --worker-class aap_eda.core.tasking.ActivationWorker
     depends_on:


### PR DESCRIPTION
The migration check was added in PR #957 to make podman-compose handle dependent containers coming up before the DB was ready. This check causes podman-compose/podman to terminate containers if they dont respond within 10 seconds. So reverting for now till we can come up with other solution to solve this for podman-compose