### PR TITLE
chore: suppress a pytest warning for a non-test class

### DIFF
--- a/tests/integration/services/test_project_import.py
+++ b/tests/integration/services/test_project_import.py
@@ -34,6 +34,8 @@ DATA_DIR = Path(__file__).parent / "data"
 
 
 class TestTempdirFactory:
+    __test__ = False
+
     def __init__(self):
         self.last_name = None
 


### PR DESCRIPTION
suppress warning: PytestCollectionWarning: cannot collect test class 'TestTempdirFactory' because it has a __init__ constructor (from: tests/integration/services/test_project_import.py)

Add `__test__ = False` to tell pytest to skip a class that does not contain any tests