### PR TITLE
chore: fix dependency for podman

### DIFF
--- a/tools/docker/docker-compose-dev-redis-tls.yaml
+++ b/tools/docker/docker-compose-dev-redis-tls.yaml
@@ -65,122 +65,6 @@ services:
     depends_on:
      - podman-pre-setup
 
-  eda-ui:
-    image: ${EDA_UI_IMAGE:-quay.io/ansible/eda-ui}:${EDA_UI_VERSION:-main}
-    environment: *common-env
-    ports:
-      - '${EDA_UI_PORT:-8443}:443'
-    depends_on:
-      eda-api:
-        condition: service_healthy
-
-  eda-api:
-    image: ${EDA_IMAGE:-localhost/aap-eda}
-    build:
-      context: ../../
-      dockerfile: tools/docker/Dockerfile
-    environment: *common-env
-    command:
-      - /bin/bash
-      - -c
-      - >-
-        aap-eda-manage migrate
-        && aap-eda-manage create_initial_data
-        && scripts/create_superuser.sh
-        && aap-eda-manage runserver 0.0.0.0:8000
-    ports:
-      - "${EDA_API_PORT:-8000}:8000"
-    depends_on:
-      redis:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
-    healthcheck:
-      test: [ 'CMD', 'curl', '-q', 'http://localhost:8000/_healthz' ]
-      interval: 30s
-      timeout: 5s
-      retries: 10
-    volumes:
-      - '../../:/app/src:z'
-
-  eda-ws:
-    image: ${EDA_IMAGE:-localhost/aap-eda}
-    environment: *common-env
-    command:
-      - /bin/bash
-      - -c
-      - >-
-        aap-eda-manage runserver 0.0.0.0:8000
-    ports:
-      - "${EDA_WS_PORT:-8001}:8000"
-    depends_on:
-      eda-api:
-        condition: service_healthy
-    volumes:
-      - '../../:/app/src:z'
-
-  eda-scheduler:
-    image: ${EDA_IMAGE:-localhost/aap-eda}
-    environment: *common-env
-    command:
-      - /bin/bash
-      - -c
-      - >-
-        aap-eda-manage scheduler
-    depends_on:
-      eda-api:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
-    volumes:
-      - '../../:/app/src:z'
-
-  eda-default-worker:
-    image: ${EDA_IMAGE:-localhost/aap-eda}
-    deploy:
-      replicas: ${EDA_DEFAULT_WORKERS:-1}
-    environment: *common-env
-    command:
-      - /bin/bash
-      - -c
-      - >-
-        aap-eda-manage rqworker
-        --worker-class aap_eda.core.tasking.DefaultWorker
-    depends_on:
-      eda-api:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
-    volumes:
-      - '../../:/app/src:z'
-    restart: always
-
-  eda-activation-worker:
-    image: ${EDA_IMAGE:-localhost/aap-eda}
-    deploy:
-      replicas: ${EDA_ACTIVATION_WORKERS:-2}
-    command:
-      - /bin/bash
-      - -c
-      - >-
-        aap-eda-manage rqworker
-        --worker-class aap_eda.core.tasking.ActivationWorker
-    environment: *common-env
-    depends_on:
-      eda-api:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
-    volumes:
-      - '../../:/app/src:z'
-    restart: always
-
   certs:
     image: ${EDA_CERTBOT_IMAGE:-certbot/certbot}:${EDA_CERTBOT_VERSION:-latest}
     volumes:
@@ -257,6 +141,110 @@ services:
       start_period: 5s
     volumes:
       - ./redis-tls:/var/lib/eda/redis-tls:z
+
+  eda-api:
+    image: ${EDA_IMAGE:-localhost/aap-eda}
+    build:
+      context: ../../
+      dockerfile: tools/docker/Dockerfile
+    environment: *common-env
+    command:
+      - /bin/bash
+      - -c
+      - >-
+        aap-eda-manage migrate
+        && aap-eda-manage create_initial_data
+        && scripts/create_superuser.sh
+        && aap-eda-manage runserver 0.0.0.0:8000
+    ports:
+      - "${EDA_API_PORT:-8000}:8000"
+    depends_on:
+      redis:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: [ 'CMD', 'curl', '-q', 'http://localhost:8000/_healthz' ]
+      interval: 30s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - '../../:/app/src:z'
+
+  eda-ws:
+    image: ${EDA_IMAGE:-localhost/aap-eda}
+    environment: *common-env
+    command:
+      - /bin/bash
+      - -c
+      - >-
+        aap-eda-manage runserver 0.0.0.0:8000
+    ports:
+      - "${EDA_WS_PORT:-8001}:8000"
+    depends_on:
+      eda-api:
+        condition: service_healthy
+    volumes:
+      - '../../:/app/src:z'
+
+  eda-scheduler:
+    image: ${EDA_IMAGE:-localhost/aap-eda}
+    environment: *common-env
+    command:
+      - /bin/bash
+      - -c
+      - >-
+        aap-eda-manage scheduler
+    depends_on:
+      eda-api:
+        condition: service_healthy
+    volumes:
+      - '../../:/app/src:z'
+
+  eda-default-worker:
+    image: ${EDA_IMAGE:-localhost/aap-eda}
+    deploy:
+      replicas: ${EDA_DEFAULT_WORKERS:-1}
+    environment: *common-env
+    command:
+      - /bin/bash
+      - -c
+      - >-
+        aap-eda-manage rqworker
+        --worker-class aap_eda.core.tasking.DefaultWorker
+    depends_on:
+      eda-api:
+        condition: service_healthy
+    volumes:
+      - '../../:/app/src:z'
+    restart: always
+
+  eda-activation-worker:
+    image: ${EDA_IMAGE:-localhost/aap-eda}
+    deploy:
+      replicas: ${EDA_ACTIVATION_WORKERS:-2}
+    command:
+      - /bin/bash
+      - -c
+      - >-
+        aap-eda-manage rqworker
+        --worker-class aap_eda.core.tasking.ActivationWorker
+    environment: *common-env
+    depends_on:
+      eda-api:
+        condition: service_healthy
+    volumes:
+      - '../../:/app/src:z'
+    restart: always
+
+  eda-ui:
+    image: ${EDA_UI_IMAGE:-quay.io/ansible/eda-ui}:${EDA_UI_VERSION:-main}
+    environment: *common-env
+    ports:
+      - '${EDA_UI_PORT:-8443}:443'
+    depends_on:
+      eda-api:
+        condition: service_healthy
 
 volumes:
   postgres_data: {}

--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -81,14 +81,34 @@ services:
     depends_on:
      - podman-pre-setup-node2
 
-  eda-ui:
-    image: ${EDA_UI_IMAGE:-quay.io/ansible/eda-ui}:${EDA_UI_VERSION:-main}
-    environment: *common-env
+  postgres:
+    image: ${EDA_POSTGRES_IMAGE:-quay.io/sclorg/postgresql-15-c9s}:${EDA_POSTGRES_VERSION:-latest}
+    environment:
+      POSTGRESQL_USER: eda
+      POSTGRESQL_PASSWORD: secret
+      POSTGRESQL_ADMIN_PASSWORD: secret
+      POSTGRESQL_DATABASE: eda
     ports:
-      - '${EDA_UI_PORT:-8443}:443'
-    depends_on:
-      eda-api:
-        condition: service_healthy
+      - '${EDA_PG_PORT:-5432}:5432'
+    volumes:
+      - 'postgres_data:/var/lib/pgsql/data'
+    healthcheck:
+      test: [ 'CMD', 'pg_isready', '-U', 'postgres' ]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+
+  redis:
+    image: ${EDA_REDIS_IMAGE:-quay.io/fedora/redis-6}:${EDA_REDIS_VERSION:-latest}
+    ports:
+      - '${EDA_REDIS_PORT:-6379}:6379'
+    healthcheck:
+      test: [ 'CMD', 'redis-cli', 'ping' ]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
 
   eda-api:
     image: ${EDA_IMAGE:-localhost/aap-eda}
@@ -151,10 +171,6 @@ services:
     depends_on:
       eda-api:
         condition: service_healthy
-      redis:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
     volumes:
       - '../../:/app/src:z'
 
@@ -171,10 +187,6 @@ services:
         --worker-class aap_eda.core.tasking.DefaultWorker
     depends_on:
       eda-api:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-      postgres:
         condition: service_healthy
     volumes:
       - '../../:/app/src:z'
@@ -197,10 +209,6 @@ services:
     depends_on:
       eda-api:
         condition: service_healthy
-      redis:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
     volumes:
       - '../../:/app/src:z'
     restart: always
@@ -222,42 +230,9 @@ services:
     depends_on:
       eda-api:
         condition: service_healthy
-      redis:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
     volumes:
       - '../../:/app/src:z'
     restart: always
-
-  postgres:
-    image: ${EDA_POSTGRES_IMAGE:-quay.io/sclorg/postgresql-15-c9s}:${EDA_POSTGRES_VERSION:-latest}
-    environment:
-      POSTGRESQL_USER: eda
-      POSTGRESQL_PASSWORD: secret
-      POSTGRESQL_ADMIN_PASSWORD: secret
-      POSTGRESQL_DATABASE: eda
-    ports:
-      - '${EDA_PG_PORT:-5432}:5432'
-    volumes:
-      - 'postgres_data:/var/lib/pgsql/data'
-    healthcheck:
-      test: [ 'CMD', 'pg_isready', '-U', 'postgres' ]
-      interval: 5s
-      timeout: 5s
-      retries: 3
-      start_period: 5s
-
-  redis:
-    image: ${EDA_REDIS_IMAGE:-quay.io/fedora/redis-6}:${EDA_REDIS_VERSION:-latest}
-    ports:
-      - '${EDA_REDIS_PORT:-6379}:6379'
-    healthcheck:
-      test: [ 'CMD', 'redis-cli', 'ping' ]
-      interval: 5s
-      timeout: 5s
-      retries: 3
-      start_period: 5s
 
   squid:
     image: ${EDA_SQUID_IMAGE:-quay.io/openshifttest/squid-proxy}:${EDA_SQUID_VERSION:-1.2.0}
@@ -269,6 +244,15 @@ services:
       - './squid/htpass:/etc/squid/htpass:z'
     ports:
       - '${EDA_PROXY_PORT:-3128}:3128'
+
+  eda-ui:
+    image: ${EDA_UI_IMAGE:-quay.io/ansible/eda-ui}:${EDA_UI_VERSION:-main}
+    environment: *common-env
+    ports:
+      - '${EDA_UI_PORT:-8443}:443'
+    depends_on:
+      eda-api:
+        condition: service_healthy
 
 volumes:
   postgres_data: {}

--- a/tools/docker/docker-compose-mac.yml
+++ b/tools/docker/docker-compose-mac.yml
@@ -36,14 +36,34 @@ x-environment:
 
 
 services:
-  eda-ui:
-    image: ${EDA_UI_IMAGE:-quay.io/ansible/eda-ui}:${EDA_UI_VERSION:-main}
-    environment: *common-env
+  postgres:
+    image: ${EDA_POSTGRES_IMAGE:-quay.io/sclorg/postgresql-15-c9s}:${EDA_POSTGRES_VERSION:-latest}
+    environment:
+      POSTGRESQL_USER: eda
+      POSTGRESQL_PASSWORD: secret
+      POSTGRESQL_ADMIN_PASSWORD: secret
+      POSTGRESQL_DATABASE: eda
     ports:
-      - '${EDA_UI_PORT:-8443}:443'
-    depends_on:
-      eda-api:
-        condition: service_healthy
+      - '${EDA_PG_PORT:-5432}:5432'
+    volumes:
+      - 'postgres_data:/var/lib/pgsql/data'
+    healthcheck:
+      test: [ 'CMD', 'pg_isready', '-U', 'postgres' ]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+
+  redis:
+    image: ${EDA_REDIS_IMAGE:-docker.io/library/redis}:${EDA_REDIS_VERSION:-6.2.14}
+    ports:
+      - '${EDA_REDIS_PORT:-6379}:6379'
+    healthcheck:
+      test: [ 'CMD', 'redis-cli', 'ping' ]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
 
   eda-api:
     image: ${EDA_IMAGE:-quay.io/ansible/eda-server}:${EDA_IMAGE_VERSION:-main}
@@ -104,10 +124,6 @@ services:
     depends_on:
       eda-api:
         condition: service_healthy
-      redis:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
     restart: always
     volumes:
       - ${EDA_HOST_PODMAN_SOCKET_URL:-/run/user/501/podman/podman.sock}:/run/podman/podman.sock:z
@@ -129,10 +145,6 @@ services:
     depends_on:
       eda-api:
         condition: service_healthy
-      redis:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
     restart: always
     volumes:
       - ${EDA_HOST_PODMAN_SOCKET_URL:-/run/user/501/podman/podman.sock}:/run/podman/podman.sock:z
@@ -148,39 +160,7 @@ services:
     depends_on:
       eda-api:
         condition: service_healthy
-      redis:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
 
-  postgres:
-    image: ${EDA_POSTGRES_IMAGE:-quay.io/sclorg/postgresql-15-c9s}:${EDA_POSTGRES_VERSION:-latest}
-    environment:
-      POSTGRESQL_USER: eda
-      POSTGRESQL_PASSWORD: secret
-      POSTGRESQL_ADMIN_PASSWORD: secret
-      POSTGRESQL_DATABASE: eda
-    ports:
-      - '${EDA_PG_PORT:-5432}:5432'
-    volumes:
-      - 'postgres_data:/var/lib/pgsql/data'
-    healthcheck:
-      test: [ 'CMD', 'pg_isready', '-U', 'postgres' ]
-      interval: 5s
-      timeout: 5s
-      retries: 3
-      start_period: 5s
-
-  redis:
-    image: ${EDA_REDIS_IMAGE:-docker.io/library/redis}:${EDA_REDIS_VERSION:-6.2.14}
-    ports:
-      - '${EDA_REDIS_PORT:-6379}:6379'
-    healthcheck:
-      test: [ 'CMD', 'redis-cli', 'ping' ]
-      interval: 5s
-      timeout: 5s
-      retries: 3
-      start_period: 5s
 
   squid:
     image: ${EDA_SQUID_IMAGE:-quay.io/openshifttest/squid-proxy}:${EDA_SQUID_VERSION:-1.2.0}
@@ -192,6 +172,15 @@ services:
       - ./squid/htpass:/etc/squid/htpass
     ports:
       - '${EDA_PROXY_PORT:-3128}:3128'
+
+  eda-ui:
+    image: ${EDA_UI_IMAGE:-quay.io/ansible/eda-ui}:${EDA_UI_VERSION:-main}
+    environment: *common-env
+    ports:
+      - '${EDA_UI_PORT:-8443}:443'
+    depends_on:
+      eda-api:
+        condition: service_healthy
 
 volumes:
   postgres_data: {}

--- a/tools/docker/docker-compose-stage.yaml
+++ b/tools/docker/docker-compose-stage.yaml
@@ -54,15 +54,34 @@ services:
     depends_on:
      - podman-pre-setup
 
-  eda-ui:
-    image: ${EDA_UI_IMAGE:-quay.io/ansible/eda-ui}:${EDA_UI_VERSION:-main}
-    environment: *common-env
+  postgres:
+    image: ${EDA_POSTGRES_IMAGE:-quay.io/sclorg/postgresql-15-c9s}:${EDA_POSTGRES_VERSION:-latest}
+    environment:
+      POSTGRESQL_USER: eda
+      POSTGRESQL_PASSWORD: secret
+      POSTGRESQL_ADMIN_PASSWORD: secret
+      POSTGRESQL_DATABASE: eda
     ports:
-      - '${EDA_UI_PORT:-8443}:443'
-    depends_on:
-      eda-api:
-        condition: service_healthy
+      - '${EDA_PG_PORT:-5432}:5432'
+    volumes:
+      - 'postgres_data:/var/lib/pgsql/data'
+    healthcheck:
+      test: [ 'CMD', 'pg_isready', '-U', 'postgres' ]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
 
+  redis:
+    image: ${EDA_REDIS_IMAGE:-quay.io/fedora/redis-6}:${EDA_REDIS_VERSION:-latest}
+    ports:
+      - '${EDA_REDIS_PORT:-6379}:6379'
+    healthcheck:
+      test: [ 'CMD', 'redis-cli', 'ping' ]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
   eda-api:
     image: ${EDA_IMAGE:-quay.io/ansible/eda-server}:${EDA_IMAGE_VERSION:-main}
     environment: *common-env
@@ -114,10 +133,6 @@ services:
     depends_on:
       eda-api:
         condition: service_healthy
-      redis:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
 
   eda-default-worker:
     user: "${EDA_POD_USER_ID:-0}"
@@ -133,10 +148,6 @@ services:
         --worker-class aap_eda.core.tasking.DefaultWorker
     depends_on:
       eda-api:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-      postgres:
         condition: service_healthy
     restart: always
 
@@ -155,40 +166,7 @@ services:
     depends_on:
       eda-api:
         condition: service_healthy
-      redis:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
     restart: always
-
-  postgres:
-    image: ${EDA_POSTGRES_IMAGE:-quay.io/sclorg/postgresql-15-c9s}:${EDA_POSTGRES_VERSION:-latest}
-    environment:
-      POSTGRESQL_USER: eda
-      POSTGRESQL_PASSWORD: secret
-      POSTGRESQL_ADMIN_PASSWORD: secret
-      POSTGRESQL_DATABASE: eda
-    ports:
-      - '${EDA_PG_PORT:-5432}:5432'
-    volumes:
-      - 'postgres_data:/var/lib/pgsql/data'
-    healthcheck:
-      test: [ 'CMD', 'pg_isready', '-U', 'postgres' ]
-      interval: 5s
-      timeout: 5s
-      retries: 3
-      start_period: 5s
-
-  redis:
-    image: ${EDA_REDIS_IMAGE:-quay.io/fedora/redis-6}:${EDA_REDIS_VERSION:-latest}
-    ports:
-      - '${EDA_REDIS_PORT:-6379}:6379'
-    healthcheck:
-      test: [ 'CMD', 'redis-cli', 'ping' ]
-      interval: 5s
-      timeout: 5s
-      retries: 3
-      start_period: 5s
 
   squid:
     image: ${EDA_SQUID_IMAGE:-quay.io/openshifttest/squid-proxy}:${EDA_SQUID_VERSION:-1.2.0}
@@ -200,6 +178,15 @@ services:
       - './squid/htpass:/etc/squid/htpass:z'
     ports:
       - '${EDA_PROXY_PORT:-3128}:3128'
+
+  eda-ui:
+    image: ${EDA_UI_IMAGE:-quay.io/ansible/eda-ui}:${EDA_UI_VERSION:-main}
+    environment: *common-env
+    ports:
+      - '${EDA_UI_PORT:-8443}:443'
+    depends_on:
+      eda-api:
+        condition: service_healthy
 
 volumes:
   postgres_data: {}


### PR DESCRIPTION
All of our workers have a dependency on the api-worker which has dependency to postgres and redis.
We dont need to have default worker and activation workers have a direct dependency to postgres and redis. They can have a direct dependency to api-worker.

In podman with the --requires if we have a direct dependency to redis and postgres from default and activation workers they might come up before even redis is queued up and break the dependency chain. Causing them to not start.

```
[eda-scheduler]         | Error: unable to start container c979979377dd402dacee7856328c205810362bf3abdb5c85d0e291ecb2ca6e45: generating dependency graph for container c979979377dd402dacee7856328c205810362bf3abdb5c85d0e291ecb2ca6e45: container 4f8bfe666edea37dd185d51066e09d5fcb512db3dcd2608f3acc2b5f106f9ad9 depends on container 92cc8f498d3dba3a99ca1b649fa62ba03fd5663891dc32217cd79ad2573e2315 not found in input list: no such container
[eda-activation-worker] | Error: unable to start container 2edd9cab6bcf841db30689f6379a992b0e2ecb6b7befb3a5eca9d77f945f89f8: generating dependency graph for container 2edd9cab6bcf841db30689f6379a992b0e2ecb6b7befb3a5eca9d77f945f89f8: container 4f8bfe666edea37dd185d51066e09d5fcb512db3dcd2608f3acc2b5f106f9ad9 depends on container 92cc8f498d3dba3a99ca1b649fa62ba03fd5663891dc32217cd79ad2573e2315 not found in input list: no such container
```