### PR TITLE
fix: correct trailing slash for api docs endpoints and update tests

### DIFF
--- a/src/aap_eda/api/urls.py
+++ b/src/aap_eda/api/urls.py
@@ -68,12 +68,12 @@ openapi_urls = [
         name="openapi-yaml",
     ),
     path(
-        "docs",
+        "docs/",
         SpectacularSwaggerView.as_view(url_name="openapi-json"),
         name="openapi-docs",
     ),
     path(
-        "redoc",
+        "redoc/",
         SpectacularRedocView.as_view(url_name="openapi-json"),
         name="openapi-redoc",
     ),

--- a/tests/integration/api/test_openapi.py
+++ b/tests/integration/api/test_openapi.py
@@ -1,0 +1,52 @@
+#  Copyright 2024 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import pytest
+import yaml
+from django.conf import settings
+from rest_framework import status
+
+from tests.integration.constants import api_url_v1
+
+OPENAPI_TITLE = settings.SPECTACULAR_SETTINGS["TITLE"]
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("/openapi.json", id="openapi_json"),
+        pytest.param("/openapi.yaml", id="openapi_yaml"),
+    ],
+)
+@pytest.mark.django_db
+def test_v1_openapi(admin_client, path):
+    response = admin_client.get(f"{api_url_v1}{path}")
+    assert response.status_code == status.HTTP_200_OK
+    data = yaml.safe_load(response.content)
+    assert data["info"]["title"] == OPENAPI_TITLE
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("/docs/", id="swagger_ui"),
+        pytest.param("/redoc/", id="redoc"),
+    ],
+)
+def test_v1_openapi_ui(admin_client, path):
+    response = admin_client.get(f"{api_url_v1}{path}")
+    assert response.status_code == status.HTTP_200_OK
+    assert OPENAPI_TITLE in response.content.decode()


### PR DESCRIPTION
Currently only works https://localhost:8443/api/eda/v1/docs, docs/ returns 404
This PR fixes the correct handling of the trailing slash to keep it consistent with the rest of the application, so /docs is a 301 to -> /docs/ and /docs/ works as expected
Also adds sanity tests for all these urls. 