### PR TITLE
fix(AAP-27994): update import status to completed on empty project

### DIFF
--- a/src/aap_eda/services/project/imports.py
+++ b/src/aap_eda/services/project/imports.py
@@ -62,7 +62,12 @@ def _project_import_wrapper(
             func(self, project)
             project.import_state = models.Project.ImportState.COMPLETED
         except Exception as e:
-            project.import_state = models.Project.ImportState.FAILED
+            # if a project is empty, sync status should show completed
+            project.import_state = (
+                models.Project.ImportState.COMPLETED
+                if "Project folder is empty" in e.args[0]
+                else models.Project.ImportState.FAILED
+            )
             project.import_error = str(e)
             error = e
         finally:

--- a/src/aap_eda/services/project/scm.py
+++ b/src/aap_eda/services/project/scm.py
@@ -282,7 +282,11 @@ class ScmRepository:
 
 
 class GitAnsibleRunnerExecutor:
-    ERROR_PREFIX = "Failed to clone the project:"
+    ERROR_PREFIX = "Project Import Error:"
+    PROJECT_EMPTY_ERROR_MSG = (
+        "Project folder is empty. Please add "
+        "content to your project and try syncing it again."
+    )
 
     def __call__(
         self,
@@ -320,5 +324,7 @@ class GitAnsibleRunnerExecutor:
                 ):
                     err_msg = "Credentials not provided or incorrect"
                     raise ScmAuthenticationError(err_msg)
+                if "did not match any file" in err_msg:
+                    raise ScmError(self.PROJECT_EMPTY_ERROR_MSG)
                 raise ScmError(f"{self.ERROR_PREFIX} {err_msg}")
             raise ScmError(f"{self.ERROR_PREFIX} {outputs.getvalue().strip()}")

--- a/tests/unit/test_scm.py
+++ b/tests/unit/test_scm.py
@@ -108,6 +108,28 @@ def test_git_clone_without_ssl_verification():
         )
 
 
+@pytest.mark.django_db
+def test_git_clone_empty_project(
+    credential: EdaCredential,
+):
+    executor = mock.MagicMock()
+
+    def raise_error(**kwargs):
+        raise ScmError("Project folder is empty.")
+
+    executor.side_effect = raise_error
+
+    with pytest.raises(ScmError) as exc_info:
+        with tempfile.TemporaryDirectory() as dest_path:
+            ScmRepository.clone(
+                "https://git.example.com/repo.git",
+                dest_path,
+                credential=credential,
+                _executor=executor,
+            )
+    assert "Project folder is empty." in str(exc_info)
+
+
 def test_git_rev_parse_head():
     executor = mock.Mock()
     executor.return_value = "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc"


### PR DESCRIPTION
The project import status is currently reported as failed when the project repo is empty; This PR changes the status of the project import to completed in such a scenario.

<img width="1180" alt="Screenshot 2024-08-05 at 2 27 52 PM" src="https://github.com/user-attachments/assets/e4efbcb8-86c3-4175-b743-b7721ef08d37">

JIRA: [AAP-27994](https://issues.redhat.com/browse/AAP-27994)