### PR TITLE
AAP-27921 Use DAB-provided Redis client.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -610,7 +610,7 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-ansible-base"
-version = "2024.8.1.1.dev1+g237aa24"
+version = "2024.8.5.0.dev4+gd343bd0"
 description = "A Django app used by ansible services"
 optional = false
 python-versions = ">=3.9"
@@ -640,7 +640,7 @@ testing = ["cryptography", "pytest", "pytest-django"]
 type = "git"
 url = "https://github.com/ansible/django-ansible-base.git"
 reference = "devel"
-resolved_reference = "237aa24e8054b83fe78432172839d291ff8b4adc"
+resolved_reference = "1ed57b02d5c29122c548742561d52d19e69c93c5"
 
 [[package]]
 name = "django-crum"
@@ -669,6 +669,24 @@ files = [
 
 [package.dependencies]
 Django = ">=3.2"
+
+[[package]]
+name = "django-redis"
+version = "5.4.0"
+description = "Full featured redis cache backend for Django."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "django-redis-5.4.0.tar.gz", hash = "sha256:6a02abaa34b0fea8bf9b707d2c363ab6adc7409950b2db93602e6cb292818c42"},
+    {file = "django_redis-5.4.0-py3-none-any.whl", hash = "sha256:ebc88df7da810732e2af9987f7f426c96204bf89319df4c6da6ca9a2942edd5b"},
+]
+
+[package.dependencies]
+Django = ">=3.2"
+redis = ">=3,<4.0.0 || >4.0.0,<4.0.1 || >4.0.1"
+
+[package.extras]
+hiredis = ["redis[hiredis] (>=3,!=4.0.0,!=4.0.1)"]
 
 [[package]]
 name = "django-rq"
@@ -2558,4 +2576,4 @@ dev = ["psycopg-binary"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "280cffc475b053ce548550944b30ffffe71f2546d8128df0aabeaedc183049d3"
+content-hash = "57d23ca8abd780240a0dbe3c73b7bffd0603b61ba4dbf6fb975791ee220688d0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -610,7 +610,7 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-ansible-base"
-version = "2024.8.5.0.dev4+gd343bd0"
+version = "2024.8.5.0.dev7+g708f5c5"
 description = "A Django app used by ansible services"
 optional = false
 python-versions = ">=3.9"
@@ -622,9 +622,11 @@ channels = {version = "*", optional = true, markers = "extra == \"channel-auth\"
 cryptography = "*"
 Django = ">=4.2.5,<4.3.0"
 django-crum = "*"
+django-redis = {version = "*", optional = true, markers = "extra == \"redis-client\""}
 django-split-settings = "*"
 djangorestframework = "*"
 inflection = "*"
+redis = {version = "*", optional = true, markers = "extra == \"redis-client\""}
 
 [package.extras]
 all = ["channels", "cryptography", "django-auth-ldap", "django-oauth-toolkit (<2.4.0)", "django-redis", "drf-spectacular", "pyjwt", "pyrad", "pytest", "pytest-django", "python-ldap", "python3-saml", "redis", "requests", "social-auth-app-django", "tabulate", "tacacs_plus", "xmlsec (==1.3.13)"]
@@ -640,7 +642,7 @@ testing = ["cryptography", "pytest", "pytest-django"]
 type = "git"
 url = "https://github.com/ansible/django-ansible-base.git"
 reference = "devel"
-resolved_reference = "1ed57b02d5c29122c548742561d52d19e69c93c5"
+resolved_reference = "708f5c59f7b240ea78fa9480b518b3484aeedbad"
 
 [[package]]
 name = "django-crum"
@@ -2576,4 +2578,4 @@ dev = ["psycopg-binary"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "57d23ca8abd780240a0dbe3c73b7bffd0603b61ba4dbf6fb975791ee220688d0"
+content-hash = "7baef63ab6ab0b6d514fa69525e89c3355677fa91f4e819e89a19a6e7f8cb86f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ django-ansible-base = { git = "https://github.com/ansible/django-ansible-base.gi
     "channel_auth",
     "rbac",
 ] }
+django-redis = "5.4.*"
 jinja2 = ">=3.1.3,<3.2"
 django-split-settings = "^1.2.0"
 pexpect = "^4.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ rq-scheduler = "^0.10"
 django-ansible-base = { git = "https://github.com/ansible/django-ansible-base.git", branch = "devel", extras = [
     "channel_auth",
     "rbac",
+    "redis_client",
 ] }
-django-redis = "5.4.*"
 jinja2 = ">=3.1.3,<3.2"
 django-split-settings = "^1.2.0"
 pexpect = "^4.9.0"

--- a/src/aap_eda/core/tasking/__init__.py
+++ b/src/aap_eda/core/tasking/__init__.py
@@ -10,9 +10,9 @@ import redis
 import rq
 import rq_scheduler
 from ansible_base.lib.redis.client import (
-    get_redis_client as _get_redis_client,
     DABRedis,
     DABRedisCluster,
+    get_redis_client as _get_redis_client,
 )
 from django.conf import settings
 from django_rq import enqueue, get_queue, get_scheduler, job
@@ -50,6 +50,7 @@ _ErrorHandlersArgType = Union[
     ErrorHandlerType,
     None,
 ]
+
 
 def get_redis_client(**kwargs):
     """Instantiate a Redis client via DAB.
@@ -190,7 +191,9 @@ class Job(_Job):
 # with one that is.
 def _get_necessary_client_connection(connection: Connection) -> Connection:
     if type(connection) not in [DABRedis, DABRedisCluster]:
-        connection = get_redis_client(**default.rq_redis_client_instantiation_parameters())
+        connection = get_redis_client(
+            **default.rq_redis_client_instantiation_parameters()
+        )
     return connection
 
 

--- a/src/aap_eda/core/tasking/__init__.py
+++ b/src/aap_eda/core/tasking/__init__.py
@@ -6,8 +6,14 @@ from datetime import datetime, timedelta
 from types import MethodType
 from typing import Any, Callable, Iterable, Optional, Protocol, Type, Union
 
+import redis
 import rq
 import rq_scheduler
+from ansible_base.lib.redis.client import (
+    get_redis_client as _get_redis_client,
+    DABRedis,
+    DABRedisCluster,
+)
 from django.conf import settings
 from django_rq import enqueue, get_queue, get_scheduler, job
 from django_rq.queues import Queue as _Queue
@@ -19,6 +25,8 @@ from rq.defaults import (
 )
 from rq.job import Job as _Job, JobStatus
 from rq.serializers import JSONSerializer
+
+from aap_eda.settings import default
 
 __all__ = [
     "Job",
@@ -42,6 +50,19 @@ _ErrorHandlersArgType = Union[
     ErrorHandlerType,
     None,
 ]
+
+def get_redis_client(**kwargs):
+    """Instantiate a Redis client via DAB.
+
+    DAB will return an appropriate client for HA based on the passed
+    parameters.
+    """
+    # Make the URL that DAB expects as part of the creation.
+    schema = "redis"
+    if kwargs.get("ssl", False):
+        schema = "rediss"
+    url = f"{schema}://{kwargs.get('host')}:{kwargs.get('port')}"
+    return _get_redis_client(url, **kwargs)
 
 
 def enable_redis_prefix():
@@ -190,6 +211,14 @@ class DefaultWorker(_Worker):
         if queue_class is None:
             queue_class = Queue
 
+        # django-rq's rqworker command does not support --connection-class so
+        # we cannot specify the DAB redis client that way.  Even if it did we
+        # couldn't use it as DAB requires a url parameter that Redis does not.
+        # If the connection we're given is not from DAB we replace it with one
+        # that is.
+        if type(connection) not in [DABRedis, DABRedisCluster]:
+            connection = get_redis_client(**default.rq_redis_client_instantiation_parameters())
+
         super().__init__(
             queues=queues,
             name=name,
@@ -235,6 +264,14 @@ class ActivationWorker(_Worker):
             job_class = Job
         if queue_class is None:
             queue_class = Queue
+
+        # django-rq's rqworker command does not support --connection-class so
+        # we cannot specify the DAB redis client that way.  Even if it did we
+        # couldn't use it as DAB requires a url parameter that Redis does not.
+        # If the connection we're given is not from DAB we replace it with one
+        # that is.
+        if type(connection) not in [DABRedis, DABRedisCluster]:
+            connection = get_redis_client(**default.rq_redis_client_instantiation_parameters())
 
         queue_name = settings.RULEBOOK_QUEUE_NAME
 

--- a/src/aap_eda/core/tasking/__init__.py
+++ b/src/aap_eda/core/tasking/__init__.py
@@ -190,7 +190,7 @@ class Job(_Job):
 # If the connection a worker is given is not from DAB we replace it
 # with one that is.
 def _get_necessary_client_connection(connection: Connection) -> Connection:
-    if type(connection) not in [DABRedis, DABRedisCluster]:
+    if not isinstance(connection, (DABRedis, DABRedisCluster)):
         connection = get_redis_client(
             **default.rq_redis_client_instantiation_parameters()
         )

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -403,8 +403,12 @@ def _rq_redis_client_additional_parameters():
     return params
 
 
-def _rq_redis_client_parameters():
-    return _rq_common_parameters() | _rq_redis_client_additional_parameters()
+def rq_redis_client_instantiation_parameters():
+    params = _rq_common_parameters() | _rq_redis_client_additional_parameters()
+
+    # Convert to lowercase for use in instantiating a redis client.
+    params = {k.lower(): v for (k, v) in params.items()}
+    return params
 
 
 # A list of queues to be used in multinode mode

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -443,13 +443,17 @@ def get_rq_queues() -> dict:
     # Configure the default queue
     queues["default"] = _rq_common_parameters()
     queues["default"]["DEFAULT_TIMEOUT"] = DEFAULT_QUEUE_TIMEOUT
-    queues["default"]["REDIS_CLIENT_KWARGS"] = _rq_redis_client_additional_parameters()
+    queues["default"][
+        "REDIS_CLIENT_KWARGS"
+    ] = _rq_redis_client_additional_parameters()
 
     # Configure the worker queues
     for queue in RULEBOOK_WORKER_QUEUES:
         queues[queue] = _rq_common_parameters()
         queues[queue]["DEFAULT_TIMEOUT"] = DEFAULT_RULEBOOK_QUEUE_TIMEOUT
-        queues[queue]["REDIS_CLIENT_KWARGS"] = _rq_redis_client_additional_parameters()
+        queues[queue][
+            "REDIS_CLIENT_KWARGS"
+        ] = _rq_redis_client_additional_parameters()
 
     return queues
 

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -392,7 +392,7 @@ def _rq_common_parameters():
     return params
 
 
-def _rq_redis_client_parameters():
+def _rq_redis_client_additional_parameters():
     params = {}
     if (not REDIS_UNIX_SOCKET_PATH) and REDIS_CLIENT_CERT_PATH:
         params |= {
@@ -401,6 +401,10 @@ def _rq_redis_client_parameters():
             "ssl_ca_certs": REDIS_CLIENT_CACERT_PATH,
         }
     return params
+
+
+def _rq_redis_client_parameters():
+    return _rq_common_parameters() | _rq_redis_client_additional_parameters()
 
 
 # A list of queues to be used in multinode mode
@@ -435,13 +439,13 @@ def get_rq_queues() -> dict:
     # Configure the default queue
     queues["default"] = _rq_common_parameters()
     queues["default"]["DEFAULT_TIMEOUT"] = DEFAULT_QUEUE_TIMEOUT
-    queues["default"]["REDIS_CLIENT_KWARGS"] = _rq_redis_client_parameters()
+    queues["default"]["REDIS_CLIENT_KWARGS"] = _rq_redis_client_additional_parameters()
 
     # Configure the worker queues
     for queue in RULEBOOK_WORKER_QUEUES:
         queues[queue] = _rq_common_parameters()
         queues[queue]["DEFAULT_TIMEOUT"] = DEFAULT_RULEBOOK_QUEUE_TIMEOUT
-        queues[queue]["REDIS_CLIENT_KWARGS"] = _rq_redis_client_parameters()
+        queues[queue]["REDIS_CLIENT_KWARGS"] = _rq_redis_client_additional_parameters()
 
     return queues
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 import pytest
-import redis
 
 from aap_eda.core.tasking import get_redis_client
 from aap_eda.settings import default

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,10 +24,7 @@ from aap_eda.settings import default
 @pytest.fixture
 def redis_parameters() -> dict:
     """Provide redis parameters based on settings values."""
-    params = default._rq_redis_client_parameters()
-
-    # Convert to lowercase for use in establishing a redis client.
-    params = {k.lower(): v for (k, v) in params.items()}
+    params = default.rq_redis_client_instantiation_parameters()
 
     # We try to avoid conflicting with a deployed environment by using a
     # different database from that of the settings.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@
 import pytest
 import redis
 
+from aap_eda.core.tasking import get_redis_client
 from aap_eda.settings import default
 
 
@@ -30,7 +31,7 @@ def redis_parameters() -> dict:
     # different database from that of the settings.
     # This is not guaranteed as the deployed environment could be differently
     # configured from the default, but in development it should be fine.
-    client = redis.Redis(**params)
+    client = get_redis_client(**params)
     max_dbs = int(client.config_get("databases")["databases"])
     params["db"] = (params["db"] + 1) % max_dbs
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,9 +24,7 @@ from aap_eda.settings import default
 @pytest.fixture
 def redis_parameters() -> dict:
     """Provide redis parameters based on settings values."""
-    params = (
-        default._rq_common_parameters() | default._rq_redis_client_parameters()
-    )
+    params = default._rq_redis_client_parameters()
 
     # Convert to lowercase for use in establishing a redis client.
     params = {k.lower(): v for (k, v) in params.items()}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,7 +19,6 @@ from unittest import mock
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
-import redis
 from ansible_base.rbac.models import DABPermission, RoleDefinition
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -31,7 +30,7 @@ from aap_eda.core.management.commands.create_initial_data import (
     CREDENTIAL_TYPES,
     populate_credential_types,
 )
-from aap_eda.core.tasking import Queue
+from aap_eda.core.tasking import get_redis_client, Queue
 from aap_eda.core.utils.credentials import inputs_to_store
 from aap_eda.services.activation.engine.common import ContainerEngine
 
@@ -1022,7 +1021,7 @@ def new_team(default_organization: models.Organization) -> models.Team:
 # fixture for a running redis server
 @pytest.fixture
 def redis_external(redis_parameters):
-    client = redis.Redis(**redis_parameters)
+    client = get_redis_client(**redis_parameters)
     yield client
     client.flushdb()
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -30,7 +30,7 @@ from aap_eda.core.management.commands.create_initial_data import (
     CREDENTIAL_TYPES,
     populate_credential_types,
 )
-from aap_eda.core.tasking import get_redis_client, Queue
+from aap_eda.core.tasking import Queue, get_redis_client
 from aap_eda.core.utils.credentials import inputs_to_store
 from aap_eda.services.activation.engine.common import ContainerEngine
 

--- a/tests/integration/core/test_tasking.py
+++ b/tests/integration/core/test_tasking.py
@@ -18,6 +18,7 @@ import redis
 
 from aap_eda.core.tasking import (
     DABRedis,
+    DABRedisCluster,
     DefaultWorker,
     Queue,
     get_redis_client,
@@ -68,20 +69,21 @@ def test_unique_enqueue_new_job(default_queue, eda_caplog):
 def test_worker_dab_client(default_queue: Queue):
     """Test that workers end up with a DABRedis client connection."""
 
-    # Verify if given no connection the worker gets a DABRedis.
+    # Verify if given no connection the worker gets DABRedis/DABRedisCluster.
     worker = DefaultWorker([default_queue])
-    assert type(worker.connection) is DABRedis
+    assert isinstance(worker.connection, (DABRedis, DABRedisCluster))
 
-    # Verify if given a redis.Redis connection the worker gets a DABRedis.
+    # Verify if given a redis.Redis connection the worker gets a
+    # DABRedis/DABRedisCluster.
     worker = DefaultWorker(
         [default_queue],
         connection=redis.Redis(
             **default.rq_redis_client_instantiation_parameters()
         ),
     )
-    assert type(worker.connection) is DABRedis
+    assert isinstance(worker.connection, (DABRedis, DABRedisCluster))
 
-    # Verify if given a DABRedis connection the worker uses it.
+    # Verify if given a DABRedis/DABRedisCluster connection the worker uses it.
     connection = get_redis_client(
         **default.rq_redis_client_instantiation_parameters()
     )
@@ -91,8 +93,9 @@ def test_worker_dab_client(default_queue: Queue):
     )
     assert worker.connection is connection
 
-    # Verify if given the queue's DABRedis connection the worker uses it.
-    # The queue is created with a DABRedis connection.
+    # Verify if given the queue's DABRedis/DABRedisCluster connection the
+    # worker uses it.
+    # The queue is created with a DABRedis/DABRedisCluster connection.
     worker = DefaultWorker(
         [default_queue],
         connection=default_queue.connection,

--- a/tests/integration/core/test_tasking.py
+++ b/tests/integration/core/test_tasking.py
@@ -14,18 +14,16 @@
 
 
 import pytest
-
 import redis
 
 from aap_eda.core.tasking import (
     DABRedis,
     DefaultWorker,
+    Queue,
     get_redis_client,
     logger,
-    Queue,
-    unique_enqueue
+    unique_enqueue,
 )
-
 from aap_eda.settings import default
 
 
@@ -77,12 +75,16 @@ def test_worker_dab_client(default_queue: Queue):
     # Verify if given a redis.Redis connection the worker gets a DABRedis.
     worker = DefaultWorker(
         [default_queue],
-        connection=redis.Redis(**default.rq_redis_client_instantiation_parameters())
+        connection=redis.Redis(
+            **default.rq_redis_client_instantiation_parameters()
+        ),
     )
     assert type(worker.connection) is DABRedis
 
     # Verify if given a DABRedis connection the worker uses it.
-    connection = get_redis_client(**default.rq_redis_client_instantiation_parameters())
+    connection = get_redis_client(
+        **default.rq_redis_client_instantiation_parameters()
+    )
     worker = DefaultWorker(
         [default_queue],
         connection=connection,


### PR DESCRIPTION
This change uses the DAB-provided Redis client support which encapsulates requisite HA capabilities.

It does not currently take specific advantage of these capabilities; that is to come later.