### PR TITLE
chore(AAP-28755,AAP-28761): rename webhook prefix and ensure trailing slash

### DIFF
--- a/src/aap_eda/api/views/webhook.py
+++ b/src/aap_eda/api/views/webhook.py
@@ -145,10 +145,10 @@ class WebhookViewSet(
             sub_path = f"{WEBHOOK_EXTERNAL_PATH}/{response.uuid}/post/"
             if inputs["auth_type"] == WebhookAuthType.MTLS:
                 response.url = urljoin(
-                    settings.WEBHOOK_MTLS_URL_PREFIX, sub_path
+                    settings.WEBHOOK_MTLS_BASE_URL, sub_path
                 )
             else:
-                response.url = urljoin(settings.WEBHOOK_URL_PREFIX, sub_path)
+                response.url = urljoin(settings.WEBHOOK_BASE_URL, sub_path)
             response.save(update_fields=["url"])
 
         return Response(

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -708,11 +708,18 @@ PG_NOTIFY_DSN_SERVER = settings.get(
     "PG_NOTIFY_DSN_SERVER", _DEFAULT_PG_NOTIFY_DSN_SERVER
 )
 SERVER_UUID = settings.get("SERVER_UUID", "abc-def-123-34567")
-WEBHOOK_URL_PREFIX = settings.get(
-    "WEBHOOK_URL_PREFIX", f"https://ui.eda.local:8443/{SERVER_UUID}"
+WEBHOOK_BASE_URL = (
+    settings.get(
+        "WEBHOOK_BASE_URL", f"https://ui.eda.local:8443/{SERVER_UUID}"
+    ).strip("/")
+    + "/"
 )
-WEBHOOK_MTLS_URL_PREFIX = settings.get(
-    "WEBHOOK_MTLS_URL_PREFIX", f"https://ui.eda.local:8443/mtls/{SERVER_UUID}"
+WEBHOOK_MTLS_BASE_URL = (
+    settings.get(
+        "WEBHOOK_MTLS_BASE_URL",
+        f"https://ui.eda.local:8443/mtls/{SERVER_UUID}",
+    ).strip("/")
+    + "/"
 )
 MAX_PG_NOTIFY_MESSAGE_SIZE = int(
     settings.get("MAX_PG_NOTIFY_MESSAGE_SIZE", 6144)

--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -38,8 +38,8 @@ x-environment: &common-env
   EDA_SERVER_UUID: edgecafe-beef-feed-fade-decadeedgecafe
   EDA_PG_NOTIFY_DSN: "host=host.containers.internal port=5432 dbname=eda user=postgres password=secret"
   EDA_PG_NOTIFY_DSN_SERVER: "host=postgres port=5432 dbname=eda user=postgres password=secret"
-  EDA_WEBHOOK_URL_PREFIX: ${EDA_WEBHOOK_URL_PREFIX:-https://localhost/edgecafe-beef-feed-fade-decadeedgecafe/}
-  EDA_WEBHOOK_MTLS_URL_PREFIX: ${EDA_WEBHOOK_MTLS_URL_PREFIX:-https://localhost/mtls/edgecafe-beef-feed-fade-decadeedgecafe/}
+  EDA_WEBHOOK_BASE_URL: ${EDA_WEBHOOK_BASE_URL:-https://localhost/edgecafe-beef-feed-fade-decadeedgecafe/}
+  EDA_WEBHOOK_MTLS_BASE_URL: ${EDA_WEBHOOK_MTLS_BASE_URL:-https://localhost/mtls/edgecafe-beef-feed-fade-decadeedgecafe/}
   EDA_WEBHOOK_HOST: ${EDA_WEBHOOK_HOST:-eda-webhook-api:8000}
   EDA_WEBHOOK_SERVER: http://${EDA_WEBHOOK_HOST:-eda-webhook-api:8000}
   SSL_CERTIFICATE: ${SSL_CERTIFICATE:-/certs/cert.pem}

--- a/tools/docker/docker-compose-mac.yml
+++ b/tools/docker/docker-compose-mac.yml
@@ -36,8 +36,8 @@ x-environment:
   - EDA_SERVER_UUID=edgecafe-beef-feed-fade-decadeedgecafe
   - EDA_PG_NOTIFY_DSN="host=host.containers.internal port=5432 dbname=eda user=postgres password=secret"
   - EDA_PG_NOTIFY_DSN_SERVER="host=postgres port=5432 dbname=eda user=postgres password=secret"
-  - EDA_WEBHOOK_URL_PREFIX=${EDA_WEBHOOK_URL_PREFIX:-https://localhost/edgecafe-beef-feed-fade-decadeedgecafe/}
-  - EDA_WEBHOOK_MTLS_URL_PREFIX=${EDA_WEBHOOK_MTLS_URL_PREFIX:-https://localhost/mtls/edgecafe-beef-feed-fade-decadeedgecafe/}
+  - EDA_WEBHOOK_BASE_URL=${EDA_WEBHOOK_BASE_URL:-https://localhost/edgecafe-beef-feed-fade-decadeedgecafe/}
+  - EDA_WEBHOOK_MTLS_BASE_URL=${EDA_WEBHOOK_MTLS_BASE_URL:-https://localhost/mtls/edgecafe-beef-feed-fade-decadeedgecafe/}
   - EDA_WEBHOOK_HOST=${EDA_WEBHOOK_HOST:-eda-webhook-api:8000}
   - EDA_WEBHOOK_SERVER=http://${EDA_WEBHOOK_HOST:-eda-webhook-api:8000}
   - SSL_CERTIFICATE=${SSL_CERTIFICATE:-/certs/cert.pem}

--- a/tools/docker/docker-compose-stage.yaml
+++ b/tools/docker/docker-compose-stage.yaml
@@ -33,8 +33,8 @@ x-environment:
   - EDA_SERVER_UUID=edgecafe-beef-feed-fade-decadeedgecafe
   - EDA_PG_NOTIFY_DSN="host=host.containers.internal port=5432 dbname=eda user=postgres password=secret"
   - EDA_PG_NOTIFY_DSN_SERVER="host=postgres port=5432 dbname=eda user=postgres password=secret"
-  - EDA_WEBHOOK_URL_PREFIX=${EDA_WEBHOOK_URL_PREFIX:-https://localhost/edgecafe-beef-feed-fade-decadeedgecafe/}
-  - EDA_WEBHOOK_MTLS_URL_PREFIX=${EDA_WEBHOOK_MTLS_URL_PREFIX:-https://localhost/mtls/edgecafe-beef-feed-fade-decadeedgecafe/}
+  - EDA_WEBHOOK_BASE_URL=${EDA_WEBHOOK_BASE_URL:-https://localhost/edgecafe-beef-feed-fade-decadeedgecafe/}
+  - EDA_WEBHOOK_MTLS_BASE_URL=${EDA_WEBHOOK_MTLS_BASE_URL:-https://localhost/mtls/edgecafe-beef-feed-fade-decadeedgecafe/}
   - EDA_WEBHOOK_HOST=${EDA_WEBHOOK_HOST:-eda-webhook-api:8000}
   - EDA_WEBHOOK_SERVER=http://${EDA_WEBHOOK_HOST:-eda-webhook-api:8000}
   - SSL_CERTIFICATE=${SSL_CERTIFICATE:-/certs/cert.pem}


### PR DESCRIPTION
As per internal discussions, rename WEBHOOK_URL_PREFIX to WEBHOOK_BASE_URL for a more meaningful variable name. 
Also ensure the trailing slash for the correct processing of the final url. 
Jira: https://issues.redhat.com/browse/AAP-28755