### PR TITLE
fix: align log output between deployment types

### DIFF
--- a/src/aap_eda/services/activation/engine/podman.py
+++ b/src/aap_eda/services/activation/engine/podman.py
@@ -160,7 +160,7 @@ class Engine(ContainerEngine):
                 f"pod_args: {pod_args}"
             )
 
-            log_handler.write(f"Container {container.id} is started.", True)
+            log_handler.write(f"Container {container.id} is running.", True)
             return str(container.id)
         except (
             ContainerError,

--- a/tests/integration/services/activation/engine/test_podman.py
+++ b/tests/integration/services/activation/engine/test_podman.py
@@ -207,7 +207,7 @@ def test_engine_start(init_data, podman_engine):
 
     engine.client.containers.run.assert_called_once()
     assert models.RulebookProcessLog.objects.count() == 4
-    assert models.RulebookProcessLog.objects.last().log.endswith("is started.")
+    assert models.RulebookProcessLog.objects.last().log.endswith("is running.")
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This minor change updates the log output for podman deployments so that it is similar to what is printed in k8s deployments. This improves parity between deployments and enables us to easily test log output across the different deployment types.
Equivalent log output in k8s: https://github.com/ansible/eda-server/blob/bc35a0c6b04751caa7d1197aa734ef0d9df58877/src/aap_eda/services/activation/engine/kubernetes.py#L130