### PR TITLE
feat (AAP-29049) - before deleting credentials check if event streams attached

### DIFF
--- a/src/aap_eda/api/serializers/eda_credential.py
+++ b/src/aap_eda/api/serializers/eda_credential.py
@@ -185,6 +185,9 @@ def get_references(eda_credential: models.EdaCredential) -> list[dict]:
     resources = []
 
     used_activations = eda_credential.activations.all()
+    used_webhooks = models.Webhook.objects.filter(
+        eda_credential=eda_credential
+    )
     used_decision_environments = models.DecisionEnvironment.objects.filter(
         eda_credential=eda_credential
     )
@@ -199,6 +202,15 @@ def get_references(eda_credential: models.EdaCredential) -> list[dict]:
             "id": activation.id,
             "name": activation.name,
             "url": f"api/eda/v1/activations/{activation.id}/",
+        }
+        resources.append(resource)
+
+    for webhook in used_webhooks:
+        resource = {
+            "type": "Webhook",
+            "id": webhook.id,
+            "name": webhook.name,
+            "url": (f"api/eda/v1/webhooks/{webhook.id}/"),
         }
         resources.append(resource)
 

--- a/tests/integration/api/test_eda_credential.py
+++ b/tests/integration/api/test_eda_credential.py
@@ -523,6 +523,23 @@ def test_delete_credential_with_project_reference(
 
 
 @pytest.mark.django_db
+def test_delete_credential_with_webhook_reference(
+    default_webhook: models.Webhook,
+    admin_client: APIClient,
+    preseed_credential_types,
+):
+    eda_credential = default_webhook.eda_credential
+    response = admin_client.delete(
+        f"{api_url_v1}/eda-credentials/{eda_credential.id}/"
+    )
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert (
+        f"Credential {eda_credential.name} is being referenced by other "
+        "resources and cannot be deleted"
+    ) in response.data["detail"]
+
+
+@pytest.mark.django_db
 def test_delete_credential_with_activation_reference(
     default_activation: models.Activation,
     admin_client: APIClient,


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-29049

The UI will raise a warning as shown in the screenshot. Because we support the `force` flag, the deletion will succeed after checking `Yes`.

![image](https://github.com/user-attachments/assets/a3451f2a-b65c-4d83-a2ca-05d6c7447c33)