### PR TITLE
fix(AAP-29090): remove member_organization permission from org admin role

### DIFF
--- a/src/aap_eda/core/management/commands/create_initial_data.py
+++ b/src/aap_eda/core/management/commands/create_initial_data.py
@@ -53,7 +53,7 @@ ORG_ROLES = [
             ],
             "rulebook_process": ["view"],
             "audit_rule": ["view"],
-            "organization": ["view", "change", "delete", "member"],
+            "organization": ["view", "change", "delete"],
             "team": CRUD + ["member"],
             "project": CRUD + ["sync"],
             "rulebook": ["view"],

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,6 +26,7 @@ from django.test import override_settings
 from rest_framework.test import APIClient
 
 from aap_eda.core import enums, models
+from aap_eda.core.management.commands import create_initial_data
 from aap_eda.core.management.commands.create_initial_data import (
     CREDENTIAL_TYPES,
     populate_credential_types,
@@ -1044,6 +1045,20 @@ def new_team(default_organization: models.Organization) -> models.Team:
         description="This is a new team.",
         organization=default_organization,
     )
+
+
+# TODO(doston): creating managed roles should be exported to its own
+# management command
+@pytest.fixture
+def create_initial_data_command():
+    """Create all managed roles using create_initial_data command."""
+    return create_initial_data.Command()
+
+
+@pytest.fixture
+def create_managed_org_roles(create_initial_data_command):
+    """Create managed org roles using create_initial_data command."""
+    create_initial_data_command._create_org_roles()
 
 
 #################################################################

--- a/tests/integration/core/test_create_initial_data.py
+++ b/tests/integration/core/test_create_initial_data.py
@@ -24,6 +24,9 @@ from aap_eda.core.management.commands.create_initial_data import (
 from aap_eda.core.utils.credentials import inputs_from_store
 
 
+#################################################################
+# Roles
+#################################################################
 @pytest.mark.django_db
 def test_create_all_roles():
     assert RoleDefinition.objects.count() == 0
@@ -86,6 +89,9 @@ def test_remove_extra_permission():
     assert perm not in auditor_role.permissions.all()
 
 
+#################################################################
+# Credentials
+#################################################################
 def create_old_registry_credential():
     credential = models.Credential.objects.create(
         name="registry cred",

--- a/tests/integration/dab_rbac/test_managed_roles.py
+++ b/tests/integration/dab_rbac/test_managed_roles.py
@@ -1,0 +1,58 @@
+#  Copyright 2024 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+from ansible_base.rbac.models import RoleDefinition
+from rest_framework import status
+
+from aap_eda.core.management.commands.create_initial_data import ORG_ROLES
+from tests.integration.constants import api_url_v1
+
+
+@pytest.mark.django_db
+def test_org_role_team_assignments(
+    admin_client, default_organization, default_team, create_managed_org_roles
+):
+    for org_role in ORG_ROLES:
+        # ignore Org Member role as it is not assignable to teams
+        if org_role["name"] != "Organization Member":
+            role = RoleDefinition.objects.get(name=org_role["name"])
+            post_data = {
+                "object_id": default_organization.id,
+                "role_definition": role.id,
+                "team": default_team.id,
+            }
+            response = admin_client.post(
+                f"{api_url_v1}/role_team_assignments/", data=post_data
+            )
+            assert (
+                response.status_code == status.HTTP_201_CREATED
+            ), response.data
+
+
+@pytest.mark.django_db
+def test_org_role_user_assignments(
+    admin_client, default_organization, default_user, create_managed_org_roles
+):
+    for org_role in ORG_ROLES:
+        role = RoleDefinition.objects.get(name=org_role["name"])
+        post_data = {
+            "object_id": default_organization.id,
+            "role_definition": role.id,
+            "user": default_user.id,
+        }
+        response = admin_client.post(
+            f"{api_url_v1}/role_user_assignments/", data=post_data
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.data


### PR DESCRIPTION
- remove member_organization permission from org admin role
- add tests for role user and team assignments for managed org roles

JIRA: [AAP-29090](https://issues.redhat.com/browse/AAP-29090)