### PR TITLE
feat: Add CRUD log messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ __pycache__/
 Taskfile.yml
 Taskfile.yaml
 /tools/deploy/environment.properties
+
+venv/

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -96,25 +96,13 @@ class ActivationViewSet(
                 process_parent_type=ProcessParentType.ACTIVATION,
                 process_parent_id=response.id,
             )
-        logging_kwargs = {
-            "isEnabled": response.is_enabled,
-            "Project": logging_utils.get_project_name_from_id(
-                response.project_id
-            ),
-            "Rulebook": logging_utils.get_rulebook_name_from_id(
-                response.rulebook_id
-            ),
-            "DecisionEnvironment": logging_utils.get_de_name_from_id(
-                response.decision_environment_id
-            ),
-        }
+
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Create",
                 resource_name,
                 response.name,
                 response.organization,
-                **logging_kwargs,
             )
         )
 
@@ -141,35 +129,22 @@ class ActivationViewSet(
                 "deleted.",
             )
 
+        audit_log = logging_utils.generate_simple_audit_log(
+            "Delete",
+            resource_name,
+            activation.name,
+            activation.organization,
+        )
+
         activation.status = ActivationStatus.DELETING
         activation.save(update_fields=["status"])
         logger.info(f"Now deleting {activation.name} ...")
+
         delete_rulebook_process(
             process_parent_type=ProcessParentType.ACTIVATION,
             process_parent_id=activation.id,
         )
-
-        logging_kwargs = {
-            "isEnabled": activation.is_enabled,
-            "Project": logging_utils.get_project_name_from_id(
-                activation.project_id
-            ),
-            "Rulebook": logging_utils.get_rulebook_name_from_id(
-                activation.rulebook_id
-            ),
-            "DecisionEnvironment": logging_utils.get_de_name_from_id(
-                activation.decision_environment_id
-            ),
-        }
-        logger.info(
-            logging_utils.generate_simple_audit_log(
-                "Delete",
-                resource_name,
-                activation.name,
-                activation.organization,
-                **logging_kwargs,
-            )
-        )
+        logger.info(audit_log)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -179,25 +154,12 @@ class ActivationViewSet(
     def retrieve(self, request, pk: int):
         activation = self.get_object()
 
-        logging_kwargs = {
-            "isEnabled": activation.is_enabled,
-            "Project": logging_utils.get_project_name_from_id(
-                activation.project_id
-            ),
-            "Rulebook": logging_utils.get_rulebook_name_from_id(
-                activation.rulebook_id
-            ),
-            "DecisionEnvironment": logging_utils.get_de_name_from_id(
-                activation.decision_environment_id
-            ),
-        }
         # logger.info(
         #     logging_utils.generate_simple_audit_log(
         #         "Read",
         #         resource_name,
         #         activation.name,
         #         activation.organization,
-        #         **logging_kwargs,
         #     )
         # )
 
@@ -223,7 +185,10 @@ class ActivationViewSet(
 
         logger.info(
             logging_utils.generate_simple_audit_log(
-                "ListActivations", resource_name, "*", "*", **{}
+                "ListActivations",
+                resource_name,
+                "*",
+                "*",
             )
         )
         return self.get_paginated_response(result)
@@ -337,25 +302,12 @@ class ActivationViewSet(
             process_parent_id=pk,
         )
 
-        logging_kwargs = {
-            "isEnabled": activation.is_enabled,
-            "Project": logging_utils.get_project_name_from_id(
-                activation.project_id
-            ),
-            "Rulebook": logging_utils.get_rulebook_name_from_id(
-                activation.rulebook_id
-            ),
-            "DecisionEnvironment": logging_utils.get_de_name_from_id(
-                activation.decision_environment_id
-            ),
-        }
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Enable",
                 resource_name,
                 activation.name,
                 activation.organization,
-                **logging_kwargs,
             )
         )
 
@@ -387,25 +339,13 @@ class ActivationViewSet(
                 process_parent_type=ProcessParentType.ACTIVATION,
                 process_parent_id=activation.id,
             )
-        logging_kwargs = {
-            "isEnabled": activation.is_enabled,
-            "Project": logging_utils.get_project_name_from_id(
-                activation.project_id
-            ),
-            "Rulebook": logging_utils.get_rulebook_name_from_id(
-                activation.rulebook_id
-            ),
-            "DecisionEnvironment": logging_utils.get_de_name_from_id(
-                activation.decision_environment_id
-            ),
-        }
+
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Disable",
                 resource_name,
                 activation.name,
                 activation.organization,
-                **logging_kwargs,
             )
         )
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -451,25 +391,12 @@ class ActivationViewSet(
             process_parent_id=activation.id,
         )
 
-        logging_kwargs = {
-            "isEnabled": activation.is_enabled,
-            "Project": logging_utils.get_project_name_from_id(
-                activation.project_id
-            ),
-            "Rulebook": logging_utils.get_rulebook_name_from_id(
-                activation.rulebook_id
-            ),
-            "DecisionEnvironment": logging_utils.get_de_name_from_id(
-                activation.decision_environment_id
-            ),
-        }
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Restart",
                 resource_name,
                 activation.name,
                 activation.organization,
-                **logging_kwargs,
             )
         )
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -95,14 +95,13 @@ class ActivationViewSet(
                 process_parent_id=response.id,
             )
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: Create / "
             "ResourceType: RulebookActivation / "
             f"ResourceName: {response.name} / "
             f"Organization: {response.organization} / isEnabled: {response.is_enabled} / "  # noqa: E501
             f"Project: {logging_utils.get_project_name_from_id(response.project_id)} / "  # noqa: E501
             f"Rulebook: {logging_utils.get_rulebook_name_from_id(response.rulebook_id)} / "  # noqa: E501
-            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(response.decision_environment_id)} / "  # noqa: E501
-            "Action: Create"
+            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(response.decision_environment_id)}"  # noqa: E501
         )
         logger.info(log_msg)
 
@@ -137,15 +136,14 @@ class ActivationViewSet(
             process_parent_id=activation.id,
         )
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: Delete / "
             "ResourceType: RulebookActivation / "
             f"ResourceName: {activation.name} / "
             f"Organization: {activation.organization} / "
             f"isEnabled: {activation.is_enabled} / "
             f"Project: {logging_utils.get_project_name_from_id(activation.project_id)} / "  # noqa: E501
             f"Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / "  # noqa: E501
-            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(activation.decision_environment_id)} / "  # noqa: E501
-            "Action: Delete"
+            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(activation.decision_environment_id)}"  # noqa: E501
         )
         logger.info(log_msg)
 
@@ -157,12 +155,11 @@ class ActivationViewSet(
     def retrieve(self, request, pk: int):
         activation = self.get_object()
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: Read / "
             "ResourceType: RulebookActivation / "
             f"ResourceName: {activation.name} / "
             f"Organization: {activation.organization} / "
-            f"isEnabled: {activation.is_enabled} / "
-            "Action: Read"
+            f"isEnabled: {activation.is_enabled}"
         )
         logger.info(log_msg)
         return Response(serializers.ActivationReadSerializer(activation).data)
@@ -185,10 +182,9 @@ class ActivationViewSet(
         )
         result = self.paginate_queryset(serializer.data)
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: ListActivations / "
             "ResourceType: RulebookActivation / "
-            "ResourceName: '*' / Organization: '*' / "
-            "Action: ListActivations"
+            "ResourceName: '*' / Organization: '*'"
         )
         logger.info(log_msg)
 
@@ -303,15 +299,14 @@ class ActivationViewSet(
             process_parent_id=pk,
         )
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: Enable / "
             "ResourceType: RulebookActivation / "
             f"ResourceName: {activation.name} / "
             f"Organization: {activation.organization} / "
             f"isEnabled: {activation.is_enabled} / "
             f"Project: {logging_utils.get_project_name_from_id(activation.project_id)} / "  # noqa: E501
             f"Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / "  # noqa: E501
-            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(activation.decision_environment_id)} / "  # noqa: E501
-            "Action: Enable"
+            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(activation.decision_environment_id)}"  # noqa: E501
         )
         logger.info(log_msg)
 
@@ -344,15 +339,14 @@ class ActivationViewSet(
                 process_parent_id=activation.id,
             )
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: Disable / "
             "ResourceType: RulebookActivation / "
             f"ResourceName: {activation.name} / "
             f"Organization: {activation.organization} / "
             f"isEnabled: {activation.is_enabled} / "
             f"Project: {logging_utils.get_project_name_from_id(activation.project_id)} / "  # noqa: E501
             f"Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / "  # noqa: E501
-            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(activation.decision_environment_id)} / "  # noqa: E501
-            "Action: Disable"
+            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(activation.decision_environment_id)} "  # noqa: E501
         )
         logger.info(log_msg)
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -398,15 +392,14 @@ class ActivationViewSet(
             process_parent_id=activation.id,
         )
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: Restart / "
             "ResourceType: RulebookActivation / "
             f"ResourceName: {activation.name} / "
             f"Organization: {activation.organization} / "
             f"isEnabled: {activation.is_enabled} / "
             f"Project: {logging_utils.get_project_name_from_id(activation.project_id)} / "  # noqa: E501
             f"Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / "  # noqa: E501
-            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(activation.decision_environment_id)} / "  # noqa: E501
-            "Action: Restart"
+            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(activation.decision_environment_id)}"  # noqa: E501
         )
         logger.info(log_msg)
 

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -38,6 +38,7 @@ from aap_eda.tasks.orchestrator import (
     start_rulebook_process,
     stop_rulebook_process,
 )
+from aap_eda.core.utils import logging_utils
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +94,8 @@ class ActivationViewSet(
                 process_parent_type=ProcessParentType.ACTIVATION,
                 process_parent_id=response.id,
             )
+        log_msg = f"RESOURCE UPDATE - ResourceType: RulebookActivation / ResourceName: {response.name} / Organization: {response.organization} / isEnabled: {response.is_enabled} / Project: {logging_utils.get_project_name_from_id(response.project_id)} / Rulebook: {logging_utils.get_rulebook_name_from_id(response.rulebook_id)} / DecisionEnvironment: {logging_utils.get_decisionenvironment_name_from_id(response.decision_environment_id)} / Action: Create"
+        logger.info(log_msg)
 
         return Response(
             serializers.ActivationReadSerializer(response).data,
@@ -124,6 +127,8 @@ class ActivationViewSet(
             process_parent_type=ProcessParentType.ACTIVATION,
             process_parent_id=activation.id,
         )
+        log_msg = f"RESOURCE UPDATE - ResourceType: RulebookActivation / ResourceName: {activation.name} / Organization: {activation.organization} / isEnabled: {activation.is_enabled} / Project: {logging_utils.get_project_name_from_id(activation.project_id)} / Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / DecisionEnvironment: {logging_utils.get_decisionenvironment_name_from_id(activation.decision_environment_id)} / Action: Delete"
+        logger.info(log_msg)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -132,6 +137,8 @@ class ActivationViewSet(
     )
     def retrieve(self, request, pk: int):
         activation = self.get_object()
+        log_msg = f"RESOURCE UPDATE - ResourceType: RulebookActivation / ResourceName: {activation.name} / Organization: {activation.organization} / isEnabled: {activation.is_enabled} / Action: Read"
+        logger.info(log_msg)
         return Response(serializers.ActivationReadSerializer(activation).data)
 
     @extend_schema(
@@ -151,6 +158,8 @@ class ActivationViewSet(
             activations, many=True
         )
         result = self.paginate_queryset(serializer.data)
+        log_msg = f"RESOURCE UPDATE - ResourceType: RulebookActivation / ResourceName: '*' / Organization: '*' / Action: ListActivations"
+        logger.info(log_msg)
 
         return self.get_paginated_response(result)
 
@@ -262,6 +271,8 @@ class ActivationViewSet(
             process_parent_type=ProcessParentType.ACTIVATION,
             process_parent_id=pk,
         )
+        log_msg = f"RESOURCE UPDATE - ResourceType: RulebookActivation / ResourceName: {activation.name} / Organization: {activation.organization} / isEnabled: {activation.is_enabled} / Project: {logging_utils.get_project_name_from_id(activation.project_id)} / Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / DecisionEnvironment: {logging_utils.get_decisionenvironment_name_from_id(activation.decision_environment_id)} / Action: Enable"
+        logger.info(log_msg)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -291,7 +302,8 @@ class ActivationViewSet(
                 process_parent_type=ProcessParentType.ACTIVATION,
                 process_parent_id=activation.id,
             )
-
+        log_msg = f"RESOURCE UPDATE - ResourceType: RulebookActivation / ResourceName: {activation.name} / Organization: {activation.organization} / isEnabled: {activation.is_enabled} / Project: {logging_utils.get_project_name_from_id(activation.project_id)} / Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / DecisionEnvironment: {logging_utils.get_decisionenvironment_name_from_id(activation.decision_environment_id)} / Action: Disable"
+        logger.info(log_msg)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @extend_schema(
@@ -334,6 +346,8 @@ class ActivationViewSet(
             process_parent_type=ProcessParentType.ACTIVATION,
             process_parent_id=activation.id,
         )
+        log_msg = f"RESOURCE UPDATE - ResourceType: RulebookActivation / ResourceName: {activation.name} / Organization: {activation.organization} / isEnabled: {activation.is_enabled} / Project: {logging_utils.get_project_name_from_id(activation.project_id)} / Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / DecisionEnvironment: {logging_utils.get_decisionenvironment_name_from_id(activation.decision_environment_id)} / Action: Restart"
+        logger.info(log_msg)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -154,14 +154,14 @@ class ActivationViewSet(
     def retrieve(self, request, pk: int):
         activation = self.get_object()
 
-        # logger.info(
-        #     logging_utils.generate_simple_audit_log(
-        #         "Read",
-        #         resource_name,
-        #         activation.name,
-        #         activation.organization,
-        #     )
-        # )
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Read",
+                resource_name,
+                activation.name,
+                activation.organization,
+            )
+        )
 
         return Response(serializers.ActivationReadSerializer(activation).data)
 

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -191,15 +191,15 @@ class ActivationViewSet(
                 activation.decision_environment_id
             ),
         }
-        logger.info(
-            logging_utils.generate_simple_audit_log(
-                "Read",
-                resource_name,
-                activation.name,
-                activation.organization,
-                **logging_kwargs,
-            )
-        )
+        # logger.info(
+        #     logging_utils.generate_simple_audit_log(
+        #         "Read",
+        #         resource_name,
+        #         activation.name,
+        #         activation.organization,
+        #         **logging_kwargs,
+        #     )
+        # )
 
         return Response(serializers.ActivationReadSerializer(activation).data)
 

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -42,6 +42,8 @@ from aap_eda.tasks.orchestrator import (
 
 logger = logging.getLogger(__name__)
 
+resource_name = "RulebookActivation"
+
 
 class ActivationViewSet(
     mixins.DestroyModelMixin,
@@ -94,7 +96,7 @@ class ActivationViewSet(
                 process_parent_type=ProcessParentType.ACTIVATION,
                 process_parent_id=response.id,
             )
-        kwargs = {
+        logging_kwargs = {
             "isEnabled": response.is_enabled,
             "Project": logging_utils.get_project_name_from_id(
                 response.project_id
@@ -109,10 +111,10 @@ class ActivationViewSet(
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Create",
-                "RulebookActivation",
+                resource_name,
                 response.name,
                 response.organization,
-                **kwargs,
+                **logging_kwargs,
             )
         )
 
@@ -147,7 +149,7 @@ class ActivationViewSet(
             process_parent_id=activation.id,
         )
 
-        kwargs = {
+        logging_kwargs = {
             "isEnabled": activation.is_enabled,
             "Project": logging_utils.get_project_name_from_id(
                 activation.project_id
@@ -162,10 +164,10 @@ class ActivationViewSet(
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Delete",
-                "RulebookActivation",
+                resource_name,
                 activation.name,
                 activation.organization,
-                **kwargs,
+                **logging_kwargs,
             )
         )
 
@@ -177,7 +179,7 @@ class ActivationViewSet(
     def retrieve(self, request, pk: int):
         activation = self.get_object()
 
-        kwargs = {
+        logging_kwargs = {
             "isEnabled": activation.is_enabled,
             "Project": logging_utils.get_project_name_from_id(
                 activation.project_id
@@ -192,10 +194,10 @@ class ActivationViewSet(
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Read",
-                "RulebookActivation",
+                resource_name,
                 activation.name,
                 activation.organization,
-                **kwargs,
+                **logging_kwargs,
             )
         )
 
@@ -221,7 +223,7 @@ class ActivationViewSet(
 
         logger.info(
             logging_utils.generate_simple_audit_log(
-                "ListActivations", "RulebookActivation", "*", "*", **{}
+                "ListActivations", resource_name, "*", "*", **{}
             )
         )
         return self.get_paginated_response(result)
@@ -335,7 +337,7 @@ class ActivationViewSet(
             process_parent_id=pk,
         )
 
-        kwargs = {
+        logging_kwargs = {
             "isEnabled": activation.is_enabled,
             "Project": logging_utils.get_project_name_from_id(
                 activation.project_id
@@ -350,10 +352,10 @@ class ActivationViewSet(
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Enable",
-                "RulebookActivation",
+                resource_name,
                 activation.name,
                 activation.organization,
-                **kwargs,
+                **logging_kwargs,
             )
         )
 
@@ -385,7 +387,7 @@ class ActivationViewSet(
                 process_parent_type=ProcessParentType.ACTIVATION,
                 process_parent_id=activation.id,
             )
-        kwargs = {
+        logging_kwargs = {
             "isEnabled": activation.is_enabled,
             "Project": logging_utils.get_project_name_from_id(
                 activation.project_id
@@ -400,10 +402,10 @@ class ActivationViewSet(
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Disable",
-                "RulebookActivation",
+                resource_name,
                 activation.name,
                 activation.organization,
-                **kwargs,
+                **logging_kwargs,
             )
         )
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -449,7 +451,7 @@ class ActivationViewSet(
             process_parent_id=activation.id,
         )
 
-        kwargs = {
+        logging_kwargs = {
             "isEnabled": activation.is_enabled,
             "Project": logging_utils.get_project_name_from_id(
                 activation.project_id
@@ -464,10 +466,10 @@ class ActivationViewSet(
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Restart",
-                "RulebookActivation",
+                resource_name,
                 activation.name,
                 activation.organization,
-                **kwargs,
+                **logging_kwargs,
             )
         )
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -94,16 +94,27 @@ class ActivationViewSet(
                 process_parent_type=ProcessParentType.ACTIVATION,
                 process_parent_id=response.id,
             )
-        log_msg = (
-            "Action: Create / "
-            "ResourceType: RulebookActivation / "
-            f"ResourceName: {response.name} / "
-            f"Organization: {response.organization} / isEnabled: {response.is_enabled} / "  # noqa: E501
-            f"Project: {logging_utils.get_project_name_from_id(response.project_id)} / "  # noqa: E501
-            f"Rulebook: {logging_utils.get_rulebook_name_from_id(response.rulebook_id)} / "  # noqa: E501
-            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(response.decision_environment_id)}"  # noqa: E501
+        kwargs = {
+            "isEnabled": response.is_enabled,
+            "Project": logging_utils.get_project_name_from_id(
+                response.project_id
+            ),
+            "Rulebook": logging_utils.get_rulebook_name_from_id(
+                response.rulebook_id
+            ),
+            "DecisionEnvironment": logging_utils.get_de_name_from_id(
+                response.decision_environment_id
+            ),
+        }
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Create",
+                "RulebookActivation",
+                response.name,
+                response.organization,
+                **kwargs,
+            )
         )
-        logger.info(log_msg)
 
         return Response(
             serializers.ActivationReadSerializer(response).data,
@@ -135,17 +146,28 @@ class ActivationViewSet(
             process_parent_type=ProcessParentType.ACTIVATION,
             process_parent_id=activation.id,
         )
-        log_msg = (
-            "Action: Delete / "
-            "ResourceType: RulebookActivation / "
-            f"ResourceName: {activation.name} / "
-            f"Organization: {activation.organization} / "
-            f"isEnabled: {activation.is_enabled} / "
-            f"Project: {logging_utils.get_project_name_from_id(activation.project_id)} / "  # noqa: E501
-            f"Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / "  # noqa: E501
-            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(activation.decision_environment_id)}"  # noqa: E501
+
+        kwargs = {
+            "isEnabled": activation.is_enabled,
+            "Project": logging_utils.get_project_name_from_id(
+                activation.project_id
+            ),
+            "Rulebook": logging_utils.get_rulebook_name_from_id(
+                activation.rulebook_id
+            ),
+            "DecisionEnvironment": logging_utils.get_de_name_from_id(
+                activation.decision_environment_id
+            ),
+        }
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Delete",
+                "RulebookActivation",
+                activation.name,
+                activation.organization,
+                **kwargs,
+            )
         )
-        logger.info(log_msg)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -154,14 +176,29 @@ class ActivationViewSet(
     )
     def retrieve(self, request, pk: int):
         activation = self.get_object()
-        log_msg = (
-            "Action: Read / "
-            "ResourceType: RulebookActivation / "
-            f"ResourceName: {activation.name} / "
-            f"Organization: {activation.organization} / "
-            f"isEnabled: {activation.is_enabled}"
+
+        kwargs = {
+            "isEnabled": activation.is_enabled,
+            "Project": logging_utils.get_project_name_from_id(
+                activation.project_id
+            ),
+            "Rulebook": logging_utils.get_rulebook_name_from_id(
+                activation.rulebook_id
+            ),
+            "DecisionEnvironment": logging_utils.get_de_name_from_id(
+                activation.decision_environment_id
+            ),
+        }
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Read",
+                "RulebookActivation",
+                activation.name,
+                activation.organization,
+                **kwargs,
+            )
         )
-        logger.info(log_msg)
+
         return Response(serializers.ActivationReadSerializer(activation).data)
 
     @extend_schema(
@@ -181,13 +218,12 @@ class ActivationViewSet(
             activations, many=True
         )
         result = self.paginate_queryset(serializer.data)
-        log_msg = (
-            "Action: ListActivations / "
-            "ResourceType: RulebookActivation / "
-            "ResourceName: '*' / Organization: '*'"
-        )
-        logger.info(log_msg)
 
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "ListActivations", "RulebookActivation", "*", "*", **{}
+            )
+        )
         return self.get_paginated_response(result)
 
     @extend_schema(
@@ -298,17 +334,28 @@ class ActivationViewSet(
             process_parent_type=ProcessParentType.ACTIVATION,
             process_parent_id=pk,
         )
-        log_msg = (
-            "Action: Enable / "
-            "ResourceType: RulebookActivation / "
-            f"ResourceName: {activation.name} / "
-            f"Organization: {activation.organization} / "
-            f"isEnabled: {activation.is_enabled} / "
-            f"Project: {logging_utils.get_project_name_from_id(activation.project_id)} / "  # noqa: E501
-            f"Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / "  # noqa: E501
-            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(activation.decision_environment_id)}"  # noqa: E501
+
+        kwargs = {
+            "isEnabled": activation.is_enabled,
+            "Project": logging_utils.get_project_name_from_id(
+                activation.project_id
+            ),
+            "Rulebook": logging_utils.get_rulebook_name_from_id(
+                activation.rulebook_id
+            ),
+            "DecisionEnvironment": logging_utils.get_de_name_from_id(
+                activation.decision_environment_id
+            ),
+        }
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Enable",
+                "RulebookActivation",
+                activation.name,
+                activation.organization,
+                **kwargs,
+            )
         )
-        logger.info(log_msg)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -338,17 +385,27 @@ class ActivationViewSet(
                 process_parent_type=ProcessParentType.ACTIVATION,
                 process_parent_id=activation.id,
             )
-        log_msg = (
-            "Action: Disable / "
-            "ResourceType: RulebookActivation / "
-            f"ResourceName: {activation.name} / "
-            f"Organization: {activation.organization} / "
-            f"isEnabled: {activation.is_enabled} / "
-            f"Project: {logging_utils.get_project_name_from_id(activation.project_id)} / "  # noqa: E501
-            f"Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / "  # noqa: E501
-            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(activation.decision_environment_id)} "  # noqa: E501
+        kwargs = {
+            "isEnabled": activation.is_enabled,
+            "Project": logging_utils.get_project_name_from_id(
+                activation.project_id
+            ),
+            "Rulebook": logging_utils.get_rulebook_name_from_id(
+                activation.rulebook_id
+            ),
+            "DecisionEnvironment": logging_utils.get_de_name_from_id(
+                activation.decision_environment_id
+            ),
+        }
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Disable",
+                "RulebookActivation",
+                activation.name,
+                activation.organization,
+                **kwargs,
+            )
         )
-        logger.info(log_msg)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @extend_schema(
@@ -391,18 +448,28 @@ class ActivationViewSet(
             process_parent_type=ProcessParentType.ACTIVATION,
             process_parent_id=activation.id,
         )
-        log_msg = (
-            "Action: Restart / "
-            "ResourceType: RulebookActivation / "
-            f"ResourceName: {activation.name} / "
-            f"Organization: {activation.organization} / "
-            f"isEnabled: {activation.is_enabled} / "
-            f"Project: {logging_utils.get_project_name_from_id(activation.project_id)} / "  # noqa: E501
-            f"Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / "  # noqa: E501
-            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(activation.decision_environment_id)}"  # noqa: E501
-        )
-        logger.info(log_msg)
 
+        kwargs = {
+            "isEnabled": activation.is_enabled,
+            "Project": logging_utils.get_project_name_from_id(
+                activation.project_id
+            ),
+            "Rulebook": logging_utils.get_rulebook_name_from_id(
+                activation.rulebook_id
+            ),
+            "DecisionEnvironment": logging_utils.get_de_name_from_id(
+                activation.decision_environment_id
+            ),
+        }
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Restart",
+                "RulebookActivation",
+                activation.name,
+                activation.organization,
+                **kwargs,
+            )
+        )
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def _check_deleting(self, activation):

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -94,14 +94,16 @@ class ActivationViewSet(
                 process_parent_type=ProcessParentType.ACTIVATION,
                 process_parent_id=response.id,
             )
-        log_msg = f"RESOURCE UPDATE - \
-ResourceType: RulebookActivation / ResourceName: {response.name} / \
-Organization: {response.organization} / isEnabled: {response.is_enabled} / \
-Project: {logging_utils.get_project_name_from_id(response.project_id)} / \
-Rulebook: {logging_utils.get_rulebook_name_from_id(response.rulebook_id)} / \
-DecisionEnvironment: \
-{logging_utils.get_de_name_from_id(response.decision_environment_id)} / \
-Action: Create"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            "ResourceType: RulebookActivation / "
+            f"ResourceName: {response.name} / "
+            f"Organization: {response.organization} / isEnabled: {response.is_enabled} / "  # noqa: E501
+            f"Project: {logging_utils.get_project_name_from_id(response.project_id)} / "  # noqa: E501
+            f"Rulebook: {logging_utils.get_rulebook_name_from_id(response.rulebook_id)} / "  # noqa: E501
+            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(response.decision_environment_id)} / "  # noqa: E501
+            "Action: Create"
+        )
         logger.info(log_msg)
 
         return Response(
@@ -134,15 +136,17 @@ Action: Create"
             process_parent_type=ProcessParentType.ACTIVATION,
             process_parent_id=activation.id,
         )
-        log_msg = f"RESOURCE UPDATE - \
-ResourceType: RulebookActivation / ResourceName: {activation.name} / \
-Organization: {activation.organization} / \
-isEnabled: {activation.is_enabled} / \
-Project: {logging_utils.get_project_name_from_id(activation.project_id)} / \
-Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / \
-DecisionEnvironment: \
-{logging_utils.get_de_name_from_id(activation.decision_environment_id)} / \
-Action: Delete"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            "ResourceType: RulebookActivation / "
+            f"ResourceName: {activation.name} / "
+            f"Organization: {activation.organization} / "
+            f"isEnabled: {activation.is_enabled} / "
+            f"Project: {logging_utils.get_project_name_from_id(activation.project_id)} / "  # noqa: E501
+            f"Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / "  # noqa: E501
+            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(activation.decision_environment_id)} / "  # noqa: E501
+            "Action: Delete"
+        )
         logger.info(log_msg)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -152,11 +156,14 @@ Action: Delete"
     )
     def retrieve(self, request, pk: int):
         activation = self.get_object()
-        log_msg = f"RESOURCE UPDATE - \
-ResourceType: RulebookActivation / ResourceName: {activation.name} / \
-Organization: {activation.organization} / \
-isEnabled: {activation.is_enabled} / \
-Action: Read"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            "ResourceType: RulebookActivation / "
+            f"ResourceName: {activation.name} / "
+            f"Organization: {activation.organization} / "
+            f"isEnabled: {activation.is_enabled} / "
+            "Action: Read"
+        )
         logger.info(log_msg)
         return Response(serializers.ActivationReadSerializer(activation).data)
 
@@ -177,10 +184,12 @@ Action: Read"
             activations, many=True
         )
         result = self.paginate_queryset(serializer.data)
-        log_msg = "RESOURCE UPDATE - \
-ResourceType: RulebookActivation / \
-ResourceName: '*' / Organization: '*' / \
-Action: ListActivations"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            "ResourceType: RulebookActivation / "
+            "ResourceName: '*' / Organization: '*' / "
+            "Action: ListActivations"
+        )
         logger.info(log_msg)
 
         return self.get_paginated_response(result)
@@ -293,15 +302,17 @@ Action: ListActivations"
             process_parent_type=ProcessParentType.ACTIVATION,
             process_parent_id=pk,
         )
-        log_msg = f"RESOURCE UPDATE - \
-ResourceType: RulebookActivation / ResourceName: {activation.name} / \
-Organization: {activation.organization} / \
-isEnabled: {activation.is_enabled} / \
-Project: {logging_utils.get_project_name_from_id(activation.project_id)} / \
-Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / \
-DecisionEnvironment: \
-{logging_utils.get_de_name_from_id(activation.decision_environment_id)} / \
-Action: Enable"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            "ResourceType: RulebookActivation / "
+            f"ResourceName: {activation.name} / "
+            f"Organization: {activation.organization} / "
+            f"isEnabled: {activation.is_enabled} / "
+            f"Project: {logging_utils.get_project_name_from_id(activation.project_id)} / "  # noqa: E501
+            f"Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / "  # noqa: E501
+            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(activation.decision_environment_id)} / "  # noqa: E501
+            "Action: Enable"
+        )
         logger.info(log_msg)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -332,15 +343,17 @@ Action: Enable"
                 process_parent_type=ProcessParentType.ACTIVATION,
                 process_parent_id=activation.id,
             )
-        log_msg = f"RESOURCE UPDATE - \
-ResourceType: RulebookActivation / ResourceName: {activation.name} / \
-Organization: {activation.organization} / \
-isEnabled: {activation.is_enabled} / \
-Project: {logging_utils.get_project_name_from_id(activation.project_id)} / \
-Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / \
-DecisionEnvironment: \
-{logging_utils.get_de_name_from_id(activation.decision_environment_id)} / \
-Action: Disable"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            "ResourceType: RulebookActivation / "
+            f"ResourceName: {activation.name} / "
+            f"Organization: {activation.organization} / "
+            f"isEnabled: {activation.is_enabled} / "
+            f"Project: {logging_utils.get_project_name_from_id(activation.project_id)} / "  # noqa: E501
+            f"Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / "  # noqa: E501
+            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(activation.decision_environment_id)} / "  # noqa: E501
+            "Action: Disable"
+        )
         logger.info(log_msg)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -384,15 +397,17 @@ Action: Disable"
             process_parent_type=ProcessParentType.ACTIVATION,
             process_parent_id=activation.id,
         )
-        log_msg = f"RESOURCE UPDATE - \
-ResourceType: RulebookActivation / ResourceName: {activation.name} / \
-Organization: {activation.organization} / \
-isEnabled: {activation.is_enabled} / \
-Project: {logging_utils.get_project_name_from_id(activation.project_id)} / \
-Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / \
-DecisionEnvironment: \
-{logging_utils.get_de_name_from_id(activation.decision_environment_id)} / \
-Action: Restart"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            "ResourceType: RulebookActivation / "
+            f"ResourceName: {activation.name} / "
+            f"Organization: {activation.organization} / "
+            f"isEnabled: {activation.is_enabled} / "
+            f"Project: {logging_utils.get_project_name_from_id(activation.project_id)} / "  # noqa: E501
+            f"Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / "  # noqa: E501
+            f"DecisionEnvironment: {logging_utils.get_de_name_from_id(activation.decision_environment_id)} / "  # noqa: E501
+            "Action: Restart"
+        )
         logger.info(log_msg)
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -102,6 +102,7 @@ class ActivationViewSet(
                 "Create",
                 resource_name,
                 response.name,
+                response.id,
                 response.organization,
             )
         )
@@ -133,6 +134,7 @@ class ActivationViewSet(
             "Delete",
             resource_name,
             activation.name,
+            activation.id,
             activation.organization,
         )
 
@@ -159,6 +161,7 @@ class ActivationViewSet(
                 "Read",
                 resource_name,
                 activation.name,
+                activation.id,
                 activation.organization,
             )
         )
@@ -187,6 +190,7 @@ class ActivationViewSet(
             logging_utils.generate_simple_audit_log(
                 "ListActivations",
                 resource_name,
+                "*",
                 "*",
                 "*",
             )
@@ -307,6 +311,7 @@ class ActivationViewSet(
                 "Enable",
                 resource_name,
                 activation.name,
+                activation.id,
                 activation.organization,
             )
         )
@@ -345,6 +350,7 @@ class ActivationViewSet(
                 "Disable",
                 resource_name,
                 activation.name,
+                activation.id,
                 activation.organization,
             )
         )
@@ -396,6 +402,7 @@ class ActivationViewSet(
                 "Restart",
                 resource_name,
                 activation.name,
+                activation.id,
                 activation.organization,
             )
         )

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -32,13 +32,13 @@ from aap_eda.api import exceptions as api_exc, filters, serializers
 from aap_eda.api.serializers.activation import is_activation_valid
 from aap_eda.core import models
 from aap_eda.core.enums import Action, ActivationStatus, ProcessParentType
+from aap_eda.core.utils import logging_utils
 from aap_eda.tasks.orchestrator import (
     delete_rulebook_process,
     restart_rulebook_process,
     start_rulebook_process,
     stop_rulebook_process,
 )
-from aap_eda.core.utils import logging_utils
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +94,14 @@ class ActivationViewSet(
                 process_parent_type=ProcessParentType.ACTIVATION,
                 process_parent_id=response.id,
             )
-        log_msg = f"RESOURCE UPDATE - ResourceType: RulebookActivation / ResourceName: {response.name} / Organization: {response.organization} / isEnabled: {response.is_enabled} / Project: {logging_utils.get_project_name_from_id(response.project_id)} / Rulebook: {logging_utils.get_rulebook_name_from_id(response.rulebook_id)} / DecisionEnvironment: {logging_utils.get_decisionenvironment_name_from_id(response.decision_environment_id)} / Action: Create"
+        log_msg = f"RESOURCE UPDATE - \
+ResourceType: RulebookActivation / ResourceName: {response.name} / \
+Organization: {response.organization} / isEnabled: {response.is_enabled} / \
+Project: {logging_utils.get_project_name_from_id(response.project_id)} / \
+Rulebook: {logging_utils.get_rulebook_name_from_id(response.rulebook_id)} / \
+DecisionEnvironment: \
+{logging_utils.get_de_name_from_id(response.decision_environment_id)} / \
+Action: Create"
         logger.info(log_msg)
 
         return Response(
@@ -127,7 +134,15 @@ class ActivationViewSet(
             process_parent_type=ProcessParentType.ACTIVATION,
             process_parent_id=activation.id,
         )
-        log_msg = f"RESOURCE UPDATE - ResourceType: RulebookActivation / ResourceName: {activation.name} / Organization: {activation.organization} / isEnabled: {activation.is_enabled} / Project: {logging_utils.get_project_name_from_id(activation.project_id)} / Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / DecisionEnvironment: {logging_utils.get_decisionenvironment_name_from_id(activation.decision_environment_id)} / Action: Delete"
+        log_msg = f"RESOURCE UPDATE - \
+ResourceType: RulebookActivation / ResourceName: {activation.name} / \
+Organization: {activation.organization} / \
+isEnabled: {activation.is_enabled} / \
+Project: {logging_utils.get_project_name_from_id(activation.project_id)} / \
+Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / \
+DecisionEnvironment: \
+{logging_utils.get_de_name_from_id(activation.decision_environment_id)} / \
+Action: Delete"
         logger.info(log_msg)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -137,7 +152,11 @@ class ActivationViewSet(
     )
     def retrieve(self, request, pk: int):
         activation = self.get_object()
-        log_msg = f"RESOURCE UPDATE - ResourceType: RulebookActivation / ResourceName: {activation.name} / Organization: {activation.organization} / isEnabled: {activation.is_enabled} / Action: Read"
+        log_msg = f"RESOURCE UPDATE - \
+ResourceType: RulebookActivation / ResourceName: {activation.name} / \
+Organization: {activation.organization} / \
+isEnabled: {activation.is_enabled} / \
+Action: Read"
         logger.info(log_msg)
         return Response(serializers.ActivationReadSerializer(activation).data)
 
@@ -158,7 +177,10 @@ class ActivationViewSet(
             activations, many=True
         )
         result = self.paginate_queryset(serializer.data)
-        log_msg = f"RESOURCE UPDATE - ResourceType: RulebookActivation / ResourceName: '*' / Organization: '*' / Action: ListActivations"
+        log_msg = "RESOURCE UPDATE - \
+ResourceType: RulebookActivation / \
+ResourceName: '*' / Organization: '*' / \
+Action: ListActivations"
         logger.info(log_msg)
 
         return self.get_paginated_response(result)
@@ -271,7 +293,15 @@ class ActivationViewSet(
             process_parent_type=ProcessParentType.ACTIVATION,
             process_parent_id=pk,
         )
-        log_msg = f"RESOURCE UPDATE - ResourceType: RulebookActivation / ResourceName: {activation.name} / Organization: {activation.organization} / isEnabled: {activation.is_enabled} / Project: {logging_utils.get_project_name_from_id(activation.project_id)} / Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / DecisionEnvironment: {logging_utils.get_decisionenvironment_name_from_id(activation.decision_environment_id)} / Action: Enable"
+        log_msg = f"RESOURCE UPDATE - \
+ResourceType: RulebookActivation / ResourceName: {activation.name} / \
+Organization: {activation.organization} / \
+isEnabled: {activation.is_enabled} / \
+Project: {logging_utils.get_project_name_from_id(activation.project_id)} / \
+Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / \
+DecisionEnvironment: \
+{logging_utils.get_de_name_from_id(activation.decision_environment_id)} / \
+Action: Enable"
         logger.info(log_msg)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -302,7 +332,15 @@ class ActivationViewSet(
                 process_parent_type=ProcessParentType.ACTIVATION,
                 process_parent_id=activation.id,
             )
-        log_msg = f"RESOURCE UPDATE - ResourceType: RulebookActivation / ResourceName: {activation.name} / Organization: {activation.organization} / isEnabled: {activation.is_enabled} / Project: {logging_utils.get_project_name_from_id(activation.project_id)} / Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / DecisionEnvironment: {logging_utils.get_decisionenvironment_name_from_id(activation.decision_environment_id)} / Action: Disable"
+        log_msg = f"RESOURCE UPDATE - \
+ResourceType: RulebookActivation / ResourceName: {activation.name} / \
+Organization: {activation.organization} / \
+isEnabled: {activation.is_enabled} / \
+Project: {logging_utils.get_project_name_from_id(activation.project_id)} / \
+Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / \
+DecisionEnvironment: \
+{logging_utils.get_de_name_from_id(activation.decision_environment_id)} / \
+Action: Disable"
         logger.info(log_msg)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -346,7 +384,15 @@ class ActivationViewSet(
             process_parent_type=ProcessParentType.ACTIVATION,
             process_parent_id=activation.id,
         )
-        log_msg = f"RESOURCE UPDATE - ResourceType: RulebookActivation / ResourceName: {activation.name} / Organization: {activation.organization} / isEnabled: {activation.is_enabled} / Project: {logging_utils.get_project_name_from_id(activation.project_id)} / Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / DecisionEnvironment: {logging_utils.get_decisionenvironment_name_from_id(activation.decision_environment_id)} / Action: Restart"
+        log_msg = f"RESOURCE UPDATE - \
+ResourceType: RulebookActivation / ResourceName: {activation.name} / \
+Organization: {activation.organization} / \
+isEnabled: {activation.is_enabled} / \
+Project: {logging_utils.get_project_name_from_id(activation.project_id)} / \
+Rulebook: {logging_utils.get_rulebook_name_from_id(activation.rulebook_id)} / \
+DecisionEnvironment: \
+{logging_utils.get_de_name_from_id(activation.decision_environment_id)} / \
+Action: Restart"
         logger.info(log_msg)
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/aap_eda/api/views/decision_environment.py
+++ b/src/aap_eda/api/views/decision_environment.py
@@ -177,15 +177,15 @@ class DecisionEnvironmentViewSet(
                 decision_environment
             ),
         }
-        logger.info(
-            logging_utils.generate_simple_audit_log(
-                "Read",
-                resource_name,
-                decision_environment.data["name"],
-                decision_environment.data["organization"],
-                **logging_kwargs,
-            )
-        )
+        # logger.info(
+        #     logging_utils.generate_simple_audit_log(
+        #         "Read",
+        #         resource_name,
+        #         decision_environment.data["name"],
+        #         decision_environment.data["organization"],
+        #         **logging_kwargs,
+        #     )
+        # )
 
         return Response(
             serializers.DecisionEnvironmentReadSerializer(

--- a/src/aap_eda/api/views/decision_environment.py
+++ b/src/aap_eda/api/views/decision_environment.py
@@ -41,16 +41,22 @@ class CreateDecisionEnvironmentMixin(CreateModelMixin):
     def create(self, request, *args, **kwargs):
         response = super().create(request, *args, **kwargs)
 
-        log_msg = (
-            "Action: Create / "
-            "ResourceType: DecisionEnvironment / "
-            f"ResourceName: {response.data['name']} / "
-            f"Organization: {logging_utils.get_organization_name_from_data(response)} / "  # noqa: E501
-            f"Description: {response.data['description']} / "
-            f"ImageURL: {response.data['image_url']} / "
-            f"Credential: {logging_utils.get_credential_name_from_data(response)}"  # noqa: E501
+        kwargs = {
+            "Description": response.data["description"],
+            "ImageURL": response.data["image_url"],
+            "Credential": logging_utils.get_credential_name_from_data(
+                response
+            ),
+        }
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Create",
+                "DecisionEnvironment",
+                response.data["name"],
+                logging_utils.get_organization_name_from_data(response),
+                **kwargs,
+            )
         )
-        logger.info(log_msg)
 
         return response
 
@@ -59,16 +65,22 @@ class PartialUpdateOnlyDecisionEnvironmentMixin(PartialUpdateOnlyModelMixin):
     def partial_update(self, request, *args, **kwargs):
         response = super().partial_update(request, *args, **kwargs)
 
-        log_msg = (
-            "Action: Update / "
-            "ResourceType: DecisionEnvironment / "
-            f"ResourceName: {response.data['name']} / "
-            f"Organization: {logging_utils.get_organization_name_from_data(response)} / "  # noqa: E501
-            f"Description: {response.data['description']} / "
-            f"ImageURL: {response.data['image_url']} / "
-            f"Credential: {logging_utils.get_credential_name_from_data(response)}"  # noqa: E501
+        kwargs = {
+            "Description": response.data["description"],
+            "ImageURL": response.data["image_url"],
+            "Credential": logging_utils.get_credential_name_from_data(
+                response
+            ),
+        }
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Update",
+                "DecisionEnvironment",
+                response.data["name"],
+                logging_utils.get_organization_name_from_data(response),
+                **kwargs,
+            )
         )
-        logger.info(log_msg)
 
         return response
 
@@ -156,16 +168,22 @@ class DecisionEnvironmentViewSet(
             else None
         )
 
-        log_msg = (
-            "Action: Read / "
-            "ResourceType: DesicisonEnvironment / "
-            f"ResourceName: {decision_environment.data['name']}  / "
-            f"Organization: {decision_environment.data['organization']} / "
-            f"Description: {decision_environment.data['description']} / "
-            f"ImageURL: {decision_environment.data['image_url']} / "
-            f"Credential: {logging_utils.get_credential_name_from_data(decision_environment)}"  # noqa: E501
+        kwargs = {
+            "Description": decision_environment.data["description"],
+            "ImageURL": decision_environment.data["image_url"],
+            "Credential": logging_utils.get_credential_name_from_data(
+                decision_environment
+            ),
+        }
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Read",
+                "DecisionEnvironment",
+                decision_environment.data["name"],
+                decision_environment.data["organization"],
+                **kwargs,
+            )
         )
-        logger.info(log_msg)
 
         return Response(
             serializers.DecisionEnvironmentReadSerializer(
@@ -214,14 +232,19 @@ class DecisionEnvironmentViewSet(
         credential_name = instance.eda_credential
         if instance.credential == "None":
             credential_name = instance.eda_credential.name
-        log_msg = (
-            "Action: Delete / "
-            "ResourceType: DecisionEnvironment / "
-            f"ResourceName: {instance.name} / "
-            f"Organization: {instance.organization} / "
-            f"Credential: {credential_name} / "
-            f"Description: {instance.description} / "
-            f"ImageURL: {instance.image_url}"
+
+        kwargs = {
+            "Description": instance.description,
+            "ImageURL": instance.image_url,
+            "Credential": credential_name,
+        }
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Delete",
+                "DecisionEnvironment",
+                instance.name,
+                instance.organization,
+                **kwargs,
+            )
         )
-        logger.info(log_msg)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/aap_eda/api/views/decision_environment.py
+++ b/src/aap_eda/api/views/decision_environment.py
@@ -36,12 +36,14 @@ from .mixins import (
 
 logger = logging.getLogger(__name__)
 
+resource_name = "DecisionEnvironment"
+
 
 class CreateDecisionEnvironmentMixin(CreateModelMixin):
     def create(self, request, *args, **kwargs):
         response = super().create(request, *args, **kwargs)
 
-        kwargs = {
+        logging_kwargs = {
             "Description": response.data["description"],
             "ImageURL": response.data["image_url"],
             "Credential": logging_utils.get_credential_name_from_data(
@@ -51,10 +53,10 @@ class CreateDecisionEnvironmentMixin(CreateModelMixin):
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Create",
-                "DecisionEnvironment",
+                resource_name,
                 response.data["name"],
                 logging_utils.get_organization_name_from_data(response),
-                **kwargs,
+                **logging_kwargs,
             )
         )
 
@@ -65,7 +67,7 @@ class PartialUpdateOnlyDecisionEnvironmentMixin(PartialUpdateOnlyModelMixin):
     def partial_update(self, request, *args, **kwargs):
         response = super().partial_update(request, *args, **kwargs)
 
-        kwargs = {
+        logging_kwargs = {
             "Description": response.data["description"],
             "ImageURL": response.data["image_url"],
             "Credential": logging_utils.get_credential_name_from_data(
@@ -75,10 +77,10 @@ class PartialUpdateOnlyDecisionEnvironmentMixin(PartialUpdateOnlyModelMixin):
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Update",
-                "DecisionEnvironment",
+                resource_name,
                 response.data["name"],
                 logging_utils.get_organization_name_from_data(response),
-                **kwargs,
+                **logging_kwargs,
             )
         )
 
@@ -168,7 +170,7 @@ class DecisionEnvironmentViewSet(
             else None
         )
 
-        kwargs = {
+        logging_kwargs = {
             "Description": decision_environment.data["description"],
             "ImageURL": decision_environment.data["image_url"],
             "Credential": logging_utils.get_credential_name_from_data(
@@ -178,10 +180,10 @@ class DecisionEnvironmentViewSet(
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Read",
-                "DecisionEnvironment",
+                resource_name,
                 decision_environment.data["name"],
                 decision_environment.data["organization"],
-                **kwargs,
+                **logging_kwargs,
             )
         )
 
@@ -233,7 +235,7 @@ class DecisionEnvironmentViewSet(
         if instance.credential == "None":
             credential_name = instance.eda_credential.name
 
-        kwargs = {
+        logging_kwargs = {
             "Description": instance.description,
             "ImageURL": instance.image_url,
             "Credential": credential_name,
@@ -241,10 +243,10 @@ class DecisionEnvironmentViewSet(
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Delete",
-                "DecisionEnvironment",
+                resource_name,
                 instance.name,
                 instance.organization,
-                **kwargs,
+                **logging_kwargs,
             )
         )
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/aap_eda/api/views/decision_environment.py
+++ b/src/aap_eda/api/views/decision_environment.py
@@ -13,10 +13,6 @@
 #  limitations under the License.
 import logging
 
-from ansible_base.rbac.api.related import check_related_permissions
-from ansible_base.rbac.models import RoleDefinition
-from django.db import transaction
-from django.forms import model_to_dict
 from django_filters import rest_framework as defaultfilters
 from drf_spectacular.utils import (
     OpenApiParameter,

--- a/src/aap_eda/api/views/decision_environment.py
+++ b/src/aap_eda/api/views/decision_environment.py
@@ -39,52 +39,36 @@ logger = logging.getLogger(__name__)
 resource_name = "DecisionEnvironment"
 
 
-# class CreateDecisionEnvironmentMixin(CreateModelMixin):
-#     def create(self, request, *args, **kwargs):
-#         response = super().create(request, *args, **kwargs)
+class CreateDecisionEnvironmentMixin(CreateModelMixin):
+    def create(self, request, *args, **kwargs):
+        response = super().create(request, *args, **kwargs)
 
-#         logging_kwargs = {
-#             "Description": response.data["description"],
-#             "ImageURL": response.data["image_url"],
-#             "Credential": logging_utils.get_credential_name_from_data(
-#                 response
-#             ),
-#         }
-#         logger.info(
-#             logging_utils.generate_simple_audit_log(
-#                 "Create",
-#                 resource_name,
-#                 response.data["name"],
-#                 logging_utils.get_organization_name_from_data(response),
-#                 **logging_kwargs,
-#             )
-#         )
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Create",
+                resource_name,
+                response.data["name"],
+                logging_utils.get_organization_name_from_data(response),
+            )
+        )
 
-#         return response
+        return response
 
 
-# class PartialUpdateOnlyDecisionEnvironmentMixin(PartialUpdateOnlyModelMixin):
-#     def partial_update(self, request, *args, **kwargs):
-#         response = super().partial_update(request, *args, **kwargs)
+class PartialUpdateOnlyDecisionEnvironmentMixin(PartialUpdateOnlyModelMixin):
+    def partial_update(self, request, *args, **kwargs):
+        response = super().partial_update(request, *args, **kwargs)
 
-#         logging_kwargs = {
-#             "Description": response.data["description"],
-#             "ImageURL": response.data["image_url"],
-#             "Credential": logging_utils.get_credential_name_from_data(
-#                 response
-#             ),
-#         }
-#         logger.info(
-#             logging_utils.generate_simple_audit_log(
-#                 "Update",
-#                 resource_name,
-#                 response.data["name"],
-#                 logging_utils.get_organization_name_from_data(response),
-#                 **logging_kwargs,
-#             )
-#         )
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Update",
+                resource_name,
+                response.data["name"],
+                logging_utils.get_organization_name_from_data(response),
+            )
+        )
 
-#         return response
+        return response
 
 
 @extend_schema_view(
@@ -120,10 +104,8 @@ resource_name = "DecisionEnvironment"
 )
 class DecisionEnvironmentViewSet(
     ResponseSerializerMixin,
-    # CreateDecisionEnvironmentMixin,
-    # PartialUpdateOnlyDecisionEnvironmentMixin,
-    CreateModelMixin,
-    PartialUpdateOnlyModelMixin,
+    CreateDecisionEnvironmentMixin,
+    PartialUpdateOnlyDecisionEnvironmentMixin,
     mixins.RetrieveModelMixin,
     mixins.DestroyModelMixin,
     mixins.ListModelMixin,
@@ -172,20 +154,12 @@ class DecisionEnvironmentViewSet(
             else None
         )
 
-        logging_kwargs = {
-            "Description": decision_environment.data["description"],
-            "ImageURL": decision_environment.data["image_url"],
-            "Credential": logging_utils.get_credential_name_from_data(
-                decision_environment
-            ),
-        }
         # logger.info(
         #     logging_utils.generate_simple_audit_log(
         #         "Read",
         #         resource_name,
         #         decision_environment.data["name"],
         #         decision_environment.data["organization"],
-        #         **logging_kwargs,
         #     )
         # )
 
@@ -233,22 +207,12 @@ class DecisionEnvironmentViewSet(
 
         self.perform_destroy(instance)
 
-        credential_name = instance.eda_credential
-        if instance.credential == "None":
-            credential_name = instance.eda_credential.name
-
-        logging_kwargs = {
-            "Description": instance.description,
-            "ImageURL": instance.image_url,
-            "Credential": credential_name,
-        }
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Delete",
                 resource_name,
                 instance.name,
                 instance.organization,
-                **logging_kwargs,
             )
         )
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/aap_eda/api/views/decision_environment.py
+++ b/src/aap_eda/api/views/decision_environment.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import logging
-import json
+
 from django_filters import rest_framework as defaultfilters
 from drf_spectacular.utils import (
     OpenApiParameter,
@@ -25,6 +25,7 @@ from rest_framework.response import Response
 
 from aap_eda.api import exceptions as api_exc, filters, serializers
 from aap_eda.core import models
+from aap_eda.core.utils import logging_utils
 from aap_eda.utils import str_to_bool
 
 from .mixins import (
@@ -32,9 +33,9 @@ from .mixins import (
     PartialUpdateOnlyModelMixin,
     ResponseSerializerMixin,
 )
-from aap_eda.core.utils import logging_utils
 
 logger = logging.getLogger(__name__)
+
 
 @extend_schema_view(
     list=extend_schema(
@@ -119,7 +120,15 @@ class DecisionEnvironmentViewSet(
             else None
         )
 
-        log_msg = f"RESOURCE UPDATE - ResourceType: DesicisonEnvironment / ResourceName: {decision_environment.data['name']}  / Organization: {decision_environment.data['organization']} / Description: {decision_environment.data['description']} / ImageURL: {decision_environment.data['image_url']} / Credential: {logging_utils.get_credential_name_from_data(decision_environment)} / Action: Read"
+        log_msg = f"RESOURCE UPDATE - \
+ResourceType: DesicisonEnvironment / \
+ResourceName: {decision_environment.data['name']}  / \
+Organization: {decision_environment.data['organization']} / \
+Description: {decision_environment.data['description']} / \
+ImageURL: {decision_environment.data['image_url']} / \
+Credential: \
+{logging_utils.get_credential_name_from_data(decision_environment)} / \
+Action: Read"
         logger.info(log_msg)
 
         return Response(
@@ -167,8 +176,12 @@ class DecisionEnvironmentViewSet(
         self.perform_destroy(instance)
 
         credential_name = instance.eda_credential
-        if instance.credential == 'None':
+        if instance.credential == "None":
             credential_name = instance.eda_credential.name
-        log_msg = f"RESOURCE UPDATE - ResourceType: DecisionEnvironment / ResourceName: {instance.name} / Organization: {instance.organization} / Credential: {credential_name} / Description: {instance.description} / ImageURL: {instance.image_url} / Action: Delete"
+        log_msg = f"RESOURCE UPDATE - \
+ResourceType: DecisionEnvironment / ResourceName: {instance.name} / \
+Organization: {instance.organization} / \
+Credential: {credential_name} / Description: {instance.description} / \
+ImageURL: {instance.image_url} / Action: Delete"
         logger.info(log_msg)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/aap_eda/api/views/decision_environment.py
+++ b/src/aap_eda/api/views/decision_environment.py
@@ -39,52 +39,52 @@ logger = logging.getLogger(__name__)
 resource_name = "DecisionEnvironment"
 
 
-class CreateDecisionEnvironmentMixin(CreateModelMixin):
-    def create(self, request, *args, **kwargs):
-        response = super().create(request, *args, **kwargs)
+# class CreateDecisionEnvironmentMixin(CreateModelMixin):
+#     def create(self, request, *args, **kwargs):
+#         response = super().create(request, *args, **kwargs)
 
-        logging_kwargs = {
-            "Description": response.data["description"],
-            "ImageURL": response.data["image_url"],
-            "Credential": logging_utils.get_credential_name_from_data(
-                response
-            ),
-        }
-        logger.info(
-            logging_utils.generate_simple_audit_log(
-                "Create",
-                resource_name,
-                response.data["name"],
-                logging_utils.get_organization_name_from_data(response),
-                **logging_kwargs,
-            )
-        )
+#         logging_kwargs = {
+#             "Description": response.data["description"],
+#             "ImageURL": response.data["image_url"],
+#             "Credential": logging_utils.get_credential_name_from_data(
+#                 response
+#             ),
+#         }
+#         logger.info(
+#             logging_utils.generate_simple_audit_log(
+#                 "Create",
+#                 resource_name,
+#                 response.data["name"],
+#                 logging_utils.get_organization_name_from_data(response),
+#                 **logging_kwargs,
+#             )
+#         )
 
-        return response
+#         return response
 
 
-class PartialUpdateOnlyDecisionEnvironmentMixin(PartialUpdateOnlyModelMixin):
-    def partial_update(self, request, *args, **kwargs):
-        response = super().partial_update(request, *args, **kwargs)
+# class PartialUpdateOnlyDecisionEnvironmentMixin(PartialUpdateOnlyModelMixin):
+#     def partial_update(self, request, *args, **kwargs):
+#         response = super().partial_update(request, *args, **kwargs)
 
-        logging_kwargs = {
-            "Description": response.data["description"],
-            "ImageURL": response.data["image_url"],
-            "Credential": logging_utils.get_credential_name_from_data(
-                response
-            ),
-        }
-        logger.info(
-            logging_utils.generate_simple_audit_log(
-                "Update",
-                resource_name,
-                response.data["name"],
-                logging_utils.get_organization_name_from_data(response),
-                **logging_kwargs,
-            )
-        )
+#         logging_kwargs = {
+#             "Description": response.data["description"],
+#             "ImageURL": response.data["image_url"],
+#             "Credential": logging_utils.get_credential_name_from_data(
+#                 response
+#             ),
+#         }
+#         logger.info(
+#             logging_utils.generate_simple_audit_log(
+#                 "Update",
+#                 resource_name,
+#                 response.data["name"],
+#                 logging_utils.get_organization_name_from_data(response),
+#                 **logging_kwargs,
+#             )
+#         )
 
-        return response
+#         return response
 
 
 @extend_schema_view(
@@ -120,8 +120,10 @@ class PartialUpdateOnlyDecisionEnvironmentMixin(PartialUpdateOnlyModelMixin):
 )
 class DecisionEnvironmentViewSet(
     ResponseSerializerMixin,
-    CreateDecisionEnvironmentMixin,
-    PartialUpdateOnlyDecisionEnvironmentMixin,
+    # CreateDecisionEnvironmentMixin,
+    # PartialUpdateOnlyDecisionEnvironmentMixin,
+    CreateModelMixin,
+    PartialUpdateOnlyModelMixin,
     mixins.RetrieveModelMixin,
     mixins.DestroyModelMixin,
     mixins.ListModelMixin,

--- a/src/aap_eda/api/views/decision_environment.py
+++ b/src/aap_eda/api/views/decision_environment.py
@@ -13,6 +13,10 @@
 #  limitations under the License.
 import logging
 
+from ansible_base.rbac.api.related import check_related_permissions
+from ansible_base.rbac.models import RoleDefinition
+from django.db import transaction
+from django.forms import model_to_dict
 from django_filters import rest_framework as defaultfilters
 from drf_spectacular.utils import (
     OpenApiParameter,
@@ -29,12 +33,87 @@ from aap_eda.core.utils import logging_utils
 from aap_eda.utils import str_to_bool
 
 from .mixins import (
-    CreateModelMixin,
-    PartialUpdateOnlyModelMixin,
     ResponseSerializerMixin,
 )
 
 logger = logging.getLogger(__name__)
+
+
+class CreateDecisionEnvironmentMixin(mixins.CreateModelMixin):
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        with transaction.atomic():
+            self.perform_create(serializer)
+            check_related_permissions(
+                request.user,
+                serializer.Meta.model,
+                {},
+                model_to_dict(serializer.instance),
+            )
+            RoleDefinition.objects.give_creator_permissions(
+                request.user, serializer.instance
+            )
+        headers = self.get_success_headers(serializer.data)
+
+        response_serializer_class = self.get_response_serializer_class()
+        response_serializer = response_serializer_class(serializer.instance)
+
+        log_msg = (
+            "Action: Read / "
+            "ResourceType: DecisionEnvironment / "
+            f"ResourceName: {response_serializer.data['name']} / "
+            f"Organization: {logging_utils.get_organization_name_from_data(response_serializer)} / "  # noqa: E501
+            f"Description: {response_serializer.data['description']} / "
+            f"ImageURL: {response_serializer.data['image_url']} / "
+            f"Credential: {logging_utils.get_credential_name_from_data(response_serializer)}"  # noqa: E501
+        )
+        logger.info(log_msg)
+        return Response(
+            response_serializer.data,
+            status=status.HTTP_201_CREATED,
+            headers=headers,
+        )
+
+
+class PartialUpdateOnlyDecisionEnvironmentMixin(mixins.UpdateModelMixin):
+    def partial_update(self, request, *args, **kwargs):
+        instance = self.get_object()
+        old_data = model_to_dict(instance)
+        serializer = self.get_serializer(
+            instance, data=request.data, partial=True
+        )
+        serializer.is_valid(raise_exception=True)
+
+        with transaction.atomic():
+            self.perform_update(serializer)
+            check_related_permissions(
+                request.user,
+                serializer.Meta.model,
+                old_data,
+                model_to_dict(serializer.instance),
+            )
+
+        if getattr(instance, "_prefetched_objects_cache", None):
+            # If 'prefetch_related' has been applied to a queryset, we need to
+            # forcibly invalidate the prefetch cache on the instance.
+            instance._prefetched_objects_cache = {}
+
+        response_serializer_class = self.get_response_serializer_class()
+        response_serializer = response_serializer_class(serializer.instance)
+
+        log_msg = (
+            "Action: Update / "
+            "ResourceType: DecisionEnvironment / "
+            f"ResourceName: {response_serializer.data['name']} / "
+            f"Organization: {logging_utils.get_organization_name_from_data(response_serializer)} / "  # noqa: E501
+            f"Description: {response_serializer.data['description']} / "
+            f"ImageURL: {response_serializer.data['image_url']} / "
+            f"Credential: {logging_utils.get_credential_name_from_data(response_serializer)}"  # noqa: E501
+        )
+        logger.info(log_msg)
+
+        return Response(response_serializer.data)
 
 
 @extend_schema_view(
@@ -70,8 +149,8 @@ logger = logging.getLogger(__name__)
 )
 class DecisionEnvironmentViewSet(
     ResponseSerializerMixin,
-    CreateModelMixin,
-    PartialUpdateOnlyModelMixin,
+    CreateDecisionEnvironmentMixin,
+    PartialUpdateOnlyDecisionEnvironmentMixin,
     mixins.RetrieveModelMixin,
     mixins.DestroyModelMixin,
     mixins.ListModelMixin,
@@ -121,14 +200,13 @@ class DecisionEnvironmentViewSet(
         )
 
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: Read / "
             "ResourceType: DesicisonEnvironment / "
             f"ResourceName: {decision_environment.data['name']}  / "
             f"Organization: {decision_environment.data['organization']} / "
             f"Description: {decision_environment.data['description']} / "
             f"ImageURL: {decision_environment.data['image_url']} / "
-            f"Credential: {logging_utils.get_credential_name_from_data(decision_environment)} / "  # noqa: E501
-            "Action: Read"
+            f"Credential: {logging_utils.get_credential_name_from_data(decision_environment)}"  # noqa: E501
         )
         logger.info(log_msg)
 
@@ -180,14 +258,13 @@ class DecisionEnvironmentViewSet(
         if instance.credential == "None":
             credential_name = instance.eda_credential.name
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: Delete / "
             "ResourceType: DecisionEnvironment / "
             f"ResourceName: {instance.name} / "
             f"Organization: {instance.organization} / "
             f"Credential: {credential_name} / "
             f"Description: {instance.description} / "
-            f"ImageURL: {instance.image_url} / "
-            "Action: Delete"
+            f"ImageURL: {instance.image_url}"
         )
         logger.info(log_msg)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/aap_eda/api/views/decision_environment.py
+++ b/src/aap_eda/api/views/decision_environment.py
@@ -11,7 +11,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import logging
+import json
 from django_filters import rest_framework as defaultfilters
 from drf_spectacular.utils import (
     OpenApiParameter,
@@ -31,7 +32,9 @@ from .mixins import (
     PartialUpdateOnlyModelMixin,
     ResponseSerializerMixin,
 )
+from aap_eda.core.utils import logging_utils
 
+logger = logging.getLogger(__name__)
 
 @extend_schema_view(
     list=extend_schema(
@@ -116,6 +119,9 @@ class DecisionEnvironmentViewSet(
             else None
         )
 
+        log_msg = f"RESOURCE UPDATE - ResourceType: DesicisonEnvironment / ResourceName: {decision_environment.data['name']}  / Organization: {decision_environment.data['organization']} / Description: {decision_environment.data['description']} / ImageURL: {decision_environment.data['image_url']} / Credential: {logging_utils.get_credential_name_from_data(decision_environment)} / Action: Read"
+        logger.info(log_msg)
+
         return Response(
             serializers.DecisionEnvironmentReadSerializer(
                 decision_environment.data
@@ -159,4 +165,10 @@ class DecisionEnvironmentViewSet(
             )
 
         self.perform_destroy(instance)
+
+        credential_name = instance.eda_credential
+        if instance.credential == 'None':
+            credential_name = instance.eda_credential.name
+        log_msg = f"RESOURCE UPDATE - ResourceType: DecisionEnvironment / ResourceName: {instance.name} / Organization: {instance.organization} / Credential: {credential_name} / Description: {instance.description} / ImageURL: {instance.image_url} / Action: Delete"
+        logger.info(log_msg)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/aap_eda/api/views/decision_environment.py
+++ b/src/aap_eda/api/views/decision_environment.py
@@ -154,14 +154,14 @@ class DecisionEnvironmentViewSet(
             else None
         )
 
-        # logger.info(
-        #     logging_utils.generate_simple_audit_log(
-        #         "Read",
-        #         resource_name,
-        #         decision_environment.data["name"],
-        #         decision_environment.data["organization"],
-        #     )
-        # )
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Read",
+                resource_name,
+                decision_environment.data["name"],
+                decision_environment.data["organization"],
+            )
+        )
 
         return Response(
             serializers.DecisionEnvironmentReadSerializer(

--- a/src/aap_eda/api/views/decision_environment.py
+++ b/src/aap_eda/api/views/decision_environment.py
@@ -120,15 +120,16 @@ class DecisionEnvironmentViewSet(
             else None
         )
 
-        log_msg = f"RESOURCE UPDATE - \
-ResourceType: DesicisonEnvironment / \
-ResourceName: {decision_environment.data['name']}  / \
-Organization: {decision_environment.data['organization']} / \
-Description: {decision_environment.data['description']} / \
-ImageURL: {decision_environment.data['image_url']} / \
-Credential: \
-{logging_utils.get_credential_name_from_data(decision_environment)} / \
-Action: Read"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            "ResourceType: DesicisonEnvironment / "
+            f"ResourceName: {decision_environment.data['name']}  / "
+            f"Organization: {decision_environment.data['organization']} / "
+            f"Description: {decision_environment.data['description']} / "
+            f"ImageURL: {decision_environment.data['image_url']} / "
+            f"Credential: {logging_utils.get_credential_name_from_data(decision_environment)} / "  # noqa: E501
+            "Action: Read"
+        )
         logger.info(log_msg)
 
         return Response(
@@ -178,10 +179,15 @@ Action: Read"
         credential_name = instance.eda_credential
         if instance.credential == "None":
             credential_name = instance.eda_credential.name
-        log_msg = f"RESOURCE UPDATE - \
-ResourceType: DecisionEnvironment / ResourceName: {instance.name} / \
-Organization: {instance.organization} / \
-Credential: {credential_name} / Description: {instance.description} / \
-ImageURL: {instance.image_url} / Action: Delete"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            "ResourceType: DecisionEnvironment / "
+            f"ResourceName: {instance.name} / "
+            f"Organization: {instance.organization} / "
+            f"Credential: {credential_name} / "
+            f"Description: {instance.description} / "
+            f"ImageURL: {instance.image_url} / "
+            "Action: Delete"
+        )
         logger.info(log_msg)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/aap_eda/api/views/decision_environment.py
+++ b/src/aap_eda/api/views/decision_environment.py
@@ -48,6 +48,7 @@ class CreateDecisionEnvironmentMixin(CreateModelMixin):
                 "Create",
                 resource_name,
                 response.data["name"],
+                response.data["id"],
                 logging_utils.get_organization_name_from_data(response),
             )
         )
@@ -64,6 +65,7 @@ class PartialUpdateOnlyDecisionEnvironmentMixin(PartialUpdateOnlyModelMixin):
                 "Update",
                 resource_name,
                 response.data["name"],
+                response.data["id"],
                 logging_utils.get_organization_name_from_data(response),
             )
         )
@@ -159,6 +161,7 @@ class DecisionEnvironmentViewSet(
                 "Read",
                 resource_name,
                 decision_environment.data["name"],
+                decision_environment.data["id"],
                 decision_environment.data["organization"],
             )
         )
@@ -212,6 +215,7 @@ class DecisionEnvironmentViewSet(
                 "Delete",
                 resource_name,
                 instance.name,
+                instance.id,
                 instance.organization,
             )
         )

--- a/src/aap_eda/api/views/decision_environment.py
+++ b/src/aap_eda/api/views/decision_environment.py
@@ -32,9 +32,7 @@ from aap_eda.core import models
 from aap_eda.core.utils import logging_utils
 from aap_eda.utils import str_to_bool
 
-from .mixins import (
-    ResponseSerializerMixin,
-)
+from .mixins import ResponseSerializerMixin
 
 logger = logging.getLogger(__name__)
 

--- a/src/aap_eda/api/views/mixins.py
+++ b/src/aap_eda/api/views/mixins.py
@@ -52,16 +52,16 @@ class CreateModelMixin:
 
         log_msg = ""
         if resource_type == "decisionenvironment":
-            log_msg = f"RESOURCE UPDATE - \
-ResourceType: DecisionEnvironment / \
-ResourceName: {response_serializer.data['name']} / \
-Organization: \
-{logging_utils.get_organization_name_from_data(response_serializer)} / \
-Description: {response_serializer.data['description']} / \
-ImageURL: {response_serializer.data['image_url']} / \
-Credential: \
-{logging_utils.get_credential_name_from_data(response_serializer)} / \
-Action: Read"
+            log_msg = (
+                "RESOURCE UPDATE - "
+                "ResourceType: DecisionEnvironment / "
+                f"ResourceName: {response_serializer.data['name']} / "
+                f"Organization: {logging_utils.get_organization_name_from_data(response_serializer)} / "  # noqa: E501
+                f"Description: {response_serializer.data['description']} / "
+                f"ImageURL: {response_serializer.data['image_url']} / "
+                f"Credential: {logging_utils.get_credential_name_from_data(response_serializer)} / "  # noqa: E501
+                "Action: Read"
+            )
         logger.info(log_msg)
         return Response(
             response_serializer.data,
@@ -108,16 +108,16 @@ class PartialUpdateOnlyModelMixin:
 
         log_msg = ""
         if resource_type == "decisionenvironment":
-            log_msg = f"RESOURCE UPDATE - \
-ResourceType: DecisionEnvironment / \
-ResourceName: {response_serializer.data['name']} / \
-Organization: \
-{logging_utils.get_organization_name_from_data(response_serializer)} / \
-Description: {response_serializer.data['description']} / \
-ImageURL: {response_serializer.data['image_url']} / \
-Credential: \
-{logging_utils.get_credential_name_from_data(response_serializer)} / \
-Action: Update"
+            log_msg = (
+                "RESOURCE UPDATE - "
+                "ResourceType: DecisionEnvironment / "
+                f"ResourceName: {response_serializer.data['name']} / "
+                f"Organization: {logging_utils.get_organization_name_from_data(response_serializer)} / "  # noqa: E501
+                f"Description: {response_serializer.data['description']} / "
+                f"ImageURL: {response_serializer.data['image_url']} / "
+                f"Credential: {logging_utils.get_credential_name_from_data(response_serializer)} / "  # noqa: E501
+                "Action: Update"
+            )
         logger.info(log_msg)
 
         return Response(response_serializer.data)

--- a/src/aap_eda/api/views/mixins.py
+++ b/src/aap_eda/api/views/mixins.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import logging
+
 from ansible_base.rbac.api.related import check_related_permissions
 from ansible_base.rbac.models import RoleDefinition
 from django.conf import settings
@@ -20,12 +21,12 @@ from django.forms import model_to_dict
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
-from aap_eda.core import models
-from aap_eda.core.utils import logging_utils
-from rest_framework import mixins
+
 from aap_eda.api import exceptions as api_exc
+from aap_eda.core.utils import logging_utils
 
 logger = logging.getLogger(__name__)
+
 
 # TODO: need revisit from cuwater
 class CreateModelMixin:
@@ -50,8 +51,17 @@ class CreateModelMixin:
         response_serializer = response_serializer_class(serializer.instance)
 
         log_msg = ""
-        if resource_type == 'decisionenvironment':
-            log_msg = f"RESOURCE UPDATE - ResourceType: DecisionEnvironment / ResourceName: {response_serializer.data['name']} / Organization: {logging_utils.get_organization_name_from_data(response_serializer)} / Description: {response_serializer.data['description']} / ImageURL: {response_serializer.data['image_url']} / Credential: {logging_utils.get_credential_name_from_data(response_serializer)} / Action: Read"
+        if resource_type == "decisionenvironment":
+            log_msg = f"RESOURCE UPDATE - \
+ResourceType: DecisionEnvironment / \
+ResourceName: {response_serializer.data['name']} / \
+Organization: \
+{logging_utils.get_organization_name_from_data(response_serializer)} / \
+Description: {response_serializer.data['description']} / \
+ImageURL: {response_serializer.data['image_url']} / \
+Credential: \
+{logging_utils.get_credential_name_from_data(response_serializer)} / \
+Action: Read"
         logger.info(log_msg)
         return Response(
             response_serializer.data,
@@ -97,8 +107,17 @@ class PartialUpdateOnlyModelMixin:
         response_serializer = response_serializer_class(serializer.instance)
 
         log_msg = ""
-        if resource_type == 'decisionenvironment':
-            log_msg = f"RESOURCE UPDATE - ResourceType: DecisionEnvironment / ResourceName: {response_serializer.data['name']} / Organization: {logging_utils.get_organization_name_from_data(response_serializer)} / Description: {response_serializer.data['description']} / ImageURL: {response_serializer.data['image_url']} / Credential: {logging_utils.get_credential_name_from_data(response_serializer)} / Action: Update"
+        if resource_type == "decisionenvironment":
+            log_msg = f"RESOURCE UPDATE - \
+ResourceType: DecisionEnvironment / \
+ResourceName: {response_serializer.data['name']} / \
+Organization: \
+{logging_utils.get_organization_name_from_data(response_serializer)} / \
+Description: {response_serializer.data['description']} / \
+ImageURL: {response_serializer.data['image_url']} / \
+Credential: \
+{logging_utils.get_credential_name_from_data(response_serializer)} / \
+Action: Update"
         logger.info(log_msg)
 
         return Response(response_serializer.data)

--- a/src/aap_eda/api/views/mixins.py
+++ b/src/aap_eda/api/views/mixins.py
@@ -44,7 +44,6 @@ class CreateModelMixin:
 
         response_serializer_class = self.get_response_serializer_class()
         response_serializer = response_serializer_class(serializer.instance)
-
         return Response(
             response_serializer.data,
             status=status.HTTP_201_CREATED,
@@ -86,7 +85,6 @@ class PartialUpdateOnlyModelMixin:
 
         response_serializer_class = self.get_response_serializer_class()
         response_serializer = response_serializer_class(serializer.instance)
-
         return Response(response_serializer.data)
 
     def perform_update(self, serializer):

--- a/src/aap_eda/api/views/mixins.py
+++ b/src/aap_eda/api/views/mixins.py
@@ -11,7 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import logging
 
 from ansible_base.rbac.api.related import check_related_permissions
 from ansible_base.rbac.models import RoleDefinition
@@ -23,9 +22,6 @@ from rest_framework.response import Response
 from rest_framework.settings import api_settings
 
 from aap_eda.api import exceptions as api_exc
-from aap_eda.core.utils import logging_utils
-
-logger = logging.getLogger(__name__)
 
 
 # TODO: need revisit from cuwater
@@ -33,7 +29,6 @@ class CreateModelMixin:
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        resource_type = serializer.Meta.model.router_basename
         with transaction.atomic():
             self.perform_create(serializer)
             check_related_permissions(
@@ -50,19 +45,6 @@ class CreateModelMixin:
         response_serializer_class = self.get_response_serializer_class()
         response_serializer = response_serializer_class(serializer.instance)
 
-        log_msg = ""
-        if resource_type == "decisionenvironment":
-            log_msg = (
-                "RESOURCE UPDATE - "
-                "ResourceType: DecisionEnvironment / "
-                f"ResourceName: {response_serializer.data['name']} / "
-                f"Organization: {logging_utils.get_organization_name_from_data(response_serializer)} / "  # noqa: E501
-                f"Description: {response_serializer.data['description']} / "
-                f"ImageURL: {response_serializer.data['image_url']} / "
-                f"Credential: {logging_utils.get_credential_name_from_data(response_serializer)} / "  # noqa: E501
-                "Action: Read"
-            )
-        logger.info(log_msg)
         return Response(
             response_serializer.data,
             status=status.HTTP_201_CREATED,
@@ -87,7 +69,6 @@ class PartialUpdateOnlyModelMixin:
             instance, data=request.data, partial=True
         )
         serializer.is_valid(raise_exception=True)
-        resource_type = serializer.Meta.model.router_basename
 
         with transaction.atomic():
             self.perform_update(serializer)
@@ -105,20 +86,6 @@ class PartialUpdateOnlyModelMixin:
 
         response_serializer_class = self.get_response_serializer_class()
         response_serializer = response_serializer_class(serializer.instance)
-
-        log_msg = ""
-        if resource_type == "decisionenvironment":
-            log_msg = (
-                "RESOURCE UPDATE - "
-                "ResourceType: DecisionEnvironment / "
-                f"ResourceName: {response_serializer.data['name']} / "
-                f"Organization: {logging_utils.get_organization_name_from_data(response_serializer)} / "  # noqa: E501
-                f"Description: {response_serializer.data['description']} / "
-                f"ImageURL: {response_serializer.data['image_url']} / "
-                f"Credential: {logging_utils.get_credential_name_from_data(response_serializer)} / "  # noqa: E501
-                "Action: Update"
-            )
-        logger.info(log_msg)
 
         return Response(response_serializer.data)
 

--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -31,6 +31,7 @@ from aap_eda import tasks
 from aap_eda.api import exceptions as api_exc, filters, serializers
 from aap_eda.core import models
 from aap_eda.core.enums import Action
+from aap_eda.core.utils import logging_utils
 
 from .mixins import ResponseSerializerMixin
 
@@ -43,13 +44,12 @@ class DestroyProjectMixin(mixins.DestroyModelMixin):
 
         super().destroy(request, *args, **kwargs)
 
-        log_msg = (
-            "Action: Delete / "
-            "ResourceType: Project / "
-            f"ResourceName: {project.name} / "
-            f"Organization: {project.organization}"
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Delete", "Project", project.name, project.organization, **{}
+            )
         )
-        logger.info(log_msg)
+
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
@@ -130,13 +130,11 @@ class ProjectViewSet(
         serializer = self.get_serializer(project)
         headers = self.get_success_headers(serializer.data)
 
-        log_msg = (
-            "Action: Create / "
-            "ResourceType: Project / "
-            f"ResourceName: {project.name} / "
-            f"Organization: {project.organization}"
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Create", "Project", project.name, project.organization, **{}
+            )
         )
-        logger.info(log_msg)
 
         return Response(
             serializer.data, status=status.HTTP_201_CREATED, headers=headers
@@ -173,13 +171,15 @@ class ProjectViewSet(
             else None
         )
 
-        log_msg = (
-            "Action: Read / "
-            "ResourceType: Project / "
-            f"ResourceName: {project.data['name']} / "
-            f"Organization: {project.data['organization'].name}"
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Read",
+                "Project",
+                project.data["name"],
+                project.data["organization"].name,
+                **{},
+            )
         )
-        logger.info(log_msg)
 
         return Response(serializers.ProjectReadSerializer(project.data).data)
 
@@ -222,13 +222,13 @@ class ProjectViewSet(
                 old_data,
                 model_to_dict(project),
             )
-        log_msg = (
-            "Action: Update / "
-            "ResourceType: Project / "
-            f"ResourceName: {project.name} / "
-            f"Organization: {project.organization}"
+
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Update", "Project", project.name, project.organization, **{}
+            )
         )
-        logger.info(log_msg)
+
         return Response(serializers.ProjectSerializer(project).data)
 
     @extend_schema(
@@ -271,13 +271,11 @@ class ProjectViewSet(
         project.import_error = None
         project.save()
 
-        log_msg = (
-            "Action: Sync / "
-            "ResourceType: Project / "
-            f"ResourceName: {project.name} / "
-            f"Organization: {project.organization}"
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Sync", "Project", project.name, project.organization, **{}
+            )
         )
-        logger.info(log_msg)
 
         serializer = serializers.ProjectSerializer(project)
         return Response(status=status.HTTP_202_ACCEPTED, data=serializer.data)

--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -37,6 +37,8 @@ from .mixins import ResponseSerializerMixin
 
 logger = logging.getLogger(__name__)
 
+resource_name = "Project"
+
 
 class DestroyProjectMixin(mixins.DestroyModelMixin):
     def destroy(self, request, *args, **kwargs):
@@ -46,7 +48,11 @@ class DestroyProjectMixin(mixins.DestroyModelMixin):
 
         logger.info(
             logging_utils.generate_simple_audit_log(
-                "Delete", "Project", project.name, project.organization, **{}
+                "Delete",
+                resource_name,
+                project.name,
+                project.organization,
+                **{},
             )
         )
 
@@ -132,7 +138,11 @@ class ProjectViewSet(
 
         logger.info(
             logging_utils.generate_simple_audit_log(
-                "Create", "Project", project.name, project.organization, **{}
+                "Create",
+                resource_name,
+                project.name,
+                project.organization,
+                **{},
             )
         )
 
@@ -174,7 +184,7 @@ class ProjectViewSet(
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Read",
-                "Project",
+                resource_name,
                 project.data["name"],
                 project.data["organization"].name,
                 **{},
@@ -225,7 +235,11 @@ class ProjectViewSet(
 
         logger.info(
             logging_utils.generate_simple_audit_log(
-                "Update", "Project", project.name, project.organization, **{}
+                "Update",
+                resource_name,
+                project.name,
+                project.organization,
+                **{},
             )
         )
 
@@ -273,7 +287,7 @@ class ProjectViewSet(
 
         logger.info(
             logging_utils.generate_simple_audit_log(
-                "Sync", "Project", project.name, project.organization, **{}
+                "Sync", resource_name, project.name, project.organization, **{}
             )
         )
 

--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import logging
+
 from ansible_base.rbac.api.related import check_related_permissions
 from ansible_base.rbac.models import RoleDefinition
 from django.db import transaction
@@ -35,15 +36,19 @@ from .mixins import ResponseSerializerMixin
 
 logger = logging.getLogger(__name__)
 
+
 class DestroyProjectMixin(mixins.DestroyModelMixin):
     def destroy(self, request, *args, **kwargs):
         project = self.get_object()
 
         super().destroy(request, *args, **kwargs)
 
-        log_msg = f"RESOURCE UPDATE - ResourceType: Project / ResourceName: {project.name} / Organization: {project.organization} / Action: Delete"
+        log_msg = f"RESOURCE UPDATE - \
+ResourceType: Project / ResourceName: {project.name} / \
+Organization: {project.organization} / Action: Delete"
         logger.info(log_msg)
         return Response(status=status.HTTP_204_NO_CONTENT)
+
 
 @extend_schema_view(
     list=extend_schema(
@@ -122,7 +127,9 @@ class ProjectViewSet(
         serializer = self.get_serializer(project)
         headers = self.get_success_headers(serializer.data)
 
-        log_msg = f"RESOURCE UPDATE - ResourceType: Project / ResourceName: {project.name} / Organization: {project.organization} / Action: Create"
+        log_msg = f"RESOURCE UPDATE - \
+ResourceType: Project / ResourceName: {project.name} / \
+Organization: {project.organization} / Action: Create"
         logger.info(log_msg)
 
         return Response(
@@ -160,7 +167,10 @@ class ProjectViewSet(
             else None
         )
 
-        log_msg = f"RESOURCE UPDATE - ResourceType: Project / ResourceName: {project.data['name']} / Organization: {project.data['organization'].name} / Action: Read"
+        log_msg = f"RESOURCE UPDATE - \
+ResourceType: Project / ResourceName: {project.data['name']} / \
+Organization: {project.data['organization'].name} / \
+Action: Read"
         logger.info(log_msg)
 
         return Response(serializers.ProjectReadSerializer(project.data).data)
@@ -204,7 +214,9 @@ class ProjectViewSet(
                 old_data,
                 model_to_dict(project),
             )
-        log_msg = f"RESOURCE UPDATE - ResourceType: Project / ResourceName: {project.name} / Organization: {project.organization} / Action: Update"
+        log_msg = f"RESOURCE UPDATE - \
+ResourceType: Project / ResourceName: {project.name} / \
+Organization: {project.organization} / Action: Update"
         logger.info(log_msg)
         return Response(serializers.ProjectSerializer(project).data)
 
@@ -248,7 +260,9 @@ class ProjectViewSet(
         project.import_error = None
         project.save()
 
-        log_msg = f"RESOURCE UPDATE - ResourceType: Project / ResourceName: {project.name} / Organization: {project.organization} / Action: Sync"
+        log_msg = f"RESOURCE UPDATE - \
+ResourceType: Project / ResourceName: {project.name} / \
+Organization: {project.organization} / Action: Sync"
         logger.info(log_msg)
 
         serializer = serializers.ProjectSerializer(project)

--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -44,11 +44,10 @@ class DestroyProjectMixin(mixins.DestroyModelMixin):
         super().destroy(request, *args, **kwargs)
 
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: Delete / "
             "ResourceType: Project / "
             f"ResourceName: {project.name} / "
-            f"Organization: {project.organization} / "
-            "Action: Delete"
+            f"Organization: {project.organization}"
         )
         logger.info(log_msg)
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -132,11 +131,10 @@ class ProjectViewSet(
         headers = self.get_success_headers(serializer.data)
 
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: Create / "
             "ResourceType: Project / "
             f"ResourceName: {project.name} / "
-            f"Organization: {project.organization} / "
-            "Action: Create"
+            f"Organization: {project.organization}"
         )
         logger.info(log_msg)
 
@@ -176,11 +174,10 @@ class ProjectViewSet(
         )
 
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: Read / "
             "ResourceType: Project / "
             f"ResourceName: {project.data['name']} / "
-            f"Organization: {project.data['organization'].name} / "
-            "Action: Read"
+            f"Organization: {project.data['organization'].name}"
         )
         logger.info(log_msg)
 
@@ -226,11 +223,10 @@ class ProjectViewSet(
                 model_to_dict(project),
             )
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: Update / "
             "ResourceType: Project / "
             f"ResourceName: {project.name} / "
-            f"Organization: {project.organization} / "
-            "Action: Update"
+            f"Organization: {project.organization}"
         )
         logger.info(log_msg)
         return Response(serializers.ProjectSerializer(project).data)
@@ -276,11 +272,10 @@ class ProjectViewSet(
         project.save()
 
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: Sync / "
             "ResourceType: Project / "
             f"ResourceName: {project.name} / "
-            f"Organization: {project.organization} / "
-            "Action: Sync"
+            f"Organization: {project.organization}"
         )
         logger.info(log_msg)
 

--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -51,6 +51,7 @@ class DestroyProjectMixin(mixins.DestroyModelMixin):
                 "Delete",
                 resource_name,
                 project.name,
+                project.id,
                 project.organization,
             )
         )
@@ -140,6 +141,7 @@ class ProjectViewSet(
                 "Create",
                 resource_name,
                 project.name,
+                project.id,
                 project.organization,
             )
         )
@@ -184,6 +186,7 @@ class ProjectViewSet(
                 "Read",
                 resource_name,
                 project.data["name"],
+                project.data["id"],
                 project.data["organization"].name,
             )
         )
@@ -235,6 +238,7 @@ class ProjectViewSet(
                 "Update",
                 resource_name,
                 project.name,
+                project.id,
                 project.organization,
             )
         )
@@ -286,6 +290,7 @@ class ProjectViewSet(
                 "Sync",
                 resource_name,
                 project.name,
+                project.id,
                 project.organization,
             )
         )

--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -181,15 +181,15 @@ class ProjectViewSet(
             else None
         )
 
-        logger.info(
-            logging_utils.generate_simple_audit_log(
-                "Read",
-                resource_name,
-                project.data["name"],
-                project.data["organization"].name,
-                **{},
-            )
-        )
+        # logger.info(
+        #     logging_utils.generate_simple_audit_log(
+        #         "Read",
+        #         resource_name,
+        #         project.data["name"],
+        #         project.data["organization"].name,
+        #         **{},
+        #     )
+        # )
 
         return Response(serializers.ProjectReadSerializer(project.data).data)
 

--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -43,9 +43,13 @@ class DestroyProjectMixin(mixins.DestroyModelMixin):
 
         super().destroy(request, *args, **kwargs)
 
-        log_msg = f"RESOURCE UPDATE - \
-ResourceType: Project / ResourceName: {project.name} / \
-Organization: {project.organization} / Action: Delete"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            "ResourceType: Project / "
+            f"ResourceName: {project.name} / "
+            f"Organization: {project.organization} / "
+            "Action: Delete"
+        )
         logger.info(log_msg)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -127,9 +131,13 @@ class ProjectViewSet(
         serializer = self.get_serializer(project)
         headers = self.get_success_headers(serializer.data)
 
-        log_msg = f"RESOURCE UPDATE - \
-ResourceType: Project / ResourceName: {project.name} / \
-Organization: {project.organization} / Action: Create"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            "ResourceType: Project / "
+            f"ResourceName: {project.name} / "
+            f"Organization: {project.organization} / "
+            "Action: Create"
+        )
         logger.info(log_msg)
 
         return Response(
@@ -167,10 +175,13 @@ Organization: {project.organization} / Action: Create"
             else None
         )
 
-        log_msg = f"RESOURCE UPDATE - \
-ResourceType: Project / ResourceName: {project.data['name']} / \
-Organization: {project.data['organization'].name} / \
-Action: Read"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            "ResourceType: Project / "
+            f"ResourceName: {project.data['name']} / "
+            f"Organization: {project.data['organization'].name} / "
+            "Action: Read"
+        )
         logger.info(log_msg)
 
         return Response(serializers.ProjectReadSerializer(project.data).data)
@@ -214,9 +225,13 @@ Action: Read"
                 old_data,
                 model_to_dict(project),
             )
-        log_msg = f"RESOURCE UPDATE - \
-ResourceType: Project / ResourceName: {project.name} / \
-Organization: {project.organization} / Action: Update"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            "ResourceType: Project / "
+            f"ResourceName: {project.name} / "
+            f"Organization: {project.organization} / "
+            "Action: Update"
+        )
         logger.info(log_msg)
         return Response(serializers.ProjectSerializer(project).data)
 
@@ -260,9 +275,13 @@ Organization: {project.organization} / Action: Update"
         project.import_error = None
         project.save()
 
-        log_msg = f"RESOURCE UPDATE - \
-ResourceType: Project / ResourceName: {project.name} / \
-Organization: {project.organization} / Action: Sync"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            "ResourceType: Project / "
+            f"ResourceName: {project.name} / "
+            f"Organization: {project.organization} / "
+            "Action: Sync"
+        )
         logger.info(log_msg)
 
         serializer = serializers.ProjectSerializer(project)

--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -44,7 +44,7 @@ class DestroyProjectMixin(mixins.DestroyModelMixin):
     def destroy(self, request, *args, **kwargs):
         project = self.get_object()
 
-        super().destroy(request, *args, **kwargs)
+        response = super().destroy(request, *args, **kwargs)
 
         logger.info(
             logging_utils.generate_simple_audit_log(
@@ -56,7 +56,7 @@ class DestroyProjectMixin(mixins.DestroyModelMixin):
             )
         )
 
-        return Response(status=status.HTTP_204_NO_CONTENT)
+        return response
 
 
 @extend_schema_view(

--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -179,14 +179,14 @@ class ProjectViewSet(
             else None
         )
 
-        # logger.info(
-        #     logging_utils.generate_simple_audit_log(
-        #         "Read",
-        #         resource_name,
-        #         project.data["name"],
-        #         project.data["organization"].name,
-        #     )
-        # )
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Read",
+                resource_name,
+                project.data["name"],
+                project.data["organization"].name,
+            )
+        )
 
         return Response(serializers.ProjectReadSerializer(project.data).data)
 

--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -52,7 +52,6 @@ class DestroyProjectMixin(mixins.DestroyModelMixin):
                 resource_name,
                 project.name,
                 project.organization,
-                **{},
             )
         )
 
@@ -142,7 +141,6 @@ class ProjectViewSet(
                 resource_name,
                 project.name,
                 project.organization,
-                **{},
             )
         )
 
@@ -187,7 +185,6 @@ class ProjectViewSet(
         #         resource_name,
         #         project.data["name"],
         #         project.data["organization"].name,
-        #         **{},
         #     )
         # )
 
@@ -239,7 +236,6 @@ class ProjectViewSet(
                 resource_name,
                 project.name,
                 project.organization,
-                **{},
             )
         )
 
@@ -287,7 +283,10 @@ class ProjectViewSet(
 
         logger.info(
             logging_utils.generate_simple_audit_log(
-                "Sync", resource_name, project.name, project.organization, **{}
+                "Sync",
+                resource_name,
+                project.name,
+                project.organization,
             )
         )
 

--- a/src/aap_eda/api/views/webhook.py
+++ b/src/aap_eda/api/views/webhook.py
@@ -85,16 +85,12 @@ class WebhookViewSet(
     def retrieve(self, request, *args, **kwargs):
         webhook = self.get_object()
 
-        logging_kwargs = {
-            "TestMode": webhook.test_mode,
-        }
         # logger.info(
         #     logging_utils.generate_simple_audit_log(
         #         "Read",
         #         resource_name,
         #         webhook.name,
         #         webhook.organization,
-        #         **logging_kwargs,
         #     )
         # )
 
@@ -118,16 +114,12 @@ class WebhookViewSet(
             )
         self.perform_destroy(webhook)
 
-        logging_kwargs = {
-            "TestMode": webhook.test_mode,
-        }
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Delete",
                 resource_name,
                 webhook.name,
                 webhook.organization,
-                **logging_kwargs,
             )
         )
 
@@ -150,7 +142,10 @@ class WebhookViewSet(
 
         logger.info(
             logging_utils.generate_simple_audit_log(
-                "List", "EventStream", "*", "*", **{}
+                "List",
+                "EventStream",
+                "*",
+                "*",
             )
         )
         return self.get_paginated_response(result)
@@ -197,16 +192,12 @@ class WebhookViewSet(
                 response.url = urljoin(settings.WEBHOOK_BASE_URL, sub_path)
             response.save(update_fields=["url"])
 
-        logging_kwargs = {
-            "TestMode": response.test_mode,
-        }
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Create",
                 resource_name,
                 response.name,
                 response.organization,
-                **logging_kwargs,
             )
         )
 
@@ -258,16 +249,12 @@ class WebhookViewSet(
                 model_to_dict(webhook),
             )
 
-        logging_kwargs = {
-            "TestMode": webhook.test_mode,
-        }
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Update",
                 resource_name,
                 webhook.name,
                 webhook.organization,
-                **logging_kwargs,
             )
         )
 
@@ -313,16 +300,12 @@ class WebhookViewSet(
         result = self.paginate_queryset(filtered_activations)
         serializer = serializers.ActivationListSerializer(result, many=True)
 
-        logging_kwargs = {
-            "TestMode": webhook.test_mode,
-        }
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "ListActivations",
                 resource_name,
                 webhook.name,
                 webhook.organization,
-                **logging_kwargs,
             )
         )
         return self.get_paginated_response(serializer.data)

--- a/src/aap_eda/api/views/webhook.py
+++ b/src/aap_eda/api/views/webhook.py
@@ -82,12 +82,11 @@ class WebhookViewSet(
     def retrieve(self, request, *args, **kwargs):
         webhook = self.get_object()
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: Read / "
             "ResourceType: EventStream / "
             f"ResourceName: {webhook.name} / "
             f"Organization: {webhook.organization} / "
-            f"TestMode: {webhook.test_mode} / "
-            "Action: Read"
+            f"TestMode: {webhook.test_mode}"
         )
         logger.info(log_msg)
         return Response(serializers.WebhookOutSerializer(webhook).data)
@@ -110,12 +109,11 @@ class WebhookViewSet(
             )
         self.perform_destroy(webhook)
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: Delete / "
             "ResourceType: EventStream / "
             f"ResourceName: {webhook.name} / "
             f"Organization: {webhook.organization} / "
-            f"TestMode: {webhook.test_mode} / "
-            "Action: Delete"
+            f"TestMode: {webhook.test_mode}"
         )
         logger.info(log_msg)
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -135,11 +133,10 @@ class WebhookViewSet(
         serializer = serializers.WebhookOutSerializer(webhooks, many=True)
         result = self.paginate_queryset(serializer.data)
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: List / "
             "ResourceType: EventStream / "
-            "ResourceName: * / "
-            "Organization: * / "
-            "Action: List"
+            "ResourceName: '*' / "
+            "Organization: '*'"
         )
         logger.info(log_msg)
         return self.get_paginated_response(result)
@@ -186,12 +183,11 @@ class WebhookViewSet(
                 response.url = urljoin(settings.WEBHOOK_BASE_URL, sub_path)
             response.save(update_fields=["url"])
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: Create / "
             "ResourceType: EventStream / "
             f"ResourceName: {response.name} / "
             f"Organization: {response.organization} / "
-            f"TestMode: {response.test_mode}  / "
-            "Action: Create"
+            f"TestMode: {response.test_mode}"
         )
         logger.info(log_msg)
         return Response(
@@ -242,12 +238,11 @@ class WebhookViewSet(
                 model_to_dict(webhook),
             )
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: Update / "
             "ResourceType: EventStream / "
             f"ResourceName: {webhook.name} / "
             f"Organization: {webhook.organization} / "
-            f"TestMode: {webhook.test_mode} / "
-            "Action: Update"
+            f"TestMode: {webhook.test_mode}"
         )
         logger.info(log_msg)
         return Response(
@@ -292,12 +287,11 @@ class WebhookViewSet(
         result = self.paginate_queryset(filtered_activations)
         serializer = serializers.ActivationListSerializer(result, many=True)
         log_msg = (
-            "RESOURCE UPDATE - "
+            "Action: ListActivations / "
             f"ResourceType: EventStream / "
             f"ResourceName: {webhook.name} / "
             f"Organization: {webhook.organization} / "
-            f"TestMode: {webhook.test_mode} / "
-            "Action: ListActivations"
+            f"TestMode: {webhook.test_mode}"
         )
         logger.info(log_msg)
         return self.get_paginated_response(serializer.data)

--- a/src/aap_eda/api/views/webhook.py
+++ b/src/aap_eda/api/views/webhook.py
@@ -90,6 +90,7 @@ class WebhookViewSet(
                 "Read",
                 resource_name,
                 webhook.name,
+                webhook.id,
                 webhook.organization,
             )
         )
@@ -119,6 +120,7 @@ class WebhookViewSet(
                 "Delete",
                 resource_name,
                 webhook.name,
+                webhook.id,
                 webhook.organization,
             )
         )
@@ -144,6 +146,7 @@ class WebhookViewSet(
             logging_utils.generate_simple_audit_log(
                 "List",
                 "EventStream",
+                "*",
                 "*",
                 "*",
             )
@@ -197,6 +200,7 @@ class WebhookViewSet(
                 "Create",
                 resource_name,
                 response.name,
+                response.id,
                 response.organization,
             )
         )
@@ -254,6 +258,7 @@ class WebhookViewSet(
                 "Update",
                 resource_name,
                 webhook.name,
+                webhook.id,
                 webhook.organization,
             )
         )
@@ -305,6 +310,7 @@ class WebhookViewSet(
                 "ListActivations",
                 resource_name,
                 webhook.name,
+                webhook.id,
                 webhook.organization,
             )
         )

--- a/src/aap_eda/api/views/webhook.py
+++ b/src/aap_eda/api/views/webhook.py
@@ -88,15 +88,15 @@ class WebhookViewSet(
         logging_kwargs = {
             "TestMode": webhook.test_mode,
         }
-        logger.info(
-            logging_utils.generate_simple_audit_log(
-                "Read",
-                resource_name,
-                webhook.name,
-                webhook.organization,
-                **logging_kwargs,
-            )
-        )
+        # logger.info(
+        #     logging_utils.generate_simple_audit_log(
+        #         "Read",
+        #         resource_name,
+        #         webhook.name,
+        #         webhook.organization,
+        #         **logging_kwargs,
+        #     )
+        # )
 
         return Response(serializers.WebhookOutSerializer(webhook).data)
 

--- a/src/aap_eda/api/views/webhook.py
+++ b/src/aap_eda/api/views/webhook.py
@@ -85,14 +85,14 @@ class WebhookViewSet(
     def retrieve(self, request, *args, **kwargs):
         webhook = self.get_object()
 
-        # logger.info(
-        #     logging_utils.generate_simple_audit_log(
-        #         "Read",
-        #         resource_name,
-        #         webhook.name,
-        #         webhook.organization,
-        #     )
-        # )
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Read",
+                resource_name,
+                webhook.name,
+                webhook.organization,
+            )
+        )
 
         return Response(serializers.WebhookOutSerializer(webhook).data)
 

--- a/src/aap_eda/api/views/webhook.py
+++ b/src/aap_eda/api/views/webhook.py
@@ -81,10 +81,14 @@ class WebhookViewSet(
     )
     def retrieve(self, request, *args, **kwargs):
         webhook = self.get_object()
-        log_msg = f"RESOURCE UPDATE - \
-ResourceType: EventStream / ResourceName: {webhook.name} / \
-Organization: {webhook.organization} / TestMode: {webhook.test_mode} / \
-Action: Read"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            "ResourceType: EventStream / "
+            f"ResourceName: {webhook.name} / "
+            f"Organization: {webhook.organization} / "
+            f"TestMode: {webhook.test_mode} / "
+            "Action: Read"
+        )
         logger.info(log_msg)
         return Response(serializers.WebhookOutSerializer(webhook).data)
 
@@ -105,10 +109,14 @@ Action: Read"
                 f"{ref_count} activation(s) and cannot be deleted"
             )
         self.perform_destroy(webhook)
-        log_msg = f"RESOURCE UPDATE - \
-ResourceType: EventStream / ResourceName: {webhook.name} / \
-Organization: {webhook.organization} / TestMode: {webhook.test_mode} / \
-Action: Delete"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            "ResourceType: EventStream / "
+            f"ResourceName: {webhook.name} / "
+            f"Organization: {webhook.organization} / "
+            f"TestMode: {webhook.test_mode} / "
+            "Action: Delete"
+        )
         logger.info(log_msg)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -126,9 +134,13 @@ Action: Delete"
         webhooks = self.filter_queryset(webhooks)
         serializer = serializers.WebhookOutSerializer(webhooks, many=True)
         result = self.paginate_queryset(serializer.data)
-        log_msg = "RESOURCE UPDATE - \
-ResourceType: EventStream / ResourceName: * / Organization: * / \
-Action: List"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            "ResourceType: EventStream / "
+            "ResourceName: * / "
+            "Organization: * / "
+            "Action: List"
+        )
         logger.info(log_msg)
         return self.get_paginated_response(result)
 
@@ -173,10 +185,14 @@ Action: List"
             else:
                 response.url = urljoin(settings.WEBHOOK_BASE_URL, sub_path)
             response.save(update_fields=["url"])
-        log_msg = f"RESOURCE UPDATE - \
-ResourceType: EventStream / ResourceName: {response.name} / \
-Organization: {response.organization} / TestMode: {response.test_mode}  / \
-Action: Create"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            "ResourceType: EventStream / "
+            f"ResourceName: {response.name} / "
+            f"Organization: {response.organization} / "
+            f"TestMode: {response.test_mode}  / "
+            "Action: Create"
+        )
         logger.info(log_msg)
         return Response(
             serializers.WebhookOutSerializer(response).data,
@@ -225,10 +241,14 @@ Action: Create"
                 old_data,
                 model_to_dict(webhook),
             )
-        log_msg = f"RESOURCE UPDATE - \
-ResourceType: EventStream / ResourceName: {webhook.name} / \
-Organization: {webhook.organization} / TestMode: {webhook.test_mode} / \
-Action: Update"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            "ResourceType: EventStream / "
+            f"ResourceName: {webhook.name} / "
+            f"Organization: {webhook.organization} / "
+            f"TestMode: {webhook.test_mode} / "
+            "Action: Update"
+        )
         logger.info(log_msg)
         return Response(
             serializers.WebhookOutSerializer(webhook).data,
@@ -271,9 +291,13 @@ Action: Update"
         filtered_activations = self.filter_queryset(activations)
         result = self.paginate_queryset(filtered_activations)
         serializer = serializers.ActivationListSerializer(result, many=True)
-        log_msg = f"RESOURCE UPDATE - \
-ResourceType: EventStream / ResourceName: {webhook.name} / \
-Organization: {webhook.organization} / \
-TestMode: {webhook.test_mode} / Action: ListActivations"
+        log_msg = (
+            "RESOURCE UPDATE - "
+            f"ResourceType: EventStream / "
+            f"ResourceName: {webhook.name} / "
+            f"Organization: {webhook.organization} / "
+            f"TestMode: {webhook.test_mode} / "
+            "Action: ListActivations"
+        )
         logger.info(log_msg)
         return self.get_paginated_response(serializer.data)

--- a/src/aap_eda/api/views/webhook.py
+++ b/src/aap_eda/api/views/webhook.py
@@ -40,6 +40,8 @@ logger = logging.getLogger(__name__)
 
 WEBHOOK_EXTERNAL_PATH = "api/eda/v1/external_webhook"
 
+resource_name = "EventStream"
+
 
 class WebhookViewSet(
     mixins.CreateModelMixin,
@@ -83,16 +85,16 @@ class WebhookViewSet(
     def retrieve(self, request, *args, **kwargs):
         webhook = self.get_object()
 
-        kwargs = {
+        logging_kwargs = {
             "TestMode": webhook.test_mode,
         }
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Read",
-                "EventStream",
+                resource_name,
                 webhook.name,
                 webhook.organization,
-                **kwargs,
+                **logging_kwargs,
             )
         )
 
@@ -116,16 +118,16 @@ class WebhookViewSet(
             )
         self.perform_destroy(webhook)
 
-        kwargs = {
+        logging_kwargs = {
             "TestMode": webhook.test_mode,
         }
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Delete",
-                "EventStream",
+                resource_name,
                 webhook.name,
                 webhook.organization,
-                **kwargs,
+                **logging_kwargs,
             )
         )
 
@@ -194,14 +196,20 @@ class WebhookViewSet(
             else:
                 response.url = urljoin(settings.WEBHOOK_BASE_URL, sub_path)
             response.save(update_fields=["url"])
-        log_msg = (
-            "Action: Create / "
-            "ResourceType: EventStream / "
-            f"ResourceName: {response.name} / "
-            f"Organization: {response.organization} / "
-            f"TestMode: {response.test_mode}"
+
+        logging_kwargs = {
+            "TestMode": response.test_mode,
+        }
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Create",
+                resource_name,
+                response.name,
+                response.organization,
+                **logging_kwargs,
+            )
         )
-        logger.info(log_msg)
+
         return Response(
             serializers.WebhookOutSerializer(response).data,
             status=status.HTTP_201_CREATED,
@@ -250,16 +258,16 @@ class WebhookViewSet(
                 model_to_dict(webhook),
             )
 
-        kwargs = {
+        logging_kwargs = {
             "TestMode": webhook.test_mode,
         }
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Update",
-                "EventStream",
+                resource_name,
                 webhook.name,
                 webhook.organization,
-                **kwargs,
+                **logging_kwargs,
             )
         )
 
@@ -305,16 +313,16 @@ class WebhookViewSet(
         result = self.paginate_queryset(filtered_activations)
         serializer = serializers.ActivationListSerializer(result, many=True)
 
-        kwargs = {
+        logging_kwargs = {
             "TestMode": webhook.test_mode,
         }
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "ListActivations",
-                "EventStream",
+                resource_name,
                 webhook.name,
                 webhook.organization,
-                **kwargs,
+                **logging_kwargs,
             )
         )
         return self.get_paginated_response(serializer.data)

--- a/src/aap_eda/api/views/webhook.py
+++ b/src/aap_eda/api/views/webhook.py
@@ -81,6 +81,8 @@ class WebhookViewSet(
     )
     def retrieve(self, request, *args, **kwargs):
         webhook = self.get_object()
+        log_msg = f"RESOURCE UPDATE - ResourceType: EventStream / ResourceName: {webhook.name} / Organization: {webhook.organization} / TestMode: {webhook.test_mode} / Action: Read"
+        logger.info(log_msg)
         return Response(serializers.WebhookOutSerializer(webhook).data)
 
     @extend_schema(
@@ -93,7 +95,6 @@ class WebhookViewSet(
     )
     def destroy(self, request, *args, **kwargs):
         webhook = self.get_object()
-
         ref_count = webhook.activations.count()
         if ref_count > 0:
             raise api_exc.Conflict(
@@ -101,6 +102,8 @@ class WebhookViewSet(
                 f"{ref_count} activation(s) and cannot be deleted"
             )
         self.perform_destroy(webhook)
+        log_msg = f"RESOURCE UPDATE - ResourceType: EventStream / ResourceName: {webhook.name} / Organization: {webhook.organization} / TestMode: {webhook.test_mode} / Action: Delete"
+        logger.info(log_msg)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @extend_schema(
@@ -117,7 +120,8 @@ class WebhookViewSet(
         webhooks = self.filter_queryset(webhooks)
         serializer = serializers.WebhookOutSerializer(webhooks, many=True)
         result = self.paginate_queryset(serializer.data)
-
+        log_msg = f"RESOURCE UPDATE - ResourceType: EventStream / ResourceName: * / Organization: * / Action: List"
+        logger.info(log_msg)
         return self.get_paginated_response(result)
 
     @extend_schema(
@@ -161,7 +165,8 @@ class WebhookViewSet(
             else:
                 response.url = urljoin(settings.WEBHOOK_BASE_URL, sub_path)
             response.save(update_fields=["url"])
-
+        log_msg = f"RESOURCE UPDATE - ResourceType: EventStream / ResourceName: {response.name} / Organization: {response.organization} / TestMode: {response.test_mode}  / Action: Create"
+        logger.info(log_msg)
         return Response(
             serializers.WebhookOutSerializer(response).data,
             status=status.HTTP_201_CREATED,
@@ -209,7 +214,8 @@ class WebhookViewSet(
                 old_data,
                 model_to_dict(webhook),
             )
-
+        log_msg = f"RESOURCE UPDATE - ResourceType: EventStream / ResourceName: {webhook.name} / Organization: {webhook.organization} / TestMode: {webhook.test_mode} / Action: Update"
+        logger.info(log_msg)
         return Response(
             serializers.WebhookOutSerializer(webhook).data,
             status=status.HTTP_200_OK,
@@ -251,4 +257,6 @@ class WebhookViewSet(
         filtered_activations = self.filter_queryset(activations)
         result = self.paginate_queryset(filtered_activations)
         serializer = serializers.ActivationListSerializer(result, many=True)
+        log_msg = f"RESOURCE UPDATE - ResourceType: EventStream / ResourceName: {webhook.name} / Organization: {webhook.organization} / TestMode: {webhook.test_mode} / Action: ListActivations"
+        logger.info(log_msg)
         return self.get_paginated_response(serializer.data)

--- a/src/aap_eda/api/views/webhook.py
+++ b/src/aap_eda/api/views/webhook.py
@@ -81,7 +81,10 @@ class WebhookViewSet(
     )
     def retrieve(self, request, *args, **kwargs):
         webhook = self.get_object()
-        log_msg = f"RESOURCE UPDATE - ResourceType: EventStream / ResourceName: {webhook.name} / Organization: {webhook.organization} / TestMode: {webhook.test_mode} / Action: Read"
+        log_msg = f"RESOURCE UPDATE - \
+ResourceType: EventStream / ResourceName: {webhook.name} / \
+Organization: {webhook.organization} / TestMode: {webhook.test_mode} / \
+Action: Read"
         logger.info(log_msg)
         return Response(serializers.WebhookOutSerializer(webhook).data)
 
@@ -102,7 +105,10 @@ class WebhookViewSet(
                 f"{ref_count} activation(s) and cannot be deleted"
             )
         self.perform_destroy(webhook)
-        log_msg = f"RESOURCE UPDATE - ResourceType: EventStream / ResourceName: {webhook.name} / Organization: {webhook.organization} / TestMode: {webhook.test_mode} / Action: Delete"
+        log_msg = f"RESOURCE UPDATE - \
+ResourceType: EventStream / ResourceName: {webhook.name} / \
+Organization: {webhook.organization} / TestMode: {webhook.test_mode} / \
+Action: Delete"
         logger.info(log_msg)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -120,7 +126,9 @@ class WebhookViewSet(
         webhooks = self.filter_queryset(webhooks)
         serializer = serializers.WebhookOutSerializer(webhooks, many=True)
         result = self.paginate_queryset(serializer.data)
-        log_msg = f"RESOURCE UPDATE - ResourceType: EventStream / ResourceName: * / Organization: * / Action: List"
+        log_msg = "RESOURCE UPDATE - \
+ResourceType: EventStream / ResourceName: * / Organization: * / \
+Action: List"
         logger.info(log_msg)
         return self.get_paginated_response(result)
 
@@ -165,7 +173,10 @@ class WebhookViewSet(
             else:
                 response.url = urljoin(settings.WEBHOOK_BASE_URL, sub_path)
             response.save(update_fields=["url"])
-        log_msg = f"RESOURCE UPDATE - ResourceType: EventStream / ResourceName: {response.name} / Organization: {response.organization} / TestMode: {response.test_mode}  / Action: Create"
+        log_msg = f"RESOURCE UPDATE - \
+ResourceType: EventStream / ResourceName: {response.name} / \
+Organization: {response.organization} / TestMode: {response.test_mode}  / \
+Action: Create"
         logger.info(log_msg)
         return Response(
             serializers.WebhookOutSerializer(response).data,
@@ -214,7 +225,10 @@ class WebhookViewSet(
                 old_data,
                 model_to_dict(webhook),
             )
-        log_msg = f"RESOURCE UPDATE - ResourceType: EventStream / ResourceName: {webhook.name} / Organization: {webhook.organization} / TestMode: {webhook.test_mode} / Action: Update"
+        log_msg = f"RESOURCE UPDATE - \
+ResourceType: EventStream / ResourceName: {webhook.name} / \
+Organization: {webhook.organization} / TestMode: {webhook.test_mode} / \
+Action: Update"
         logger.info(log_msg)
         return Response(
             serializers.WebhookOutSerializer(webhook).data,
@@ -257,6 +271,9 @@ class WebhookViewSet(
         filtered_activations = self.filter_queryset(activations)
         result = self.paginate_queryset(filtered_activations)
         serializer = serializers.ActivationListSerializer(result, many=True)
-        log_msg = f"RESOURCE UPDATE - ResourceType: EventStream / ResourceName: {webhook.name} / Organization: {webhook.organization} / TestMode: {webhook.test_mode} / Action: ListActivations"
+        log_msg = f"RESOURCE UPDATE - \
+ResourceType: EventStream / ResourceName: {webhook.name} / \
+Organization: {webhook.organization} / \
+TestMode: {webhook.test_mode} / Action: ListActivations"
         logger.info(log_msg)
         return self.get_paginated_response(serializer.data)

--- a/src/aap_eda/api/views/webhook.py
+++ b/src/aap_eda/api/views/webhook.py
@@ -34,6 +34,7 @@ from rest_framework.response import Response
 from aap_eda.api import exceptions as api_exc, filters, serializers
 from aap_eda.core import models
 from aap_eda.core.enums import ResourceType, WebhookAuthType
+from aap_eda.core.utils import logging_utils
 
 logger = logging.getLogger(__name__)
 
@@ -81,14 +82,20 @@ class WebhookViewSet(
     )
     def retrieve(self, request, *args, **kwargs):
         webhook = self.get_object()
-        log_msg = (
-            "Action: Read / "
-            "ResourceType: EventStream / "
-            f"ResourceName: {webhook.name} / "
-            f"Organization: {webhook.organization} / "
-            f"TestMode: {webhook.test_mode}"
+
+        kwargs = {
+            "TestMode": webhook.test_mode,
+        }
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Read",
+                "EventStream",
+                webhook.name,
+                webhook.organization,
+                **kwargs,
+            )
         )
-        logger.info(log_msg)
+
         return Response(serializers.WebhookOutSerializer(webhook).data)
 
     @extend_schema(
@@ -108,14 +115,20 @@ class WebhookViewSet(
                 f"{ref_count} activation(s) and cannot be deleted"
             )
         self.perform_destroy(webhook)
-        log_msg = (
-            "Action: Delete / "
-            "ResourceType: EventStream / "
-            f"ResourceName: {webhook.name} / "
-            f"Organization: {webhook.organization} / "
-            f"TestMode: {webhook.test_mode}"
+
+        kwargs = {
+            "TestMode": webhook.test_mode,
+        }
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Delete",
+                "EventStream",
+                webhook.name,
+                webhook.organization,
+                **kwargs,
+            )
         )
-        logger.info(log_msg)
+
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @extend_schema(
@@ -132,13 +145,12 @@ class WebhookViewSet(
         webhooks = self.filter_queryset(webhooks)
         serializer = serializers.WebhookOutSerializer(webhooks, many=True)
         result = self.paginate_queryset(serializer.data)
-        log_msg = (
-            "Action: List / "
-            "ResourceType: EventStream / "
-            "ResourceName: '*' / "
-            "Organization: '*'"
+
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "List", "EventStream", "*", "*", **{}
+            )
         )
-        logger.info(log_msg)
         return self.get_paginated_response(result)
 
     @extend_schema(
@@ -237,14 +249,20 @@ class WebhookViewSet(
                 old_data,
                 model_to_dict(webhook),
             )
-        log_msg = (
-            "Action: Update / "
-            "ResourceType: EventStream / "
-            f"ResourceName: {webhook.name} / "
-            f"Organization: {webhook.organization} / "
-            f"TestMode: {webhook.test_mode}"
+
+        kwargs = {
+            "TestMode": webhook.test_mode,
+        }
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "Update",
+                "EventStream",
+                webhook.name,
+                webhook.organization,
+                **kwargs,
+            )
         )
-        logger.info(log_msg)
+
         return Response(
             serializers.WebhookOutSerializer(webhook).data,
             status=status.HTTP_200_OK,
@@ -286,12 +304,17 @@ class WebhookViewSet(
         filtered_activations = self.filter_queryset(activations)
         result = self.paginate_queryset(filtered_activations)
         serializer = serializers.ActivationListSerializer(result, many=True)
-        log_msg = (
-            "Action: ListActivations / "
-            f"ResourceType: EventStream / "
-            f"ResourceName: {webhook.name} / "
-            f"Organization: {webhook.organization} / "
-            f"TestMode: {webhook.test_mode}"
+
+        kwargs = {
+            "TestMode": webhook.test_mode,
+        }
+        logger.info(
+            logging_utils.generate_simple_audit_log(
+                "ListActivations",
+                "EventStream",
+                webhook.name,
+                webhook.organization,
+                **kwargs,
+            )
         )
-        logger.info(log_msg)
         return self.get_paginated_response(serializer.data)

--- a/src/aap_eda/core/utils/logging_utils.py
+++ b/src/aap_eda/core/utils/logging_utils.py
@@ -1,0 +1,49 @@
+from aap_eda.core import models
+
+def get_credential_name_from_data(data):
+    credential_name = ""
+    if data.data["eda_credential_id"]:
+        credential_name = (
+            models.EdaCredential.objects.get(
+                pk=data.data["eda_credential_id"]
+            ).name
+            if data.data["eda_credential_id"]
+            else None
+        )
+    return credential_name
+
+def get_organization_name_from_data(data):
+    org_name = ""
+    if data.data["organization_id"]:
+        org_name = (
+            models.Organization.objects.get(
+                pk=data.data["organization_id"]
+            ).name
+            if data.data["organization_id"]
+            else None
+        )
+    return org_name
+
+def get_project_name_from_id(id):
+    project = (
+        models.Project.objects.get(
+            pk=id
+        ).name
+    )
+    return project
+
+def get_rulebook_name_from_id(id):
+    rulebook = (
+        models.Rulebook.objects.get(
+            pk=id
+        ).name
+    )
+    return rulebook
+
+def get_decisionenvironment_name_from_id(id):
+    rulebook = (
+        models.DecisionEnvironment.objects.get(
+            pk=id
+        ).name
+    )
+    return rulebook

--- a/src/aap_eda/core/utils/logging_utils.py
+++ b/src/aap_eda/core/utils/logging_utils.py
@@ -1,6 +1,22 @@
 from aap_eda.core import models
 
 
+def generate_simple_audit_log(
+    action, resource_type, resource_name, organization, **kwargs
+):
+    extra_data = ""
+    for key, value in kwargs.items():
+        extra_data += "%s: %s / " % (key, value)
+    log_msg = (
+        f"Action: {action} / "
+        f"ResourceType: {resource_type} / "
+        f"ResourceName: {resource_name} / "
+        f"Organization: {organization} / "
+        f"{extra_data}"
+    )
+    return log_msg[:-3]
+
+
 def get_credential_name_from_data(data):
     credential_name = ""
     if data.data["eda_credential_id"]:

--- a/src/aap_eda/core/utils/logging_utils.py
+++ b/src/aap_eda/core/utils/logging_utils.py
@@ -2,12 +2,13 @@ from aap_eda.core import models
 
 
 def generate_simple_audit_log(
-    action, resource_type, resource_name, organization
+    action, resource_type, resource_name, resource_id, organization
 ):
     log_msg = (
         f"Action: {action} / "
         f"ResourceType: {resource_type} / "
         f"ResourceName: {resource_name} / "
+        f"ResourceID: {resource_id} / "
         f"Organization: {organization}"
     )
     return log_msg

--- a/src/aap_eda/core/utils/logging_utils.py
+++ b/src/aap_eda/core/utils/logging_utils.py
@@ -2,32 +2,15 @@ from aap_eda.core import models
 
 
 def generate_simple_audit_log(
-    action, resource_type, resource_name, organization, **kwargs
+    action, resource_type, resource_name, organization
 ):
-    extra_data = ""
-    for key, value in kwargs.items():
-        extra_data += "%s: %s / " % (key, value)
     log_msg = (
         f"Action: {action} / "
         f"ResourceType: {resource_type} / "
         f"ResourceName: {resource_name} / "
-        f"Organization: {organization} / "
-        f"{extra_data}"
+        f"Organization: {organization}"
     )
-    return log_msg[:-3]
-
-
-def get_credential_name_from_data(data):
-    credential_name = ""
-    if data.data["eda_credential_id"]:
-        credential_name = (
-            models.EdaCredential.objects.get(
-                pk=data.data["eda_credential_id"]
-            ).name
-            if data.data["eda_credential_id"]
-            else None
-        )
-    return credential_name
+    return log_msg
 
 
 def get_organization_name_from_data(data):
@@ -41,18 +24,3 @@ def get_organization_name_from_data(data):
             else None
         )
     return org_name
-
-
-def get_project_name_from_id(id):
-    project = models.Project.objects.get(pk=id).name
-    return project
-
-
-def get_rulebook_name_from_id(id):
-    rulebook = models.Rulebook.objects.get(pk=id).name
-    return rulebook
-
-
-def get_de_name_from_id(id):
-    rulebook = models.DecisionEnvironment.objects.get(pk=id).name
-    return rulebook

--- a/src/aap_eda/core/utils/logging_utils.py
+++ b/src/aap_eda/core/utils/logging_utils.py
@@ -1,5 +1,6 @@
 from aap_eda.core import models
 
+
 def get_credential_name_from_data(data):
     credential_name = ""
     if data.data["eda_credential_id"]:
@@ -11,6 +12,7 @@ def get_credential_name_from_data(data):
             else None
         )
     return credential_name
+
 
 def get_organization_name_from_data(data):
     org_name = ""
@@ -24,26 +26,17 @@ def get_organization_name_from_data(data):
         )
     return org_name
 
+
 def get_project_name_from_id(id):
-    project = (
-        models.Project.objects.get(
-            pk=id
-        ).name
-    )
+    project = models.Project.objects.get(pk=id).name
     return project
 
+
 def get_rulebook_name_from_id(id):
-    rulebook = (
-        models.Rulebook.objects.get(
-            pk=id
-        ).name
-    )
+    rulebook = models.Rulebook.objects.get(pk=id).name
     return rulebook
 
-def get_decisionenvironment_name_from_id(id):
-    rulebook = (
-        models.DecisionEnvironment.objects.get(
-            pk=id
-        ).name
-    )
+
+def get_de_name_from_id(id):
+    rulebook = models.DecisionEnvironment.objects.get(pk=id).name
     return rulebook


### PR DESCRIPTION
Description: Adds CRUD logging messages to core EDA resources.
Jira: https://issues.redhat.com/browse/AAP-29258

**Rulebook Activations** Logging added for following operations- 

1. Create
2. Read
3. Update
4. Delete
5. ListActivations
6. Enable
7. Disable
8. Restart

**Decision Environments** Logging  added for following operations- 

1. Create
2. Read
3. Update
4. Delete

**Project** Logging added for following operations-

1. Create
2. Read
3. Update
4. Delete
5. Sync

EventStreams Logging added for following operations -
1. Create
2. Read
3. Update
4. Delete
5. List
6. ListActivations

Rulebook Activation Start/Stop/Restart (Already exists)
1. [Activation Start](https://github.com/ansible/eda-server/blob/main/src/aap_eda/services/activation/activation_manager.py#L651)
    1. Has many [log messsages](https://github.com/ansible/eda-server/blob/main/src/aap_eda/services/activation/activation_manager.py#L179) including various statuses an activation may hit
2. [Activation Stop](https://github.com/ansible/eda-server/blob/main/src/aap_eda/services/activation/activation_manager.py#L687)
3. [Activation Restart](https://github.com/ansible/eda-server/blob/main/src/aap_eda/services/activation/activation_manager.py#L738)
4. [Activation Delete](https://github.com/ansible/eda-server/blob/main/src/aap_eda/services/activation/activation_manager.py#L761-L764)