### PR TITLE
fix: (AAP-29630) - save extra_var when creating an activation with vault/AAP credentials

### DIFF
--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -199,7 +199,7 @@ def _update_extra_vars_from_eda_credentials(
         )
         # when creating an activation we need to return the updated extra vars
         if creating:
-            return updated_extra_vars
+            validated_data["extra_var"] = updated_extra_vars
         # if not creating, update the existing activation object extra vars
         else:
             activation.extra_var = updated_extra_vars
@@ -516,9 +516,7 @@ class ActivationCreateSerializer(serializers.ModelSerializer):
         vault = _get_vault_credential_type()
 
         if validated_data.get("eda_credentials"):
-            validated_data[
-                "extra_var"
-            ] = _update_extra_vars_from_eda_credentials(
+            _update_extra_vars_from_eda_credentials(
                 validated_data=validated_data,
                 vault_data=vault_data,
                 creating=True,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -906,6 +906,34 @@ def default_vault_credential(
 
 
 @pytest.fixture
+def default_aap_credential(
+    default_organization: models.Organization,
+    preseed_credential_types,
+) -> models.EdaCredential:
+    """Return a default Vault Credential"""
+    aap_credential_type = models.CredentialType.objects.get(
+        name=enums.DefaultCredentialType.AAP
+    )
+    data = "secret"
+
+    return models.EdaCredential.objects.create(
+        name="default-aap-credential",
+        description="Default RH-AAP Credential",
+        inputs=inputs_to_store(
+            {
+                "host": "https://eda_controller_url",
+                "username": "adam",
+                "password": data,
+                "ssl_verify": "no",
+                "oauth_token": "",
+            }
+        ),
+        credential_type=aap_credential_type,
+        organization=default_organization,
+    )
+
+
+@pytest.fixture
 def default_scm_credential(
     default_organization: models.Organization,
     preseed_credential_types,


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-29630