### PR TITLE
Change fixtures to managed roles to work with expected validators

### DIFF
--- a/tests/integration/api/test_user.py
+++ b/tests/integration/api/test_user.py
@@ -42,7 +42,7 @@ def org_admin_rd():
             "delete_organization",
         ],
         content_type=ContentType.objects.get_for_model(models.Organization),
-        managed=True,  # custom roles can not ordinarily include these permissions
+        managed=True,  # custom roles can not include these permissions
     )
 
 

--- a/tests/integration/api/test_user.py
+++ b/tests/integration/api/test_user.py
@@ -42,6 +42,7 @@ def org_admin_rd():
             "delete_organization",
         ],
         content_type=ContentType.objects.get_for_model(models.Organization),
+        managed=True,  # custom roles can not ordinarily include these permissions
     )
 
 
@@ -54,6 +55,7 @@ def org_member_rd():
             "view_organization",
         ],
         content_type=ContentType.objects.get_for_model(models.Organization),
+        managed=True,
     )
 
 


### PR DESCRIPTION
This is an enabling PR to fix downstream test failures so we can clear the way for https://github.com/ansible/django-ansible-base/pull/562, which changes the default behavior so you can't create custom roles with non-read permissions to shared resources.

The `org_admin_rd` role was returning effectively a custom role, but we really don't want to allow creating this sort of custom roles.