### PR TITLE
fix: perform project create request validation before redis check

### DIFF
--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -112,13 +112,14 @@ class ProjectViewSet(
         | RedisDependencyMixin.redis_unavailable_response(),
     )
     def create(self, request):
-        # We cant do anything without redis.
-        self.redis_is_available()
-
         serializer = serializers.ProjectCreateRequestSerializer(
             data=request.data
         )
         serializer.is_valid(raise_exception=True)
+
+        # We cant do anything without redis.
+        self.redis_is_available()
+
         with transaction.atomic():
             project = serializer.save()
             check_related_permissions(


### PR DESCRIPTION
Aligns "pre-flight" checking across requests that depend on redis.