### PR TITLE
Update communication links

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,8 @@ Refer to the [Contributing guide](docs/contributing.md) for further information.
 
 ## Communication
 
-Join the Ansible forum to ask questions, get help, and interact with the community.
-
-- [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
-  Please add appropriate tags if you start new discussions, for example the
-  `eda-server` or `eda-operator` tags.
-- [Social Spaces](https://forum.ansible.com/c/chat/4): meet and interact with
-  fellow enthusiasts.
-- [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide
-  announcements including social events.
-
-To get release announcements and important changes from the community, see the
-[Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn).
+See the [Communication](https://github.com/ansible/eda-server/blob/main/docs/contributing.md#communication) section of the
+Contributing guide to find out how to get help and contact us.
 
 For more information about getting in touch, see the
 [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).

--- a/README.md
+++ b/README.md
@@ -27,6 +27,24 @@ If you have questions or need assistance, please reach out to our community team
 
 Refer to the [Contributing guide](docs/contributing.md) for further information.
 
+## Communication
+
+Join the Ansible forum to ask questions, get help, and interact with the community.
+
+- [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
+  Please add appropriate tags if you start new discussions, for example the
+  `eda-server` or `eda-operator` tags.
+- [Social Spaces](https://forum.ansible.com/c/chat/4): meet and interact with
+  fellow enthusiasts.
+- [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide
+  announcements including social events.
+
+To get release announcements and important changes from the community, see the
+[Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn).
+
+For more information about getting in touch, see the
+[Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
+
 ## Credits
 
 EDA-Controller is sponsored by [Red Hat, Inc](https://www.redhat.com).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -31,10 +31,20 @@ Before you submit a pull request, check that it meets these guidelines:
 3. The pull request should pass all tests, linters and CI checks. You can run
    each of these locally in your [development environment](docs/development.md)
 
-## Contact
+## Communication
 
-Join the Ansible forum to get in touch and ask questions.
-The [Get Help](https://forum.ansible.com/c/help/6) section is a good place to start.
-You can filter topics tagged as [`eda-server`](https://forum.ansible.com/tag/eda-server).
+Join the Ansible forum to ask questions, get help, and interact with the community.
+
+* [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
+  Please add appropriate tags if you start new discussions, for example the
+  `eda-server` or `eda-operator` tags.
+  For example, you can filter topics tagged as [`eda-server`](https://forum.ansible.com/tag/eda-server)
+* [Social Spaces](https://forum.ansible.com/c/chat/4): meet and interact with
+  fellow enthusiasts.
+* [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide
+  announcements including social events.
+
+To get release announcements and important changes from the community, see the
+[Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn).
 
 You can also get in touch by sending an email to <event-driven-automation@redhat.com>.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -33,5 +33,8 @@ Before you submit a pull request, check that it meets these guidelines:
 
 ## Contact
 
-Also you can check the [Matrix chat](https://matrix.to/#/#eda:ansible.com), or via the
-<event-driven-automation@redhat.com> email.
+Join the Ansible forum to get in touch and ask questions.
+The [Get Help](https://forum.ansible.com/c/help/6) section is a good place to start.
+You can filter topics tagged as [`eda-server`](https://forum.ansible.com/tag/eda-server).
+
+You can also get in touch by sending an email to <event-driven-automation@redhat.com>.


### PR DESCRIPTION
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README and the docsite. Similar PRs are now being raised across all the Ansible ecosystem projects.

Thanks!