### PR TITLE
fix: (AAP-29615) 500 error when creating a credential with a none credential type id

### DIFF
--- a/src/aap_eda/api/serializers/eda_credential.py
+++ b/src/aap_eda/api/serializers/eda_credential.py
@@ -103,7 +103,7 @@ class EdaCredentialSerializer(serializers.ModelSerializer):
 class EdaCredentialCreateSerializer(serializers.ModelSerializer):
     credential_type_id = serializers.IntegerField(
         required=True,
-        allow_null=True,
+        allow_null=False,
         validators=[validators.check_if_credential_type_exists],
     )
     organization_id = serializers.IntegerField(

--- a/tests/integration/api/test_eda_credential.py
+++ b/tests/integration/api/test_eda_credential.py
@@ -141,6 +141,25 @@ def test_create_eda_credential(
         )
 
 
+@pytest.mark.django_db
+def test_create_eda_credential_with_none_credential_type(
+    admin_client: APIClient,
+    default_organization: models.Organization,
+):
+    data = "secret"
+    data_in = {
+        "name": "eda-credential",
+        "inputs": {"username": "adam", "password": data},
+        "credential_type_id": None,
+        "organization_id": default_organization.id,
+    }
+    response = admin_client.post(
+        f"{api_url_v1}/eda-credentials/", data=data_in
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "This field may not be null." in response.data["credential_type_id"]
+
+
 @pytest.mark.parametrize(
     ("key_file", "status_code", "status_message"),
     [


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-29615

Change credential_type_id as required when creating credentials, and return a 400 error if it's missed.