### PR TITLE
Only run unit test upload on main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,7 +114,7 @@ jobs:
           verbose: true
       
       - name: Upload jUnit test results (APDE CI)
-        if: github.repository == 'ansible/eda-server'
+        if: github.repository == 'ansible/eda-server' && github.ref == 'refs/heads/main'
         run: >-
           poetry run http --check-status --ignore-stdin
           --auth "${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}:${{ secrets.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}"

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -97,6 +97,7 @@ jobs:
 
       - name: Upload jUnit test results (APDE CI)
         working-directory: ${{ env.EDA_QA_PATH }}
+        if: github.ref == 'refs/heads/main'
         run: >-
           http --check-status --ignore-stdin
           --auth "${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}:${{ secrets.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}"
@@ -179,6 +180,7 @@ jobs:
 
       - name: Upload jUnit test results (APDE CI)
         working-directory: ${{ env.EDA_QA_PATH }}
+        if: github.ref == 'refs/heads/main'
         run: >-
           http --check-status --ignore-stdin
           --auth "${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}:${{ secrets.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}"


### PR DESCRIPTION
After further validation, we should only be triggering the upload of unit test results on the main branch.