### PR TITLE
fix:  (AAP-30118) - remove awx token from error message

### DIFF
--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -845,7 +845,7 @@ def _validate_rulebook(data: dict, with_token: bool = False) -> None:
         rulesets_data,
     ):
         raise serializers.ValidationError(
-            "The rulebook requires an Awx Token or RH AAP credential.",
+            "The rulebook requires a RH AAP credential.",
         )
 
 

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -907,7 +907,7 @@ def test_create_activation_no_token_but_required(
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert (
-        "The rulebook requires an Awx Token or RH AAP credential."
+        "The rulebook requires a RH AAP credential."
         in response.data["non_field_errors"]
     )
 
@@ -959,8 +959,7 @@ def test_restart_activation_with_required_token_deleted(
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert (
-        "The rulebook requires an Awx Token or RH AAP credential."
-        in response.data["errors"]
+        "The rulebook requires a RH AAP credential." in response.data["errors"]
     )
 
 

--- a/tests/integration/api/test_activation_with_credential.py
+++ b/tests/integration/api/test_activation_with_credential.py
@@ -210,9 +210,7 @@ def test_is_activation_valid_with_run_job_template_and_no_token_no_credential(
     valid, message = is_activation_valid(activation)
 
     assert valid is False
-    assert (
-        "The rulebook requires an Awx Token or RH AAP credential."
-    ) in message
+    assert "The rulebook requires a RH AAP credential." in message
 
 
 @pytest.mark.django_db

--- a/tests/integration/services/activation/test_manager.py
+++ b/tests/integration/services/activation/test_manager.py
@@ -241,9 +241,7 @@ def test_start_no_awx_token(
     with pytest.raises(exceptions.ActivationStartError) as exc:
         activation_manager.start()
     assert basic_activation.status == enums.ActivationStatus.ERROR
-    assert "The rulebook requires an Awx Token or RH AAP credential." in str(
-        exc.value
-    )
+    assert "The rulebook requires a RH AAP credential." in str(exc.value)
     assert str(exc.value) in basic_activation.status_message
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-30118

After the fix, the error message looks like this:
![image](https://github.com/user-attachments/assets/7a769198-52b5-4269-be20-42c99d0939e9)

Previously it looked like
<img width="1270" alt="Screenshot 2024-08-27 at 5 30 51 PM" src="https://github.com/user-attachments/assets/a0cd06f1-bf11-4d96-a2d0-3c20133dc49e">

