### PR TITLE
Add setting to force TLS on for Redis connections

### DIFF
--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -63,7 +63,7 @@ Redis queue settings:
 *   - Takes precedence over host and port
 * MQ_HOST - Redis queue hostname (default: "127.0.0.1")
 * MQ_PORT - Redis queue port (default: 6379)
-* MQ_TLS - Force TLS on when True (default: False)
+* MQ_TLS - Force TLS on when True (default: None)
 * MQ_DB - Redis queue database (default: 0)
 * MQ_USER - Redis user (default: None)
 * MQ_USER_PASSWORD - Redis user passed (default: None)
@@ -366,7 +366,7 @@ REDIS_USER_PASSWORD = settings.get("MQ_USER_PASSWORD", None)
 REDIS_CLIENT_CACERT_PATH = settings.get("MQ_CLIENT_CACERT_PATH", None)
 REDIS_CLIENT_CERT_PATH = settings.get("MQ_CLIENT_CERT_PATH", None)
 REDIS_CLIENT_KEY_PATH = settings.get("MQ_CLIENT_KEY_PATH", None)
-REDIS_TLS = settings.get("MQ_TLS", False)
+REDIS_TLS = settings.get("MQ_TLS", None)
 DEFAULT_REDIS_DB = 0
 REDIS_DB = settings.get("MQ_DB", DEFAULT_REDIS_DB)
 RQ_REDIS_PREFIX = settings.get("RQ_REDIS_PREFIX", "eda-rq")
@@ -393,8 +393,15 @@ def _rq_common_parameters():
             "HOST": REDIS_HOST,
             "PORT": REDIS_PORT,
         }
-        if REDIS_CLIENT_CERT_PATH or REDIS_TLS:
+        if REDIS_TLS:
             params["SSL"] = True
+        else:
+            # This check should be deprecated in favor of just using
+            # MQ_TLS as the determining factor for if TLS is enabled.
+            if REDIS_CLIENT_CERT_PATH and REDIS_TLS is None:
+                params["SSL"] = True
+            else:
+                params["SSL"] = False
     return params
 
 

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -396,7 +396,7 @@ def _rq_common_parameters():
         if REDIS_TLS:
             params["SSL"] = True
         else:
-            # TODO: Deprecate implicit setting based on cert path in favor of 
+            # TODO: Deprecate implicit setting based on cert path in favor of
             #       MQ_TLS as the determinant.
             if REDIS_CLIENT_CERT_PATH and REDIS_TLS is None:
                 params["SSL"] = True

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -396,8 +396,8 @@ def _rq_common_parameters():
         if REDIS_TLS:
             params["SSL"] = True
         else:
-            # TODO: Deprecate implicit setting based on cert path in favor of MQ_TLS as the determinant.
-            # MQ_TLS as the determining factor for if TLS is enabled.
+            # TODO: Deprecate implicit setting based on cert path in favor of 
+            #       MQ_TLS as the determinant.
             if REDIS_CLIENT_CERT_PATH and REDIS_TLS is None:
                 params["SSL"] = True
             else:

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -396,7 +396,7 @@ def _rq_common_parameters():
         if REDIS_TLS:
             params["SSL"] = True
         else:
-            # This check should be deprecated in favor of just using
+            # TODO: Deprecate implicit setting based on cert path in favor of MQ_TLS as the determinant.
             # MQ_TLS as the determining factor for if TLS is enabled.
             if REDIS_CLIENT_CERT_PATH and REDIS_TLS is None:
                 params["SSL"] = True

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -63,6 +63,7 @@ Redis queue settings:
 *   - Takes precedence over host and port
 * MQ_HOST - Redis queue hostname (default: "127.0.0.1")
 * MQ_PORT - Redis queue port (default: 6379)
+* MQ_TLS - Force TLS on when True (default: False)
 * MQ_DB - Redis queue database (default: 0)
 * MQ_USER - Redis user (default: None)
 * MQ_USER_PASSWORD - Redis user passed (default: None)
@@ -365,6 +366,7 @@ REDIS_USER_PASSWORD = settings.get("MQ_USER_PASSWORD", None)
 REDIS_CLIENT_CACERT_PATH = settings.get("MQ_CLIENT_CACERT_PATH", None)
 REDIS_CLIENT_CERT_PATH = settings.get("MQ_CLIENT_CERT_PATH", None)
 REDIS_CLIENT_KEY_PATH = settings.get("MQ_CLIENT_KEY_PATH", None)
+REDIS_TLS = settings.get("MQ_TLS", False)
 DEFAULT_REDIS_DB = 0
 REDIS_DB = settings.get("MQ_DB", DEFAULT_REDIS_DB)
 RQ_REDIS_PREFIX = settings.get("RQ_REDIS_PREFIX", "eda-rq")
@@ -391,7 +393,7 @@ def _rq_common_parameters():
             "HOST": REDIS_HOST,
             "PORT": REDIS_PORT,
         }
-        if REDIS_CLIENT_CERT_PATH:
+        if REDIS_CLIENT_CERT_PATH or REDIS_TLS:
             params["SSL"] = True
     return params
 


### PR DESCRIPTION
This will add a new setting "MQ_TLS" to force TLS on for Redis connections. 

The default value for this setting is 'False'.  Switching it to 'True' will force TLS to be used for Redis connections.

The current logic of enabling TLS when provided a client certificate remains.