### PR TITLE
feat: Extend credentials to support file contents

### DIFF
--- a/src/aap_eda/core/exceptions.py
+++ b/src/aap_eda/core/exceptions.py
@@ -31,3 +31,7 @@ class PGNotifyError(Exception):
 
 class ParseError(Exception):
     pass
+
+
+class DuplicateFileTemplateKeyError(Exception):
+    pass

--- a/src/aap_eda/core/utils/credentials.py
+++ b/src/aap_eda/core/utils/credentials.py
@@ -19,6 +19,7 @@ import gnupg
 import jinja2
 import yaml
 from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
 from jinja2.nativetypes import NativeTemplate
 
 from aap_eda.api.constants import EDA_SERVER_VAULT_LABEL
@@ -26,13 +27,21 @@ from aap_eda.core.utils.awx import validate_ssh_private_key
 
 ENCRYPTED_STRING = "$encrypted$"
 EDA_PREFIX = "EDA_"
-SUPPORTED_KEYS_IN_INJECTORS = ["extra_vars"]
+SUPPORTED_KEYS_IN_INJECTORS = {"extra_vars", "file"}
 PROTECTED_PASSPHRASE_ERROR = (
     "The key is passphrase protected, please provide passphrase."
 )
 
 
 class InjectorMissingKeyException(Exception):
+    pass
+
+
+class InjectorInvalidTemplateKey(Exception):
+    pass
+
+
+class InjectorDuplicateKey(Exception):
     pass
 
 
@@ -245,18 +254,15 @@ def validate_injectors(schema: dict, injectors: dict) -> dict:
     if not isinstance(injectors, dict):
         errors.append("Injectors must be in Key-Value pairs format")
 
-    injector_keys = injectors.keys()
-    if bool(injector_keys) and not any(
-        support_key in injectors.keys()
-        for support_key in SUPPORTED_KEYS_IN_INJECTORS
-    ):
+    injector_keys = set(injectors.keys())
+    if not injector_keys.issubset(SUPPORTED_KEYS_IN_INJECTORS):
         errors.append(
             "Injectors must have keys defined in"
-            f" {SUPPORTED_KEYS_IN_INJECTORS}"
+            f" {sorted(SUPPORTED_KEYS_IN_INJECTORS)}"
         )
 
     context = _default_context(schema)
-
+    key_names = []
     for field in SUPPORTED_KEYS_IN_INJECTORS:
         input_data = injectors.get(field)
         if not input_data:
@@ -268,13 +274,23 @@ def validate_injectors(schema: dict, injectors: dict) -> dict:
 
         for k, v in input_data.items():
             try:
+                if k in key_names:
+                    raise InjectorDuplicateKey(
+                        f"Injector {field} key: {k} already exists"
+                    )
+
+                if field == "file":
+                    _validate_file_template_key(k)
                 if isinstance(v, str):
                     _check_jinja_string(v, context)
+                key_names.append(k)
             except InjectorMissingKeyException as e:
                 errors.append(
                     f"Injector key: {k} has a value which refers to an"
                     f" undefined key error: {e}"
                 )
+            except (InjectorInvalidTemplateKey, InjectorDuplicateKey) as e:
+                errors.append(f"{e}")
 
     return {"injectors": errors} if bool(errors) else {}
 
@@ -389,3 +405,23 @@ def _validate_gpg_public_key(key_data: str) -> list[str]:
             errors.append(msg)
 
     return errors
+
+
+def _validate_file_template_key(key: str) -> None:
+    keys = key.split(".")
+    if keys[0] != "template":
+        raise InjectorInvalidTemplateKey(
+            _(
+                "Injector %(injector_type)s key: %(key)s "
+                "should start with template"
+            )
+            % {"injector_type": "file", "key": key}
+        )
+    if len(keys) > 2:
+        raise InjectorInvalidTemplateKey(
+            _(
+                "Injector %(injector_type)s key: %(key)s "
+                "cannot contain multiple dots"
+            )
+            % {"injector_type": "file", "key": key}
+        )

--- a/src/aap_eda/wsapi/messages.py
+++ b/src/aap_eda/wsapi/messages.py
@@ -104,3 +104,12 @@ class HeartbeatMessage(BaseModel):
     activation_id: int
     stats: dict = {}
     reported_at: str
+
+
+class FileContentMessage(BaseModel):
+    type: str = "FileContents"
+    template_key: str
+    data: str
+    eof: bool = False
+    data_format: Optional[str] = "text"
+    encoding: Optional[str] = "base64"

--- a/tests/integration/api/test_activation_with_credential.py
+++ b/tests/integration/api/test_activation_with_credential.py
@@ -375,7 +375,7 @@ def test_create_activation_with_key_conflict(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert (
         "Key: sasl_plain_password already exists "
-        "in extra var. It conflicts with credential type: type1. "
+        "in extra_vars. It conflicts with credential type: type1. "
         "Please check injectors." in response.data["non_field_errors"]
     )
 
@@ -423,7 +423,7 @@ def test_create_activation_with_conflict_credentials(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert (
         "Key: sasl_password already exists "
-        "in extra var. It conflicts with credential type: user_type. "
+        "in extra_vars. It conflicts with credential type: user_type. "
         "Please check injectors." in response.data["non_field_errors"]
     )
 
@@ -507,7 +507,7 @@ def test_create_activation_without_extra_vars_duplicate_credentials(
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert (
-        "Key: sasl_password already exists in extra var. It conflicts with"
+        "Key: sasl_password already exists in extra_vars. It conflicts with"
         " credential type: user_type. Please check injectors."
         in response.data["non_field_errors"]
     )
@@ -706,3 +706,85 @@ def test_create_activation_with_multip_aap_credentials(
         f"{len(aap_credentials)} RH AAP credentials"
         " are provided instead of 1" in response.data["eda_credentials"]
     )
+
+
+@pytest.mark.django_db
+def test_create_activation_with_conflict_key_file_contents(
+    admin_client: APIClient,
+    activation_payload: Dict[str, Any],
+    default_organization: models.Organization,
+    preseed_credential_types,
+):
+    test_activation = {
+        "name": "test_activation",
+        "decision_environment_id": activation_payload[
+            "decision_environment_id"
+        ],
+        "rulebook_id": activation_payload["rulebook_id"],
+        "organization_id": default_organization.id,
+    }
+
+    credential_type_inputs = {
+        "fields": [
+            {"id": "cert", "label": "Certificate", "type": "string"},
+            {"id": "key", "label": "Key", "type": "string"},
+        ]
+    }
+    credential_type_injectors = {
+        "file": {
+            "template.cert_file": "[mycert]\n{{ cert }}",
+        },
+    }
+    credential_type = models.CredentialType.objects.create(
+        name="sample_credential_type",
+        inputs=credential_type_inputs,
+        injectors=credential_type_injectors,
+    )
+
+    eda_credentials = [
+        _create_credential(
+            admin_client,
+            "credential-1",
+            {"cert": "my_pem_data", "key": "my_pem_key"},
+            credential_type.id,
+            default_organization.id,
+        ),
+        _create_credential(
+            admin_client,
+            "credential-2",
+            {"cert": "my_pem_data", "key": "my_pem_key"},
+            credential_type.id,
+            default_organization.id,
+        ),
+    ]
+
+    eda_credential_ids = [credential["id"] for credential in eda_credentials]
+    test_activation["eda_credentials"] = eda_credential_ids
+
+    response = admin_client.post(
+        f"{api_url_v1}/activations/", data=test_activation
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert (
+        "Key: template.cert_file already exists in file. "
+        "It conflicts with credential type: sample_credential_type. "
+        "Please check injectors." in response.data["non_field_errors"]
+    )
+
+
+def _create_credential(
+    api_client,
+    name: str,
+    inputs: dict,
+    credential_type_id: int,
+    organization_id: int,
+) -> dict:
+    data = {
+        "name": name,
+        "inputs": inputs,
+        "credential_type_id": credential_type_id,
+        "organization_id": organization_id,
+    }
+    response = api_client.post(f"{api_url_v1}/eda-credentials/", data=data)
+    assert response.status_code == status.HTTP_201_CREATED
+    return response.data

--- a/tests/integration/wsapi/test_consumer.py
+++ b/tests/integration/wsapi/test_consumer.py
@@ -1,3 +1,4 @@
+import base64
 import uuid
 from typing import Generator
 from unittest.mock import patch
@@ -117,10 +118,10 @@ async def test_handle_workers_with_eda_system_vault_credential(
     preseed_credential_types,
     default_organization: models.Organization,
 ):
-    rulebook_process_id = (
-        await _prepare_activation_instance_with_eda_system_vault_credential(
-            default_organization,
-        )
+    credential = await _prepare_system_vault_credential(default_organization)
+    rulebook_process_id = await _prepare_activation_instance_with_credentials(
+        default_organization,
+        [credential],
     )
 
     payload = {
@@ -726,8 +727,9 @@ def get_job_instance_event_count():
 
 
 @database_sync_to_async
-def _prepare_activation_instance_with_eda_system_vault_credential(
+def _prepare_activation_instance_with_credentials(
     default_organization: models.Organization,
+    credentials: list[models.EdaCredential],
 ):
     project, _ = models.Project.objects.get_or_create(
         name="test-project",
@@ -757,18 +759,6 @@ def _prepare_activation_instance_with_eda_system_vault_credential(
         email="luke.skywalker@example.com",
         password="secret",
     )
-    vault_credential_type = models.CredentialType.objects.get(
-        name=enums.DefaultCredentialType.VAULT
-    )
-
-    credential = models.EdaCredential.objects.create(
-        name="eda_credential",
-        inputs={"vault_id": "adam", "vault_password": "secret"},
-        managed=False,
-        credential_type=vault_credential_type,
-        organization=default_organization,
-    )
-
     activation, _ = models.Activation.objects.get_or_create(
         name="test-activation",
         restart_policy=enums.RestartPolicy.ALWAYS,
@@ -778,7 +768,7 @@ def _prepare_activation_instance_with_eda_system_vault_credential(
         decision_environment=decision_environment,
         organization=default_organization,
     )
-    activation.eda_credentials.add(credential)
+    activation.eda_credentials.add(*credentials)
 
     rulebook_process, _ = models.RulebookProcess.objects.get_or_create(
         activation=activation,
@@ -1111,3 +1101,110 @@ def _create_event(data, uuid):
         },
         "i": data,
     }
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_handle_workers_with_file_contents(
+    ws_communicator: WebsocketCommunicator,
+    preseed_credential_types,
+    default_organization: models.Organization,
+):
+    credential_type_inputs = {
+        "fields": [
+            {"id": "cert", "label": "Certificate", "type": "string"},
+            {"id": "key", "label": "Key", "type": "string"},
+        ]
+    }
+    credential_type_injectors = {
+        "file": {
+            "template.cert_file": "[mycert]\n{{ cert }}",
+            "template.key_file": "[mykey]\n{{ key }}",
+        },
+    }
+
+    credential_inputs = {
+        "cert": "This is a certificate",
+        "key": "This is a key",
+    }
+
+    cert_template = "[mycert]\nThis is a certificate"
+    key_template = "[mykey]\nThis is a key"
+    cert_template_encoded = base64.b64encode(cert_template.encode()).decode()
+    key_template_encoded = base64.b64encode(key_template.encode()).decode()
+
+    eda_credential = await _prepare_credential(
+        credential_type_inputs,
+        credential_type_injectors,
+        credential_inputs,
+        default_organization,
+    )
+
+    rulebook_process_id = await _prepare_activation_instance_with_credentials(
+        default_organization,
+        [eda_credential],
+    )
+
+    payload = {
+        "type": "Worker",
+        "activation_id": rulebook_process_id,
+    }
+    await ws_communicator.send_json_to(payload)
+    cert_data = {
+        "data": cert_template_encoded,
+        "template_key": "template.cert_file",
+    }
+    key_data = {
+        "data": key_template_encoded,
+        "template_key": "template.key_file",
+    }
+
+    for type, data in [
+        ("Rulebook", None),
+        ("FileContents", key_data),
+        ("FileContents", cert_data),
+        ("EndOfResponse", None),
+    ]:
+        response = await ws_communicator.receive_json_from(timeout=TIMEOUT)
+        assert response["type"] == type
+        if data:
+            for key, value in data.items():
+                assert response[key] == value
+
+
+@database_sync_to_async
+def _prepare_credential(
+    credential_type_inputs: dict,
+    credential_type_injectors: dict,
+    credential_inputs: dict,
+    default_organization: models.Organization,
+) -> models.EdaCredential:
+    credential_type = models.CredentialType.objects.create(
+        name="sample_credential_type",
+        inputs=credential_type_inputs,
+        injectors=credential_type_injectors,
+    )
+
+    return models.EdaCredential.objects.create(
+        name="sample_eda_credential",
+        inputs=credential_inputs,
+        managed=False,
+        credential_type=credential_type,
+        organization=default_organization,
+    )
+
+
+@database_sync_to_async
+def _prepare_system_vault_credential(
+    default_organization: models.Organization,
+) -> models.EdaCredential:
+    vault_credential_type = models.CredentialType.objects.get(
+        name=enums.DefaultCredentialType.VAULT
+    )
+
+    return models.EdaCredential.objects.create(
+        name="eda_system_credential",
+        inputs={"vault_id": "adam", "vault_password": "secret"},
+        managed=False,
+        credential_type=vault_credential_type,
+        organization=default_organization,
+    )

--- a/tests/unit/test_credential_validation.py
+++ b/tests/unit/test_credential_validation.py
@@ -424,14 +424,13 @@ def test_validate_injectors():
     bad_injectors = {"name": "fred"}
     errors = validate_injectors(inputs, bad_injectors)
     assert (
-        f"Injectors must have keys defined in {SUPPORTED_KEYS_IN_INJECTORS}"
-        in errors["injectors"]
+        "Injectors must have keys defined in "
+        f"{sorted(SUPPORTED_KEYS_IN_INJECTORS)}" in errors["injectors"]
     )
 
-    for key in SUPPORTED_KEYS_IN_INJECTORS:
-        valid_injectors = {key: {"name": "fred"}}
-        errors = validate_injectors(inputs, valid_injectors)
-        assert errors == {}
+    valid_injectors = {"extra_vars": {"username": "fred"}}
+    errors = validate_injectors(inputs, valid_injectors)
+    assert errors == {}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This borrows a feature from AAP Credential Types to send file content to ansible-rulebook which can be used with sources. In AAP the vars are called tower.filename.certfile In eda its called eda.filename.certfile.
https://docs.ansible.com/automation-controller/latest/html/userguide/credential_types.html Please read injector configuration

https://issues.redhat.com/browse/AAP-25518