### PR TITLE
Allow reverse-sync if resource server is defined

### DIFF
--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -665,6 +665,11 @@ ALLOW_LOCAL_RESOURCE_MANAGEMENT = settings.get(
     "ALLOW_LOCAL_RESOURCE_MANAGEMENT", True
 )
 
+# If we have a resource server defined, apply local changes to that server
+RESOURCE_SERVER_SYNC_ENABLED = settings.get(
+    "RESOURCE_SERVER_SYNC_ENABLED", True
+)
+
 # ---------------------------------------------------------
 # DJANGO ANSIBLE BASE RESOURCES REGISTRY SETTINGS
 # ---------------------------------------------------------


### PR DESCRIPTION
AAP-30009

Specifically with this commit:

https://github.com/ansible/django-ansible-base/commit/2af5f34dd4887eeba65f48e01e488745e90f8f04#diff-8623b469b6e5d0b1173a741c5702169d5a06e643a8d416c860127373d662217d

This should now be safe to add, because any standalone variation will not have the URL of the resource server defined, which means that it still will not sync.