### PR TITLE
enable middleware to log traceback on timeout

### DIFF
--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -206,6 +206,7 @@ MIDDLEWARE = [
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "ansible_base.lib.middleware.logging.log_request.LogTracebackMiddleware",
     "crum.CurrentRequestUserMiddleware",
 ]
 


### PR DESCRIPTION
gunicorn sends a signal 6 when it is about to timeout a request This middleware handles that request and logs a traceback.

this aids in debugging infrastructure issues that may be causing requests to timeout.