### PR TITLE
fix(AAP-30640): update use roles to mitigate permission escalation

### DIFF
--- a/src/aap_eda/core/management/commands/create_initial_data.py
+++ b/src/aap_eda/core/management/commands/create_initial_data.py
@@ -1317,7 +1317,7 @@ class Command(BaseCommand):
                 use_permissions = [
                     perm
                     for perm in permissions
-                    if not perm.codename.startswith("delete_")
+                    if perm.codename.startswith("view_")
                 ]
                 use_role.permissions.set(use_permissions)
                 if use_role_created:

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -693,6 +693,8 @@ ALLOW_SHARED_RESOURCE_CUSTOM_ROLES = settings.get(
     "ALLOW_SHARED_RESOURCE_CUSTOM_ROLES", False
 )
 
+ANSIBLE_BASE_CHECK_RELATED_PERMISSIONS = ["view"]
+
 # --------------------------------------------------------
 # DJANGO ANSIBLE BASE RESOURCE API CLIENT
 # --------------------------------------------------------

--- a/tests/integration/dab_rbac/test_related_permissions.py
+++ b/tests/integration/dab_rbac/test_related_permissions.py
@@ -79,18 +79,9 @@ def test_project_credential_access(
     default_project.refresh_from_db()
     assert default_project.eda_credential_id != new_scm_credential.pk
 
-    # User can view related credential, but does not have permission to use
+    # view permission is enough to use related credential
+    # as defined by ANSIBLE_BASE_CHECK_RELATED_PERMISSIONS
     give_obj_perm(default_user, new_scm_credential, "view")
-    response = user_client.patch(
-        url, data={"eda_credential_id": new_scm_credential.pk}
-    )
-    assert response.status_code == 403, response.data
-    assert "eda_credential" in str(response.data), response.data
-    default_project.refresh_from_db()
-    assert default_project.eda_credential_id != new_scm_credential.pk
-
-    # User has permission to change the related credential
-    give_obj_perm(default_user, new_scm_credential, "change")
     response = user_client.patch(
         url, data={"eda_credential_id": new_scm_credential.pk}
     )


### PR DESCRIPTION
This PR updates managed Use roles (e.g. Decision Environment Use) to limit their capabilities and avoid granting unwanted permissions. 

JIRA: [AAP-30640](https://issues.redhat.com/browse/AAP-30640) & [AAP-30627](https://issues.redhat.com/browse/AAP-30627)
