### PR TITLE
[AAP-30722] add Redis cluster-related retry and timeout settings

### DIFF
--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -136,16 +136,16 @@ def _get_secret_key() -> str:
 SECRET_KEY = _get_secret_key()
 
 
-def _get_debug() -> bool:
-    debug = settings.get("DEBUG", False)
-    if isinstance(debug, str):
-        debug = str_to_bool(debug)
-    if not isinstance(debug, bool):
-        raise ImproperlyConfigured("DEBUG setting must be a boolean value.")
-    return debug
+def _get_boolean(name: str, default=False) -> bool:
+    value = settings.get(name, default)
+    if isinstance(value, str):
+        value = str_to_bool(value)
+    if not isinstance(value, bool):
+        raise ImproperlyConfigured("{name} setting must be a boolean value.")
+    return value
 
 
-DEBUG = _get_debug()
+DEBUG = _get_boolean("DEBUG")
 
 ALLOWED_HOSTS = settings.get("ALLOWED_HOSTS", [])
 ALLOWED_HOSTS = (
@@ -448,7 +448,14 @@ def rq_redis_client_instantiation_parameters():
     if REDIS_HA_CLUSTER_HOSTS:
         params["mode"] = "cluster"
         params["redis_hosts"] = REDIS_HA_CLUSTER_HOSTS
-
+        params["socket_keepalive"] = _get_boolean("SOCKET_KEEP_ALIVE", True)
+        params["socket_connect_timeout"] = settings.get(
+            "SOCKET_CONNECT_TIMEOUT", 10
+        )
+        params["socket_timeout"] = settings.get("SOCKET_TIMEOUT", 10)
+        params["cluster_error_retry_attempts"] = settings.get(
+            "CLUSTER_ERROR_RETRY_ATTEMPTS", 3
+        )
     return params
 
 

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -448,13 +448,13 @@ def rq_redis_client_instantiation_parameters():
     if REDIS_HA_CLUSTER_HOSTS:
         params["mode"] = "cluster"
         params["redis_hosts"] = REDIS_HA_CLUSTER_HOSTS
-        params["socket_keepalive"] = _get_boolean("SOCKET_KEEP_ALIVE", True)
+        params["socket_keepalive"] = _get_boolean("MQ_SOCKET_KEEP_ALIVE", True)
         params["socket_connect_timeout"] = settings.get(
-            "SOCKET_CONNECT_TIMEOUT", 10
+            "MQ_SOCKET_CONNECT_TIMEOUT", 10
         )
-        params["socket_timeout"] = settings.get("SOCKET_TIMEOUT", 10)
+        params["socket_timeout"] = settings.get("MQ_SOCKET_TIMEOUT", 10)
         params["cluster_error_retry_attempts"] = settings.get(
-            "CLUSTER_ERROR_RETRY_ATTEMPTS", 3
+            "MQ_CLUSTER_ERROR_RETRY_ATTEMPTS", 3
         )
     return params
 

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -21,7 +21,7 @@ from aap_eda.settings.default import (
     DEFAULT_RULEBOOK_QUEUE_TIMEOUT,
     ImproperlyConfigured,
     RulebookProcessLogLevel,
-    _get_debug,
+    _get_boolean,
     get_rq_queues,
     get_rulebook_process_log_level,
 )
@@ -159,14 +159,14 @@ def test_rq_queues_custom_host_multiple_queues():
     ],
 )
 @patch("aap_eda.settings.default.settings")
-def test_get_debug(mock_settings, value, expected):
+def test_get_boolean(mock_settings, value, expected):
     mock_settings.get.return_value = value
-    result = _get_debug()
+    result = _get_boolean("DEBUG")
     assert result == expected
 
 
 @patch("aap_eda.settings.default.settings")
-def test_get_debug_exception(mock_settings):
+def test_get_boolean_exception(mock_settings):
     mock_settings.get.return_value = ["something", "else"]
     with pytest.raises(ImproperlyConfigured):
-        _get_debug()
+        _get_boolean("DEBUG")


### PR DESCRIPTION
Adds settings to EDA allowing manipulation of timeouts and retries for Redis cluster deployments.