### PR TITLE
fix: remove client login when using self certs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -621,7 +621,7 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-ansible-base"
-version = "2024.9.2.0.dev8+g5f718b4"
+version = "2024.9.12.0.dev4+ga44d6bf"
 description = "A Django app used by ansible services"
 optional = false
 python-versions = ">=3.9"
@@ -653,7 +653,7 @@ testing = ["cryptography", "pytest", "pytest-django"]
 type = "git"
 url = "https://github.com/ansible/django-ansible-base.git"
 reference = "devel"
-resolved_reference = "5f718b41107f942967155dea0434e4802e3b5380"
+resolved_reference = "a44d6bfab27ffb33a2bd04604b0cb88c7dd7762d"
 
 [[package]]
 name = "django-crum"

--- a/src/aap_eda/core/tasking/__init__.py
+++ b/src/aap_eda/core/tasking/__init__.py
@@ -176,6 +176,10 @@ def enable_redis_prefix():
     rq.queue.Queue.redis_queues_keys = f"{redis_prefix}:queues"
 
     # Worker.
+    # Although PUBSUB_CHANNEL_TEMPLATE is defined in rq.command (and we've
+    # overridden it there for any new uses) rq.worker, which we've already
+    # imported, imports it so we need to override that value as well.
+    rq.worker.PUBSUB_CHANNEL_TEMPLATE = rq.command.PUBSUB_CHANNEL_TEMPLATE
     rq.worker.Worker.redis_worker_namespace_prefix = f"{redis_prefix}:worker:"
     rq.worker.Worker.redis_workers_keys = f"{redis_prefix}:workers"
     rq.worker_registration.REDIS_WORKER_KEYS = f"{redis_prefix}:workers"

--- a/src/aap_eda/services/activation/engine/podman.py
+++ b/src/aap_eda/services/activation/engine/podman.py
@@ -124,7 +124,6 @@ class Engine(ContainerEngine):
             raise exceptions.ContainerStartError("Missing image url")
 
         try:
-            self._login(request)
             LOGGER.info(f"Image URL is {request.image_url}")
             if request.pull_policy == "Always" or not self._image_exists(
                 request.image_url,

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -327,6 +327,23 @@ REST_FRAMEWORK = {
     "EXCEPTION_HANDLER": "aap_eda.api.exceptions.api_fallback_handler",
 }
 
+
+def _config_authentication_backends():
+    from django.conf import settings as djsettings
+
+    backend = (
+        "ansible_base.lib.backends.prefixed_user_auth.PrefixedUserAuthBackend"
+    )
+    backends = djsettings.AUTHENTICATION_BACKENDS or []
+    if backend not in backends:
+        backends.append(backend)
+    return backends
+
+
+RENAMED_USERNAME_PREFIX = settings.get("RENAMED_USERNAME_PREFIX", "eda_")
+AUTHENTICATION_BACKENDS = _config_authentication_backends()
+
+
 # ---------------------------------------------------------
 # DEPLOYMENT SETTINGS
 # ---------------------------------------------------------


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-31349

Based on [podman doc](https://docs.podman.io/en/latest/markdown/podman-login.1.html), we don't need the login in our scenario.