### PR TITLE
[Hold] Consistency fixes to -dev compose file for aap-dev

### DIFF
--- a/tools/deploy/eda-api/deployment.yaml
+++ b/tools/deploy/eda-api/deployment.yaml
@@ -22,8 +22,8 @@ spec:
             - -c
             - >-
               aap-eda-manage migrate
-              && aap-eda-manage create_initial_data
-              && scripts/create_superuser.sh
+              && ANSIBLE_REVERSE_RESOURCE_SYNC=false aap-eda-manage create_initial_data
+              && ANSIBLE_REVERSE_RESOURCE_SYNC=false scripts/create_superuser.sh
               && aap-eda-manage runserver 0.0.0.0:8000
           env:
             - name: EDA_DATABASE_URL

--- a/tools/docker/docker-compose-dev-redis-tls.yaml
+++ b/tools/docker/docker-compose-dev-redis-tls.yaml
@@ -156,8 +156,8 @@ services:
       - -c
       - >-
         aap-eda-manage migrate
-        && aap-eda-manage create_initial_data
-        && scripts/create_superuser.sh
+        && ANSIBLE_REVERSE_RESOURCE_SYNC=false aap-eda-manage create_initial_data
+        && ANSIBLE_REVERSE_RESOURCE_SYNC=false scripts/create_superuser.sh
         && aap-eda-manage runserver 0.0.0.0:8000
     ports:
       - "${EDA_API_PORT:-8000}:8000"

--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -137,8 +137,8 @@ services:
       - -c
       - >-
         aap-eda-manage migrate
-        && aap-eda-manage create_initial_data
-        && scripts/create_superuser.sh
+        && ANSIBLE_REVERSE_RESOURCE_SYNC=false aap-eda-manage create_initial_data
+        && ANSIBLE_REVERSE_RESOURCE_SYNC=false scripts/create_superuser.sh
         && aap-eda-manage runserver 0.0.0.0:8000
     ports:
       - "${EDA_API_PORT:-8000}:8000"
@@ -252,7 +252,7 @@ services:
     restart: always
 
   eda-webhook-api:
-    image: "${EDA_IMAGE:-quay.io/ansible/eda-server:main}"
+    image: ${EDA_IMAGE:-localhost/aap-eda}
     environment: *common-env
     command:
       - /bin/bash
@@ -269,6 +269,8 @@ services:
       interval: 30s
       timeout: 5s
       retries: 10
+    volumes:
+      - '../../:/app/src:z'
 
   squid:
     image: ${EDA_SQUID_IMAGE:-quay.io/openshifttest/squid-proxy}:${EDA_SQUID_VERSION:-1.2.0}

--- a/tools/docker/docker-compose-mac.yml
+++ b/tools/docker/docker-compose-mac.yml
@@ -89,8 +89,8 @@ services:
       - -c
       - >-
         aap-eda-manage migrate
-        && aap-eda-manage create_initial_data
-        && scripts/create_superuser.sh
+        && ANSIBLE_REVERSE_RESOURCE_SYNC=false aap-eda-manage create_initial_data
+        && ANSIBLE_REVERSE_RESOURCE_SYNC=false scripts/create_superuser.sh
         && aap-eda-manage runserver 0.0.0.0:8000
     ports:
       - '${EDA_API_PORT:-8000}:8000'

--- a/tools/docker/docker-compose-stage.yaml
+++ b/tools/docker/docker-compose-stage.yaml
@@ -104,8 +104,8 @@ services:
       - -c
       - >-
         aap-eda-manage migrate
-        && aap-eda-manage create_initial_data
-        && scripts/create_superuser.sh
+        && ANSIBLE_REVERSE_RESOURCE_SYNC=false aap-eda-manage create_initial_data
+        && ANSIBLE_REVERSE_RESOURCE_SYNC=false scripts/create_superuser.sh
         && gunicorn -b 0.0.0.0:8000
         -w ${EDA_API_WORKERS:-4} aap_eda.wsgi
         --access-logfile -


### PR DESCRIPTION
I confirmed with @relrod that official installers set the environment variable `ANSIBLE_REVERSE_RESOURCE_SYNC` False when running the create_initial_data command. We could change the command itself, but I don't think we did this for any AWX commands, and in any case, I only want to modify `tools/` and not `src/` at this particular moment.

Adding that env var fixes this error for me:

```
  File "/app/venv/lib64/python3.11/site-packages/django/contrib/auth/management/commands/createsuperuser.py", line 88, in execute
    return super().execute(*args, **options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib64/python3.11/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib64/python3.11/site-packages/django/contrib/auth/management/commands/createsuperuser.py", line 233, in handle
    self.UserModel._default_manager.db_manager(database).create_superuser(
  File "/app/venv/lib64/python3.11/site-packages/django/contrib/auth/models.py", line 172, in create_superuser
    return self._create_user(username, email, password, **extra_fields)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib64/python3.11/site-packages/django/contrib/auth/models.py", line 155, in _create_user
    user.save(using=self._db)
  File "/app/venv/lib64/python3.11/site-packages/ansible_base/resource_registry/apps.py", line 135, in save
    _original_save(self, *args, **kwargs)
  File "/app/venv/lib64/python3.11/site-packages/django/contrib/auth/base_user.py", line 76, in save
    super().save(*args, **kwargs)
  File "/app/venv/lib64/python3.11/site-packages/django/db/models/base.py", line 814, in save
    self.save_base(
  File "/app/venv/lib64/python3.11/site-packages/django/db/models/base.py", line 892, in save_base
    post_save.send(
  File "/app/venv/lib64/python3.11/site-packages/django/dispatch/dispatcher.py", line 176, in send
    return [
           ^
  File "/app/venv/lib64/python3.11/site-packages/django/dispatch/dispatcher.py", line 177, in <listcomp>
    (receiver, receiver(signal=self, sender=sender, **named))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib64/python3.11/site-packages/ansible_base/resource_registry/signals/handlers.py", line 103, in sync_to_resource_server_post_save
    sync_to_resource_server(instance, action)
  File "/app/venv/lib64/python3.11/site-packages/ansible_base/resource_registry/utils/sync_to_resource_server.py", line 73, in sync_to_resource_server
    client = get_resource_server_client(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib64/python3.11/site-packages/ansible_base/resource_registry/rest_client.py", line 26, in get_resource_server_client
    return ResourceAPIClient(
           ^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib64/python3.11/site-packages/ansible_base/resource_registry/rest_client.py", line 66, in __init__
    self.base_url = f"{service_url}/{service_path.strip('/')}/"
                                     ^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'strip'
```

Next, I created a new settings file and was trying to point `DJANGO_SETTINGS_MODULE` to that file, but this caused errors in the `docker-eda-webhook-api-1` container.

This was because the source code was volume mounted in the API container but not the other. So the source code didn't have the file I added, because it was using source from the _image itself_. This leads me to believe this is the root cause which forced @chrismeyersfsu original implementation to be to add the settings file, then build the image, then run the server, which I undid.

Adding the volume mount allows these changes before running the server, but after building the image.