### PR TITLE
Use DAB value as fallback value for service path setting

### DIFF
--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -733,7 +733,15 @@ RESOURCE_SERVER = {
     "VALIDATE_HTTPS": settings.get("RESOURCE_SERVER__VALIDATE_HTTPS", False),
 }
 RESOURCE_JWT_USER_ID = settings.get("RESOURCE_JWT_USER_ID", None)
-RESOURCE_SERVICE_PATH = settings.get("RESOURCE_SERVICE_PATH", None)
+
+try:
+    service_path_default = RESOURCE_SERVICE_PATH  # noqa
+except NameError:
+    service_path_default = None
+
+RESOURCE_SERVICE_PATH = settings.get(
+    "RESOURCE_SERVICE_PATH", service_path_default
+)
 ANSIBLE_BASE_MANAGED_ROLE_REGISTRY = settings.get(
     "ANSIBLE_BASE_MANAGED_ROLE_REGISTRY", {}
 )


### PR DESCRIPTION
I kept hitting this error even when it should have been fixed:

```
  File "/app/venv/lib64/python3.11/site-packages/ansible_base/resource_registry/signals/handlers.py", line 103, in sync_to_resource_server_post_save
    sync_to_resource_server(instance, action)
  File "/app/venv/lib64/python3.11/site-packages/ansible_base/resource_registry/utils/sync_to_resource_server.py", line 73, in sync_to_resource_server
    client = get_resource_server_client(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib64/python3.11/site-packages/ansible_base/resource_registry/rest_client.py", line 26, in get_resource_server_client
    return ResourceAPIClient(
           ^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib64/python3.11/site-packages/ansible_base/resource_registry/rest_client.py", line 66, in __init__
    self.base_url = f"{service_url}/{service_path.strip('/')}/"
                                     ^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'strip'
```

My finding here is that this is (fortunately) a one-off problem in the eda-server settings processing for just this setting. I don't have any problem allowing the dynaconf setting override, so I made this patch to continue allowing that. But if there is _not_ an override present, then we need to fall back to the DAB value, and the traceback above is because it incorrectly gives the `None` value, after the DAB defaults are already loaded about 100 lines earlier in this file.