### PR TITLE
feat: add settings/all/ and settings/system/ endpoints

### DIFF
--- a/src/aap_eda/api/serializers/setting.py
+++ b/src/aap_eda/api/serializers/setting.py
@@ -1,0 +1,38 @@
+#  Copyright 2024 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from rest_framework import serializers
+
+from aap_eda.conf import settings_registry
+
+
+class SettingSerializer(serializers.Serializer):
+    pass
+
+
+for key in settings_registry.get_registered_settings():
+    v_type = settings_registry.get_setting_type(key)
+    read_only = settings_registry.is_setting_read_only(key)
+    if v_type == str:
+        field = serializers.CharField(allow_blank=True, read_only=read_only)
+    elif v_type == int:
+        field = serializers.IntegerField(read_only=read_only)
+    elif v_type == bool:
+        field = serializers.BooleanField(read_only=read_only)
+    elif v_type == dict:
+        field = serializers.JSONField(read_only=read_only)
+    else:
+        raise TypeError(f"unsupported type {v_type}")
+    setattr(SettingSerializer, key, field)
+    SettingSerializer._declared_fields[key] = field

--- a/src/aap_eda/api/urls.py
+++ b/src/aap_eda/api/urls.py
@@ -85,6 +85,10 @@ openapi_urls = [
 
 eda_v1_urls = [
     path("config/", views.ConfigView.as_view(), name="config"),
+    path("settings/all/", views.SettingView.as_view(), name="setting-all"),
+    path(
+        "settings/system/", views.SettingView.as_view(), name="setting-system"
+    ),
     path("status/", core_views.StatusView.as_view(), name="status"),
     path("", include(openapi_urls)),
     path(

--- a/src/aap_eda/api/views/__init__.py
+++ b/src/aap_eda/api/views/__init__.py
@@ -24,6 +24,7 @@ from .organization import OrganizationViewSet
 from .project import ProjectViewSet
 from .root import ApiRootView, ApiV1RootView
 from .rulebook import AuditRuleViewSet, RulebookViewSet
+from .setting import SettingView
 from .team import TeamViewSet
 from .user import CurrentUserAwxTokenViewSet, CurrentUserView, UserViewSet
 
@@ -61,4 +62,5 @@ __all__ = (
     "EventStreamViewSet",
     # External event stream
     "ExternalEventStreamViewSet",
+    "SettingView",
 )

--- a/src/aap_eda/api/views/setting.py
+++ b/src/aap_eda/api/views/setting.py
@@ -1,0 +1,60 @@
+#  Copyright 2024 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.permissions import IsAdminUser
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from aap_eda.api.serializers.setting import SettingSerializer
+from aap_eda.conf import settings_registry
+
+
+class SettingView(APIView):
+    permission_classes = [IsAdminUser]
+
+    def get_serializer(self, *args, **kwargs):
+        return SettingSerializer(*args, **kwargs)
+
+    @extend_schema(
+        description="Get application settings",
+        responses={
+            status.HTTP_200_OK: OpenApiResponse(
+                SettingSerializer,
+                description=("Return application settings"),
+            )
+        },
+    )
+    def get(self, request):
+        data = settings_registry.db_get_settings_for_display()
+        return Response(SettingSerializer(data).data)
+
+    @extend_schema(
+        description="Partially update application settings",
+        request=SettingSerializer,
+        responses={
+            status.HTTP_200_OK: OpenApiResponse(
+                SettingSerializer,
+                description="Return updated settings.",
+            ),
+        },
+    )
+    def patch(self, request: Request):
+        serializer = SettingSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        settings_registry.db_update_settings(serializer.validated_data)
+
+        return self.get(None)

--- a/tests/integration/api/test_application_setting.py
+++ b/tests/integration/api/test_application_setting.py
@@ -1,0 +1,77 @@
+#  Copyright 2024 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from aap_eda.conf import settings_registry
+from tests.integration.constants import api_url_v1
+
+
+@pytest.fixture(autouse=True)
+def register() -> None:
+    settings_registry.persist_registry_data()
+
+
+def list_settings(client: APIClient, path: str):
+    response = client.get(path)
+    assert response.status_code == status.HTTP_200_OK
+    data = response.data
+    assert len(data) == 10
+    assert data["INSIGHTS_TRACKING_STATE"] is False
+    assert data["AUTOMATION_ANALYTICS_GATHER_INTERVAL"] == 14400
+
+
+def update_settings(client: APIClient, path: str):
+    pword = "secret"
+    body = {"REDHAT_USERNAME": "auser", "REDHAT_PASSWORD": pword}
+    response = client.patch(path, data=body)
+    assert response.status_code == status.HTTP_200_OK
+    data = response.data
+    assert len(data) == 10
+    assert data["REDHAT_USERNAME"] == "auser"
+    assert data["REDHAT_PASSWORD"] == "$encrypted$"
+
+
+@pytest.mark.django_db
+def test_list_all_settings(superuser_client: APIClient):
+    list_settings(superuser_client, f"{api_url_v1}/settings/all/")
+
+
+@pytest.mark.django_db
+def test_partial_update_all_settings(superuser_client: APIClient):
+    update_settings(superuser_client, f"{api_url_v1}/settings/all/")
+
+
+@pytest.mark.django_db
+def test_list_system_settings(superuser_client: APIClient):
+    list_settings(superuser_client, f"{api_url_v1}/settings/system/")
+
+
+@pytest.mark.django_db
+def test_partial_update_system_settings(superuser_client: APIClient):
+    update_settings(superuser_client, f"{api_url_v1}/settings/system/")
+
+
+@pytest.mark.django_db
+def test_list_settings_forbidden(user_client: APIClient):
+    response = user_client.get(f"{api_url_v1}/settings/system/")
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_update_settings_forbidden(user_client: APIClient):
+    response = user_client.patch(f"{api_url_v1}/settings/system/", {})
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -74,6 +74,7 @@ def super_user():
         password="superuser123",
         email="superuser@localhost",
         is_superuser=True,
+        is_staff=True,
     )
 
 


### PR DESCRIPTION
Only admin is allowed to list or update settings.
initially all/ and system/ are identical. all/ may expand in the future.

AAP-30794: new eda settings API endpoint