### PR TITLE
feat: [AAP-32189] Collect event streams used by each activation

### DIFF
--- a/tests/integration/analytics/test_analytics_collectors.py
+++ b/tests/integration/analytics/test_analytics_collectors.py
@@ -67,14 +67,13 @@ def test_internal_infra_files():
             data_collection_status_csv, encoding="utf-8"
         )
 
-        assert len(config_json.keys()) == 5
+        assert len(config_json.keys()) == 4
         for key in config_json.keys():
             assert key in [
                 "install_uuid",
                 "platform",
                 "eda_log_level",
                 "eda_version",
-                "eda_deployment_type",
             ]
         assert manifest_json["config.json"] == "1.0"
         assert manifest_json["data_collection_status.csv"] == "1.0"
@@ -470,15 +469,7 @@ def test_event_streams_table_collector(
                 "name",
                 "event_stream_type",
                 "eda_credential_id",
-                "additional_data_headers",
-                "test_mode",
-                "test_content_type",
-                "test_content",
-                "test_headers",
-                "test_error_message",
-                "owner_id",
                 "uuid",
-                "url",
                 "created_at",
                 "modified_at",
                 "events_received",
@@ -515,24 +506,23 @@ def test_event_streams_table_by_activation_collector(
             lines = list(reader)
 
             assert header == [
-                "activation_id",
-                "event_stream_id",
                 "name",
                 "event_stream_type",
                 "eda_credential_id",
-                "owner_id",
                 "events_received",
                 "last_event_received_at",
                 "organization_id",
+                "event_stream_id",
+                "activation_id",
             ]
             assert len(lines) == 2
-            assert lines[0][1] == str(default_event_streams[0].id)
-            assert lines[0][2] == default_event_streams[0].name
-            assert lines[0][3] == default_event_streams[0].event_stream_type
-            assert lines[1][1] == str(default_event_streams[1].id)
-            assert lines[1][2] == default_event_streams[1].name
-            assert lines[1][3] == default_event_streams[1].event_stream_type
-            assert sorted([lines[0][0], lines[1][0]]) == sorted(
+            assert lines[0][0] == default_event_streams[0].name
+            assert lines[0][1] == default_event_streams[0].event_stream_type
+            assert lines[0][6] == str(default_event_streams[0].id)
+            assert lines[1][0] == default_event_streams[1].name
+            assert lines[1][1] == default_event_streams[1].event_stream_type
+            assert lines[1][6] == str(default_event_streams[1].id)
+            assert sorted([lines[0][7], lines[1][7]]) == sorted(
                 [str(default_activation.id), str(new_activation.id)]
             )
 

--- a/tests/integration/analytics/test_analytics_collectors.py
+++ b/tests/integration/analytics/test_analytics_collectors.py
@@ -491,6 +491,53 @@ def test_event_streams_table_collector(
 
 
 @pytest.mark.django_db
+def test_event_streams_table_by_activation_collector(
+    default_activation: models.Activation,
+    new_activation: models.Activation,
+    default_event_streams: list[models.EventStream],
+):
+    default_activation.event_streams.add(default_event_streams[0])
+    new_activation.event_streams.add(default_event_streams[1])
+
+    until = now()
+    time_start = until - timedelta(hours=9)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        collectors.event_streams_by_activation_table(
+            time_start, tmpdir, until=now() + timedelta(seconds=1)
+        )
+        with open(
+            os.path.join(tmpdir, "event_streams_by_activation_table.csv")
+        ) as f:
+            reader = csv.reader(f)
+
+            header = next(reader)
+            lines = list(reader)
+
+            assert header == [
+                "activation_id",
+                "event_stream_id",
+                "name",
+                "event_stream_type",
+                "eda_credential_id",
+                "owner_id",
+                "events_received",
+                "last_event_received_at",
+                "organization_id",
+            ]
+            assert len(lines) == 2
+            assert lines[0][1] == str(default_event_streams[0].id)
+            assert lines[0][2] == default_event_streams[0].name
+            assert lines[0][3] == default_event_streams[0].event_stream_type
+            assert lines[1][1] == str(default_event_streams[1].id)
+            assert lines[1][2] == default_event_streams[1].name
+            assert lines[1][3] == default_event_streams[1].event_stream_type
+            assert sorted([lines[0][0], lines[1][0]]) == sorted(
+                [str(default_activation.id), str(new_activation.id)]
+            )
+
+
+@pytest.mark.django_db
 def test_projects_table_collector(
     default_project: models.Project,
 ):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1170,6 +1170,7 @@ def default_event_streams(
             models.EventStream(
                 uuid=uuid.uuid4(),
                 name="test-es-1",
+                event_stream_type=default_hmac_credential.credential_type.kind,
                 owner=default_user,
                 organization=default_organization,
                 url=DUMMY_URL,
@@ -1179,6 +1180,7 @@ def default_event_streams(
             models.EventStream(
                 uuid=uuid.uuid4(),
                 name="another-test-es-2",
+                event_stream_type=default_hmac_credential.credential_type.kind,
                 owner=default_user,
                 organization=default_organization,
                 url=DUMMY_URL,


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-32189

The collected data is stored at event_streams_by_activation_table.csv in the tar file. It looks like:

![image](https://github.com/user-attachments/assets/ae9c0753-b957-4843-a44f-caf62cb6e386)

