### PR TITLE
feat: add a periodic task to run gather_analytics

### DIFF
--- a/src/aap_eda/analytics/analytics_collectors.py
+++ b/src/aap_eda/analytics/analytics_collectors.py
@@ -5,10 +5,10 @@ from datetime import datetime
 import distro
 from ansible_base.resource_registry.models.service_identifier import service_id
 from django.conf import settings
+from django.db import connection
 from django.db.models import Manager, Q
 from insights_analytics_collector import CsvFileSplitter, register
 
-from aap_eda.analytics.collector import AnalyticsCollector
 from aap_eda.core import models
 from aap_eda.utils import get_eda_version
 
@@ -352,7 +352,7 @@ def _get_audit_action_qs(since: datetime, until: datetime):
 def _copy_table(table, query, path):
     file_path = os.path.join(path, table + "_table.csv")
     file = CsvFileSplitter(filespec=file_path)
-    with AnalyticsCollector.db_connection().cursor() as cursor:
+    with connection.cursor() as cursor:
         with cursor.copy(query) as copy:
             while data := copy.read():
                 byte_data = bytes(data)

--- a/src/aap_eda/core/management/commands/gather_analytics.py
+++ b/src/aap_eda/core/management/commands/gather_analytics.py
@@ -13,13 +13,12 @@
 #  limitations under the License.
 
 import logging
+from datetime import timezone
 
 from dateutil import parser
 from django.core.management.base import BaseCommand, CommandParser
-from django.utils import timezone
 
-from aap_eda.analytics import analytics_collectors
-from aap_eda.analytics.collector import AnalyticsCollector
+from aap_eda.analytics import collector
 
 
 class Command(BaseCommand):
@@ -90,12 +89,13 @@ class Command(BaseCommand):
             self.logger.error("Either --ship or --dry-run needs to be set.")
             return
 
-        collector = AnalyticsCollector(
-            collector_module=analytics_collectors,
-            collection_type="manual" if opt_ship else "dry-run",
+        collection_type = "manual" if opt_ship else "dry-run"
+        tgzfiles = collector.gather(
+            collection_type=collection_type,
+            since=since,
+            until=until,
             logger=self.logger,
         )
-        tgzfiles = collector.gather(since=since, until=until)
 
         if not tgzfiles:
             self.logger.info("No analytics collected")

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -517,7 +517,12 @@ RQ_QUEUES = get_rq_queues()
 # Otherwise, the default name is used
 RULEBOOK_QUEUE_NAME = settings.get("RULEBOOK_QUEUE_NAME", "activation")
 
-RQ_STARTUP_JOBS = []
+RQ_STARTUP_JOBS = [
+    {
+        "func": "aap_eda.tasks.analytics.schedule_gather_analytics",
+        "job_id": "start_analytics_scheduler",
+    },
+]
 
 # Id of the scheduler job it's required when we have multiple instances of
 # the scheduler running to avoid duplicate jobs

--- a/src/aap_eda/tasks/analytics.py
+++ b/src/aap_eda/tasks/analytics.py
@@ -1,0 +1,78 @@
+#  Copyright 2024 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+from datetime import datetime, timezone
+
+import django_rq
+from rq.exceptions import NoSuchJobError
+
+from aap_eda.analytics import collector
+from aap_eda.conf import application_settings
+from aap_eda.core.tasking import Job, unique_enqueue
+
+logger = logging.getLogger(__name__)
+
+
+ANALYTICS_SCHEDULE_JOB_ID = "gather_analytics"
+ANALYTICS_JOB_ID = "job_gather_analytics"
+ANALYTICS_TASKS_QUEUE = "default"
+
+
+def schedule_gather_analytics() -> None:
+    scheduler = django_rq.get_scheduler()
+    func = "aap_eda.tasks.analytics.gather_analytics"
+    scheduled_time = datetime.now(timezone.utc)
+    interval = application_settings.AUTOMATION_ANALYTICS_GATHER_INTERVAL
+    logger.info(
+        f"Adding periodic job {ANALYTICS_SCHEDULE_JOB_ID} "
+        f"to run every {interval} seconds"
+    )
+    scheduler.schedule(
+        scheduled_time=scheduled_time,
+        func=func,
+        interval=interval,
+        id=ANALYTICS_SCHEDULE_JOB_ID,
+    )
+
+
+def reschedule_gather_analytics(new_interval: int, serializer=None) -> None:
+    try:
+        job = Job.fetch(ANALYTICS_SCHEDULE_JOB_ID, serializer=serializer)
+    except NoSuchJobError:
+        logger.warning(f"Job {ANALYTICS_SCHEDULE_JOB_ID} does not exist")
+        return
+    job.meta["interval"] = new_interval
+    job.save()
+    logger.info(
+        f"Reconfigure periodic job {ANALYTICS_SCHEDULE_JOB_ID} with "
+        f"new interval {new_interval} seconds"
+    )
+
+
+def gather_analytics(queue_name: str = ANALYTICS_TASKS_QUEUE) -> None:
+    logger.info("Queue EDA analytics")
+    unique_enqueue(queue_name, ANALYTICS_JOB_ID, _gather_analytics)
+
+
+def _gather_analytics() -> None:
+    if not application_settings.INSIGHTS_TRACKING_STATE:
+        logger.info("INSIGHTS_TRACKING_STATE is not enabled")
+        return
+    logger.info("Collecting EDA analytics")
+    tgzfiles = collector.gather(logger=logger)
+    if not tgzfiles:
+        logger.info("No analytics collected")
+        return
+    logger.info("Analytics collection is done")

--- a/tests/integration/tasks/test_analytics.py
+++ b/tests/integration/tasks/test_analytics.py
@@ -1,0 +1,85 @@
+#  Copyright 2024 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+
+import pytest
+from rq.serializers import DefaultSerializer
+
+from aap_eda.conf import application_settings, settings_registry
+from aap_eda.core.tasking import DefaultWorker, Job, Queue, Scheduler
+from aap_eda.tasks import analytics
+
+
+@pytest.fixture(autouse=True)
+def register() -> None:
+    settings_registry.persist_registry_data()
+    return None
+
+
+@pytest.mark.django_db
+def test_gather_analytics(default_queue: Queue):
+    with mock.patch("aap_eda.analytics.collector.gather") as mock_method:
+        # purposely fail the gather() method in order to assert it gets called
+        mock_method.side_effect = AssertionError("gather called")
+        application_settings.INSIGHTS_TRACKING_STATE = True
+        default_queue.enqueue(analytics.gather_analytics, default_queue.name)
+
+        worker = DefaultWorker(
+            [default_queue], connection=default_queue.connection
+        )
+        worker.work(burst=True)
+
+        job = Job.fetch(analytics.ANALYTICS_JOB_ID, default_queue.connection)
+        result = job.latest_result()
+        assert "AssertionError: gather called" in result.exc_string
+        assert result.type == result.Type.FAILED
+
+
+@pytest.mark.django_db
+def test_schedule_and_reschedule(default_queue: Queue):
+    scheduler = Scheduler(
+        queue_name=default_queue.name, connection=default_queue.connection
+    )
+    with mock.patch(
+        "aap_eda.tasks.analytics.django_rq.get_scheduler",
+        return_value=scheduler,
+    ):
+        analytics.schedule_gather_analytics()
+        scheduler.run(burst=True)
+        job = Job.fetch(
+            analytics.ANALYTICS_SCHEDULE_JOB_ID,
+            default_queue.connection,
+            serializer=DefaultSerializer,
+        )
+        # the first job scheduled to run immediately
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        assert abs(job.enqueued_at - now) < timedelta(seconds=1)
+        assert (
+            job.meta["interval"]
+            == application_settings.AUTOMATION_ANALYTICS_GATHER_INTERVAL
+        )
+
+        analytics.reschedule_gather_analytics(
+            500, serializer=DefaultSerializer
+        )
+        job.refresh()
+        assert job.meta["interval"] == 500
+
+
+@pytest.mark.django_db
+def test_reschedule_without_scheduler():
+    # should not raise any error
+    analytics.reschedule_gather_analytics(500)


### PR DESCRIPTION
Run the task with internval set to AUTOMATION_ANALYTICS_GATHER_INTERVAL. Admin is able to change the interval and auto reschedule without restart

AAP-31635: Create a scheduler task to collect and send analytics data