### PR TITLE
Add support for some more missing settings

### DIFF
--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -690,9 +690,21 @@ ANSIBLE_BASE_JWT_KEY = settings.get(
     "ANSIBLE_BASE_JWT_KEY", "https://localhost"
 )
 
-ALLOW_LOCAL_RESOURCE_MANAGEMENT = settings.get(
-    "ALLOW_LOCAL_RESOURCE_MANAGEMENT", True
-)
+# These settings have defaults in DAB
+# if the file or env var does not define them, leave as default
+if settings.exists("ALLOW_LOCAL_RESOURCE_MANAGEMENT"):
+    ALLOW_LOCAL_RESOURCE_MANAGEMENT = settings.get(
+        "ALLOW_LOCAL_RESOURCE_MANAGEMENT"
+    )
+
+if settings.exists("RESOURCE_SERVICE_PATH"):
+    RESOURCE_SERVICE_PATH = settings.get("RESOURCE_SERVICE_PATH")
+
+if settings.exists("RESOURCE_SERVER_SYNC_ENABLED"):
+    RESOURCE_SERVER_SYNC_ENABLED = settings.get("RESOURCE_SERVER_SYNC_ENABLED")
+
+if settings.exists("ENABLE_SERVICE_BACKED_SSO"):
+    ENABLE_SERVICE_BACKED_SSO = settings.get("ENABLE_SERVICE_BACKED_SSO")
 
 # ---------------------------------------------------------
 # DJANGO ANSIBLE BASE RESOURCES REGISTRY SETTINGS
@@ -734,14 +746,6 @@ RESOURCE_SERVER = {
 }
 RESOURCE_JWT_USER_ID = settings.get("RESOURCE_JWT_USER_ID", None)
 
-try:
-    service_path_default = RESOURCE_SERVICE_PATH  # noqa
-except NameError:
-    service_path_default = None
-
-RESOURCE_SERVICE_PATH = settings.get(
-    "RESOURCE_SERVICE_PATH", service_path_default
-)
 ANSIBLE_BASE_MANAGED_ROLE_REGISTRY = settings.get(
     "ANSIBLE_BASE_MANAGED_ROLE_REGISTRY", {}
 )


### PR DESCRIPTION
What I got merged in https://github.com/ansible/eda-server/pull/1059 was necessary, but didn't process everything that we needed. This should have been obvious to me, but the way I was testing didn't make everything immediately break at the time.

I'm trying to use a new method with `settings.exists` here, which I think it way way nicer than catching `NameError`. I haven't tested that it works with env vars (I'm pretty sure it will), but I'll try to post a confirmation of that soon.