### PR TITLE
fix: [AAP-30827] - validate the event_stream_type with credential_type in creating event streams

### DIFF
--- a/src/aap_eda/api/serializers/event_stream.py
+++ b/src/aap_eda/api/serializers/event_stream.py
@@ -31,6 +31,23 @@ class EventStreamInSerializer(serializers.ModelSerializer):
         ],
     )
 
+    def validate(self, data):
+        eda_credential_id = data.get("eda_credential_id")
+        if not eda_credential_id:
+            return data
+
+        credential = models.EdaCredential.objects.get(id=eda_credential_id)
+        kind = credential.credential_type.kind
+
+        event_stream_type = data.get("event_stream_type")
+        if kind != event_stream_type:
+            raise serializers.ValidationError(
+                f"The input event stream type {event_stream_type} does not "
+                f"match with the credential type {kind}"
+            )
+
+        return data
+
     class Meta:
         model = models.EventStream
         fields = [

--- a/tests/integration/api/test_event_stream_basic.py
+++ b/tests/integration/api/test_event_stream_basic.py
@@ -58,6 +58,7 @@ def test_post_event_stream_with_basic_auth(
     data_in = {
         "name": "test-es-1",
         "eda_credential_id": obj["id"],
+        "event_stream_type": obj["credential_type"]["kind"],
         "organization_id": get_default_test_org().id,
         "test_mode": True,
     }

--- a/tests/integration/api/test_event_stream_ecdsa.py
+++ b/tests/integration/api/test_event_stream_ecdsa.py
@@ -90,6 +90,7 @@ def test_post_event_stream_with_ecdsa(
     data_in = {
         "name": "test-es-1",
         "eda_credential_id": obj["id"],
+        "event_stream_type": obj["credential_type"]["kind"],
         "organization_id": get_default_test_org().id,
         "test_mode": True,
     }

--- a/tests/integration/api/test_event_stream_oauth2.py
+++ b/tests/integration/api/test_event_stream_oauth2.py
@@ -67,6 +67,7 @@ def test_post_event_stream_with_oauth2(
     data_in = {
         "name": "test-es-1",
         "eda_credential_id": obj["id"],
+        "event_stream_type": obj["credential_type"]["kind"],
         "organization_id": get_default_test_org().id,
         "test_mode": True,
     }

--- a/tests/integration/api/test_event_stream_oauth2_jwt.py
+++ b/tests/integration/api/test_event_stream_oauth2_jwt.py
@@ -60,6 +60,7 @@ def test_post_event_stream_with_oauth2_jwt(
     data_in = {
         "name": "test-es-1",
         "eda_credential_id": obj["id"],
+        "event_stream_type": obj["credential_type"]["kind"],
         "organization_id": get_default_test_org().id,
         "test_mode": True,
     }

--- a/tests/integration/api/test_event_stream_token.py
+++ b/tests/integration/api/test_event_stream_token.py
@@ -57,6 +57,7 @@ def test_post_event_stream_with_token(
     data_in = {
         "name": "test-es-1",
         "eda_credential_id": obj["id"],
+        "event_stream_type": obj["credential_type"]["kind"],
         "organization_id": get_default_test_org().id,
         "test_mode": True,
     }
@@ -102,6 +103,7 @@ def test_post_event_stream_with_test_mode_extra_headers(
     data_in = {
         "name": "test-es-1",
         "eda_credential_id": obj["id"],
+        "event_stream_type": obj["credential_type"]["kind"],
         "organization_id": get_default_test_org().id,
         "test_mode": True,
         "additional_data_headers": additional_data_headers,


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-30827

Raise validation error if the `event_stream_type` of event streams doesn't match with the `kind` attribute of its related `credential_type` during creating time.