### PR TITLE
fix: allow event streams be filtered by test_mode

### DIFF
--- a/src/aap_eda/api/filters/event_stream.py
+++ b/src/aap_eda/api/filters/event_stream.py
@@ -23,6 +23,10 @@ class EventStreamFilter(django_filters.FilterSet):
         lookup_expr="istartswith",
         label="Filter by event stream name.",
     )
+    test_mode = django_filters.BooleanFilter(
+        field_name="test_mode",
+        label="Filter by the test_mode being true or false",
+    )
 
     class Meta:
         model = models.EventStream

--- a/tests/integration/api/test_event_stream.py
+++ b/tests/integration/api/test_event_stream.py
@@ -40,6 +40,35 @@ def test_list_event_streams(
 
 
 @pytest.mark.django_db
+def test_list_event_streams_filter_test_mode(
+    admin_client: APIClient,
+    default_event_streams: List[models.EventStream],
+    default_vault_credential,
+):
+    response = admin_client.get(f"{api_url_v1}/event-streams/?test_mode=true")
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data["results"]) == 1
+    assert response.data["results"][0]["test_mode"] is True
+
+    response = admin_client.get(f"{api_url_v1}/event-streams/?test_mode=false")
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data["results"]) == 1
+    assert response.data["results"][0]["test_mode"] is False
+
+
+@pytest.mark.django_db
+def test_list_event_streams_filter_name(
+    admin_client: APIClient,
+    default_event_streams: List[models.EventStream],
+    default_vault_credential,
+):
+    response = admin_client.get(f"{api_url_v1}/event-streams/?name=another")
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data["results"]) == 1
+    assert response.data["results"][0]["name"].startswith("another")
+
+
+@pytest.mark.django_db
 def test_retrieve_event_stream(
     admin_client: APIClient,
     default_event_streams: List[models.EventStream],

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1185,14 +1185,16 @@ def default_event_streams(
                 organization=default_organization,
                 url=DUMMY_URL,
                 eda_credential=default_hmac_credential,
+                test_mode=False,
             ),
             models.EventStream(
                 uuid=uuid.uuid4(),
-                name="test-es-2",
+                name="another-test-es-2",
                 owner=default_user,
                 organization=default_organization,
                 url=DUMMY_URL,
                 eda_credential=default_hmac_credential,
+                test_mode=True,
             ),
         ]
     )


### PR DESCRIPTION
AAP-30356: Allow filtering of event streams based on the test_mode flag