### PR TITLE
feat: [AAP-32877] - Collect activations stats data

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -684,6 +684,7 @@ def new_activation(
         organization=default_organization,
         user=default_user,
         log_level="debug",
+        status="completed",
     )
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-32877

For each activation, we collect its `name, id, status, restart_count, failure_count, log_level, organization_id, created_at, ended_at` (empty for those active activations), `counts`, and `max_retry_count`.

The `activations_stats_table.csv` has following columns:

![image](https://github.com/user-attachments/assets/a54be97d-136b-4c30-af75-fd9edbcce23c)
