### PR TITLE
ci: remove podman data persistence for docker-compose

### DIFF
--- a/tools/docker/docker-compose-dev-redis-tls.yaml
+++ b/tools/docker/docker-compose-dev-redis-tls.yaml
@@ -51,27 +51,13 @@ x-environment:
 
 
 services:
-  podman-pre-setup:
-    user: "0"
-    image: ${EDA_PODMAN_IMAGE:-quay.io/containers/podman}:${EDA_PODMAN_VERSION:-v4}
-    privileged: true
-    command: >-
-      chown -R podman /home/podman/.local/share/containers/storage
-    volumes:
-      - 'podman_data:/home/podman/.local/share/containers/storage'
-
   podman:
-    user: "1000"
     image: ${EDA_PODMAN_IMAGE:-quay.io/containers/podman}:${EDA_PODMAN_VERSION:-v4}
     privileged: true
     command: >-
       podman system service --time=0 tcp://0.0.0.0:8888
     ports:
       - "${EDA_PODMAN_PORT:-8888}:8888"
-    volumes:
-      - 'podman_data:/home/podman/.local/share/containers/storage'
-    depends_on:
-     - podman-pre-setup
 
   certs:
     image: ${EDA_CERTBOT_IMAGE:-certbot/certbot}:${EDA_CERTBOT_VERSION:-latest}
@@ -262,4 +248,3 @@ services:
 
 volumes:
   postgres_data: {}
-  podman_data: {}

--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -54,49 +54,21 @@ x-environment: &common-env
   SSL_CLIENT_CERTIFICATE: ${SSL_CLIENT_CERTIFICATE:-/certs/client.crt}
 
 services:
-  podman-pre-setup-node1:
-    user: "0"
-    image: ${EDA_PODMAN_IMAGE:-quay.io/containers/podman}:${EDA_PODMAN_VERSION:-v4}
-    privileged: true
-    command: >-
-      chown -R podman /home/podman/.local/share/containers/storage
-    volumes:
-      - 'podman_data_node1:/home/podman/.local/share/containers/storage'
-
-  podman-pre-setup-node2:
-    user: "0"
-    image: ${EDA_PODMAN_IMAGE:-quay.io/containers/podman}:${EDA_PODMAN_VERSION:-v4}
-    privileged: true
-    command: >-
-      chown -R podman /home/podman/.local/share/containers/storage
-    volumes:
-      - 'podman_data_node2:/home/podman/.local/share/containers/storage'
-
   podman-node1:
-    user: "1000"
     image: ${EDA_PODMAN_IMAGE:-quay.io/containers/podman}:${EDA_PODMAN_VERSION:-v4}
     privileged: true
     command: >-
       podman system service --time=0 tcp://0.0.0.0:8888
     ports:
       - "${EDA_PODMAN_NODE1_PORT:-8888}:8888"
-    volumes:
-      - 'podman_data_node1:/home/podman/.local/share/containers/storage'
-    depends_on:
-     - podman-pre-setup-node1
 
   podman-node2:
-    user: "1000"
     image: ${EDA_PODMAN_IMAGE:-quay.io/containers/podman}:${EDA_PODMAN_VERSION:-v4}
     privileged: true
     command: >-
       podman system service --time=0 tcp://0.0.0.0:8888
     ports:
       - "${EDA_PODMAN_NODE2_PORT:-8889}:8888"
-    volumes:
-      - 'podman_data_node2:/home/podman/.local/share/containers/storage'
-    depends_on:
-     - podman-pre-setup-node2
 
   postgres:
     image: ${EDA_POSTGRES_IMAGE:-quay.io/sclorg/postgresql-15-c9s}:${EDA_POSTGRES_VERSION:-latest}
@@ -303,8 +275,6 @@ services:
 
 volumes:
   postgres_data: {}
-  podman_data_node1: {}
-  podman_data_node2: {}
 
 networks:
   service-mesh:

--- a/tools/docker/docker-compose-stage.yaml
+++ b/tools/docker/docker-compose-stage.yaml
@@ -46,27 +46,13 @@ x-environment:
   - SSL_CLIENT_CERTIFICATE=${SSL_CLIENT_CERTIFICATE:-/certs/client.crt}
 
 services:
-  podman-pre-setup:
-    user: "0"
-    image: ${EDA_PODMAN_IMAGE:-quay.io/containers/podman}:${EDA_PODMAN_VERSION:-v4}
-    privileged: true
-    command: >-
-      chown -R podman /home/podman/.local/share/containers/storage
-    volumes:
-      - 'podman_data:/home/podman/.local/share/containers/storage'
-
   podman:
-    user: "1000"
     image: ${EDA_PODMAN_IMAGE:-quay.io/containers/podman}:${EDA_PODMAN_VERSION:-v4}
     privileged: true
     command: >-
       podman system service --time=0 tcp://0.0.0.0:8888
     ports:
       - '${EDA_PODMAN_PORT:-8888}:8888'
-    volumes:
-      - 'podman_data:/home/podman/.local/share/containers/storage'
-    depends_on:
-     - podman-pre-setup
 
   postgres:
     image: ${EDA_POSTGRES_IMAGE:-quay.io/sclorg/postgresql-15-c9s}:${EDA_POSTGRES_VERSION:-latest}
@@ -237,7 +223,6 @@ services:
 
 volumes:
   postgres_data: {}
-  podman_data: {}
   eda-api-staticfiles: {}
 
 networks:


### PR DESCRIPTION
The persisting data for podman was added just as enhancement to not download the DE's every time the environment is restarted. 
This is generating more problems than solutions specially supporting cross compatibility between podman and docker. Its benefit is debatable since many of our workflows already removes the volumes. Now, for a reason that I couldn't figure out 100% (and because I don't want to spend more time on it) GH workflows are failing running podman so several e2e tests fails due to error connections to the podman socket. 

So, I think the best solution is just remove the persisted data for podman and simplify its deployment. 