### PR TITLE
fix: use quote with safe="" for user/secret in urls

### DIFF
--- a/src/aap_eda/services/project/scm.py
+++ b/src/aap_eda/services/project/scm.py
@@ -206,7 +206,7 @@ class ScmRepository:
             msg = str(e)
             if secret:
                 msg = msg.replace(secret, "****", 1)
-                msg = msg.replace(quote(secret), "****", 1)
+                msg = msg.replace(quote(secret, safe=""), "****", 1)
             logger.warning("SCM clone failed: %s", msg)
             raise ScmError(msg) from None
         finally:
@@ -232,11 +232,11 @@ class ScmRepository:
             return url
 
         if user and password:
-            encoded_user = quote(user)
-            encoded_password = quote(password)
+            encoded_user = quote(user, safe="")
+            encoded_password = quote(password, safe="")
             domain = f"{encoded_user}:{encoded_password}@{domain}"
         elif password:
-            encoded_token = quote(password)
+            encoded_token = quote(password, safe="")
             domain = f"{encoded_token}@{domain}"
 
         unparsed = (


### PR DESCRIPTION
quote considers "/" safe by default.