### PR TITLE
feat: [AAP-33453] - Collect the stats data of jobs which launched by the EDA

### DIFF
--- a/src/aap_eda/analytics/package.py
+++ b/src/aap_eda/analytics/package.py
@@ -39,7 +39,7 @@ class Package(InsightsAnalyticsPackage):
         self._check_users()
         user_name = (
             application_settings.REDHAT_USERNAME
-            | application_settings.SUBSCRIPTIONS_USERNAME
+            or application_settings.SUBSCRIPTIONS_USERNAME
         )
 
         return user_name
@@ -48,7 +48,7 @@ class Package(InsightsAnalyticsPackage):
         self._check_users()
         user_password = (
             application_settings.REDHAT_PASSWORD
-            | application_settings.SUBSCRIPTIONS_PASSWORD
+            or application_settings.SUBSCRIPTIONS_PASSWORD
         )
 
         return user_password

--- a/src/aap_eda/analytics/utils.py
+++ b/src/aap_eda/analytics/utils.py
@@ -12,7 +12,19 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import base64
+import logging
+import re
+from typing import Optional, Tuple
+
+import requests
+import yaml
 from django.utils.dateparse import parse_datetime
+
+from aap_eda.core import enums, models
+from aap_eda.utils import str_to_bool
+
+logger = logging.getLogger("aap_eda.analytics")
 
 
 def datetime_hook(dt: dict) -> dict:
@@ -23,3 +35,72 @@ def datetime_hook(dt: dict) -> dict:
         except TypeError:
             new_dt[key] = value
     return new_dt
+
+
+def collect_controllers_info() -> dict:
+    aap_credentia_type = models.CredentialType.objects.get(
+        name=enums.DefaultCredentialType.AAP
+    )
+    credentials = models.EdaCredential.objects.filter(
+        credential_type=aap_credentia_type
+    )
+    info = {}
+    for credential in credentials:
+        controller_info = {}
+        inputs = yaml.safe_load(credential.inputs.get_secret_value())
+        host = inputs["host"]
+        url = f"{host}/api/v2/ping/"
+        verify = str_to_bool(inputs.get("verify_ssl", ""))
+        token = inputs.get("oauth_token")
+
+        controller_info["credential_id"] = credential.id
+        controller_info["inputs"] = inputs
+        if token:
+            headers = {"Authorization": f"Bearer {token}"}
+            logger.info("Use Bearer token to ping the controller.")
+        else:
+            user_pass = f"{inputs.get('username')}:{inputs.get('password')}"
+            auth_value = (
+                f"Basic {base64.b64encode(user_pass.encode()).decode()}"
+            )
+            headers = {"Authorization": f"{auth_value}"}
+            logger.info("Use Basic authentication to ping the controller.")
+
+        try:
+            resp = requests.get(url, headers=headers, verify=verify)
+            resp_json = resp.json()
+            controller_info["install_uuid"] = resp_json["install_uuid"]
+
+            info[host] = controller_info
+        except requests.exceptions.RequestException as e:
+            logger.warning(
+                "Failed to connect with controller using credential "
+                f"{credential.name}: {e}"
+            )
+
+    return info
+
+
+def extract_job_details(
+    url: str,
+    controllers_info: dict,
+) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    for host, info in controllers_info.items():
+        if not url.startswith(host):
+            continue
+
+        pattern = r"/jobs/([a-zA-Z]+)/(\d+)/"
+
+        match = re.search(pattern, url)
+
+        if match:
+            job_type = match.group(1)
+            job_type = (
+                "run_job_template"
+                if job_type == "playbook"
+                else "run_workflow_template"
+            )
+            job_number = match.group(2)
+            return job_type, str(job_number), info["install_uuid"]
+
+    return None, None, None

--- a/tests/integration/analytics/conftest.py
+++ b/tests/integration/analytics/conftest.py
@@ -1,0 +1,65 @@
+#  Copyright 2024 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from typing import List
+
+import pytest
+
+from aap_eda.core import enums, models
+from aap_eda.core.utils.credentials import inputs_to_store
+
+
+@pytest.fixture
+def aap_credentials(
+    default_organization: models.Organization,
+    preseed_credential_types,
+) -> List[models.EdaCredential]:
+    """Return two RH AAP Credentials"""
+    aap_credential_type = models.CredentialType.objects.get(
+        name=enums.DefaultCredentialType.AAP
+    )
+
+    data = "secret"
+
+    return models.EdaCredential.objects.bulk_create(
+        [
+            models.EdaCredential(
+                name="aap-credential-1",
+                description="First RH-AAP Credential",
+                inputs=inputs_to_store(
+                    {
+                        "host": "https://first_eda_controller_url",
+                        "ssl_verify": "no",
+                        "oauth_token": "token",
+                    }
+                ),
+                credential_type=aap_credential_type,
+                organization=default_organization,
+            ),
+            models.EdaCredential(
+                name="aap-credential-2",
+                description="Second RH-AAP Credential",
+                inputs=inputs_to_store(
+                    {
+                        "host": "https://second_eda_controller_url",
+                        "username": "adam",
+                        "password": data,
+                        "ssl_verify": "no",
+                        "oauth_token": "",
+                    }
+                ),
+                credential_type=aap_credential_type,
+                organization=default_organization,
+            ),
+        ]
+    )

--- a/tests/integration/analytics/test_gather_analytics.py
+++ b/tests/integration/analytics/test_gather_analytics.py
@@ -83,32 +83,32 @@ def test_gather_analytics_invalid_settings(
         (
             ("--dry-run", "--since", "2024-08-20"),
             "INFO",
-            "No analytics collected",
+            "Analytics collection is done",
         ),
         (
             ("--dry-run", "--since", "'2024-08-20 19:44:43.622759+00'"),
             "INFO",
-            "No analytics collected",
+            "Analytics collection is done",
         ),
         (
             ("--dry-run", "--since", "'2024-08-20 19:44:43'"),
             "INFO",
-            "No analytics collected",
+            "Analytics collection is done",
         ),
         (
             ("--dry-run", "--since", "'2024-08-20 19:44:43.622759'"),
             "INFO",
-            "No analytics collected",
+            "Analytics collection is done",
         ),
         (
             ("--dry-run", "--until", "2024-09-20"),
             "INFO",
-            "No analytics collected",
+            "Analytics collection is done",
         ),
         (
             ("--dry-run", "--until", "'2024-09-20 19:44:43.622759+00'"),
             "INFO",
-            "No analytics collected",
+            "Analytics collection is done",
         ),
         (
             (
@@ -119,7 +119,7 @@ def test_gather_analytics_invalid_settings(
                 "'2024-09-20 19:44:43'",
             ),
             "INFO",
-            "No analytics collected",
+            "Analytics collection is done",
         ),
     ],
 )

--- a/tests/integration/analytics/test_utils.py
+++ b/tests/integration/analytics/test_utils.py
@@ -14,10 +14,20 @@
 
 import datetime
 import json
+import uuid
+from typing import List
+from unittest import mock
 
+import pytest
+import requests
 from django.core.serializers.json import DjangoJSONEncoder
 
-from aap_eda.analytics.utils import datetime_hook
+from aap_eda.analytics.utils import (
+    collect_controllers_info,
+    datetime_hook,
+    extract_job_details,
+)
+from aap_eda.core import models
 
 
 def test_datetime_hook():
@@ -44,3 +54,102 @@ def test_bad_datetime_hook():
 
     assert isinstance(result["started_at"], datetime.datetime) is True
     assert isinstance(result["ended_at"], datetime.datetime) is False
+
+
+def test_extract_job_details():
+    install_uuid = uuid.uuid4()
+    job_id = 8018
+
+    controllers_info = {
+        "https://controller_1/": {"install_uuid": install_uuid}
+    }
+
+    job_type, job_id, retrieved_uuid = extract_job_details(
+        f"https://controller_1/#/jobs/workflow/{job_id}/details/",
+        controllers_info,
+    )
+
+    assert job_type == "run_workflow_template"
+    assert job_id == "8018"
+    assert retrieved_uuid == install_uuid
+
+    job_type, job_id, retrieved_uuid = extract_job_details(
+        f"https://controller_1/#/jobs/playbook/{job_id}/details/",
+        controllers_info,
+    )
+    assert job_type == "run_job_template"
+    assert job_id == "8018"
+    assert retrieved_uuid == install_uuid
+
+    job_type, job_id, retrieved_uuid = extract_job_details(
+        f"https://invalid_controller/#/jobs/workflow/{job_id}/details/",
+        controllers_info,
+    )
+    assert job_type is None
+    assert job_id is None
+    assert retrieved_uuid is None
+
+    job_type, job_id, retrieved_uuid = extract_job_details(
+        "",
+        controllers_info,
+    )
+    assert job_type is None
+    assert job_id is None
+    assert retrieved_uuid is None
+
+
+@pytest.mark.django_db
+def test_collect_controller_info(
+    aap_credentials: List[models.EdaCredential],
+    default_scm_credential: models.EdaCredential,
+):
+    install_uuid_1 = str(uuid.uuid4())
+    install_uuid_2 = str(uuid.uuid4())
+    mock_resp = mock.Mock()
+    mock_resp.status_code = 200
+    mock_resp.json.side_effect = [
+        {"install_uuid": install_uuid_1},
+        {"install_uuid": install_uuid_2},
+    ]
+
+    # hosts defined in aap_credentials
+    default_host = "https://first_eda_controller_url"
+    new_host = "https://second_eda_controller_url"
+
+    with mock.patch("aap_eda.analytics.utils.logger") as mock_logger:
+        with mock.patch("aap_eda.analytics.utils.requests.get") as mock_get:
+            mock_get.return_value = mock_resp
+            data = collect_controllers_info()
+
+            assert len(data.keys()) == 2
+            assert default_host in data
+            assert data[default_host]["install_uuid"] == install_uuid_1
+            assert new_host in data
+            assert data[new_host]["install_uuid"] == install_uuid_2
+
+            assert mock_logger.info.call_count == 2
+            mock_logger.info.assert_has_calls(
+                [
+                    mock.call("Use Bearer token to ping the controller."),
+                    mock.call(
+                        "Use Basic authentication to ping the controller."
+                    ),
+                ]
+            )
+
+
+@pytest.mark.django_db
+def test_collect_controller_info_with_exception(
+    default_aap_credential: models.EdaCredential,
+):
+    with mock.patch("aap_eda.analytics.utils.logger") as mock_logger:
+        with mock.patch("aap_eda.analytics.utils.requests.get") as mock_get:
+            mock_get.side_effect = requests.exceptions.RequestException(
+                "Bad exception"
+            )
+            collect_controllers_info()
+
+            mock_logger.warning.assert_called_once_with(
+                "Failed to connect with controller using credential "
+                "default-aap-credential: Bad exception"
+            )


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-33453

The job stats data is collected and saved in the file `jobs_stats.json`. It looks like:
```
{
  "8018": [
    {
      "job_id": "8018",
      "type": "run_job_template",
      "created_at": "2023-12-14T15:19:02.319506Z",
      "status": "successful",
      "url": "https://controller_1/#/jobs/playbook/8018/details/",
      "install_uuid": "9509fade-acf8-4ff8-b5d1-6e58e01dceb9"
    },
    {
      "job_id": "8018",
      "type": "run_workflow_template",
      "created_at": "2023-12-14T15:19:02.326503Z",
      "status": "successful",
      "url": "https://controller_2/#/jobs/workflow/8018/details/",
      "install_uuid": "6e78176d-87ba-4837-9316-bf84660ca77d"
    }
  ],
  "8020": [
    {
      "job_id": "8020",
      "type": "run_workflow_template",
      "created_at": "2023-12-14T15:19:02.327547Z",
      "status": "successful",
      "url": "https://controller_1/#/jobs/workflow/8020/details/",
      "install_uuid": "9509fade-acf8-4ff8-b5d1-6e58e01dceb9"
    }
  ]
}
```