### PR TITLE
feat: enhance options for /settings/system/ API

### DIFF
--- a/src/aap_eda/api/metadata.py
+++ b/src/aap_eda/api/metadata.py
@@ -1,11 +1,34 @@
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
+from django.utils.encoding import force_str
 from rest_framework import exceptions, metadata
 from rest_framework.request import clone_request
 
+ADDITIONAL_ATTRS = [
+    "min_length",
+    "max_length",
+    "min_value",
+    "max_value",
+    "category",
+    "category_slug",
+    "defined_in_file",
+    "unit",
+    "hidden",
+    "default",
+]
+
 
 class EDAMetadata(metadata.SimpleMetadata):
-    """Overwritten to show PATCH in OPTIONS."""
+    """Overwritten to show PATCH in OPTIONS and add more attributes."""
+
+    def get_field_info(self, field):
+        field_info = super().get_field_info(field)
+
+        for attr in ADDITIONAL_ATTRS:
+            value = getattr(field, attr, None)
+            if value is not None and value != "":
+                field_info[attr] = force_str(value, strings_only=True)
+        return field_info
 
     def determine_actions(self, request, view):
         """For generic class based views we return information about.
@@ -30,8 +53,39 @@ class EDAMetadata(metadata.SimpleMetadata):
                 # If user has appropriate permissions for the view, include
                 # appropriate metadata about the fields that should be supplied
                 serializer = view.get_serializer()
-                actions[method] = self.get_serializer_info(serializer)
+                action = self.get_serializer_info(serializer)
+                EDAMetadata._customize_field_attributes(method, action)
+                actions[method] = action
             finally:
                 view.request = request
 
         return actions
+
+    @staticmethod
+    def _customize_field_attributes(method: str, action: dict):
+        for field, meta in list(action.items()):
+            if not isinstance(meta, dict):
+                continue
+
+            # For GET method, remove meta attributes that aren't relevant
+            # when reading a field and remove write-only fields.
+            if method == "GET":
+                attrs_to_remove = (
+                    "required",
+                    "read_only",
+                    "default",
+                    "min_length",
+                    "max_length",
+                )
+                for attr in attrs_to_remove:
+                    meta.pop(attr, None)
+                if meta.pop("write_only", False):
+                    action.pop(field)
+
+            # For PUT/PATCH/POST methods, remove read-only fields.
+            if method in ("PUT", "PATCH", "POST"):
+                # file-based read-only settings can't be updated
+                meta.pop("defined_in_file", False)
+
+                if meta.pop("read_only", False):
+                    action.pop(field)

--- a/tests/integration/api/test_application_setting.py
+++ b/tests/integration/api/test_application_setting.py
@@ -68,3 +68,29 @@ def test_update_settings_wrong_type(superuser_client: APIClient):
         f"{api_url_v1}/settings/system/", data=data
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_options(superuser_client: APIClient):
+    response = superuser_client.options(f"{api_url_v1}/settings/system/")
+    assert response.status_code == status.HTTP_200_OK
+    get_interval = response.data["actions"]["GET"][
+        "AUTOMATION_ANALYTICS_GATHER_INTERVAL"
+    ]
+    patch_interval = response.data["actions"]["PATCH"][
+        "AUTOMATION_ANALYTICS_GATHER_INTERVAL"
+    ]
+    for field in [get_interval, patch_interval]:
+        assert field["type"] == "integer"
+        assert field["hidden"] is False
+        assert field["label"] == "Automation Analytics Gather Interval"
+        assert (
+            field["help_text"]
+            == "Interval (in seconds) between data gathering."
+        )
+        assert field["min_value"] == 1800
+        assert field["category"] == "System"
+        assert field["category_slug"] == "system"
+        assert field["unit"] == "seconds"
+    assert get_interval["defined_in_file"] is False
+    assert patch_interval["default"] == 14400


### PR DESCRIPTION
Add customized attributes to fields from GET and PATCH method in the return body from OPTIONS method. These can be used for UI to properly render them to customer.

This implemententation returns a format compatible with how the controller returns OPTIONS request.

AAP-33164: EDA settings API needs to provide Options method.

Sample output:
```
{
    "name": "Setting",
    "description": "",
    "renders": [
        "application/json",
        "text/html"
    ],
    "parses": [
        "application/json",
        "application/x-www-form-urlencoded",
        "multipart/form-data"
    ],
    "actions": {
        "PATCH": {
            "INSIGHTS_TRACKING_STATE": {
                "type": "boolean",
                "required": false,
                "label": "Gather data for Automation Analytics",
                "help_text": "Enables the service to gather data on automation and send it to Automation Analytics.",
                "category": "System",
                "category_slug": "system",
                "hidden": false,
                "default": false
            }
        }
        "GET": {
            "INSIGHTS_TRACKING_STATE": {
                "type": "boolean",
                "label": "Gather data for Automation Analytics",
                "help_text": "Enables the service to gather data on automation and send it to Automation Analytics.",
                "category": "System",
                "category_slug": "system",
                "defined_in_file": false,
                "hidden": false
            }
        }
    }
}
```