### PR TITLE
Revert fix: add EDA_PODMAN_USER_ID env var use in compose files

### DIFF
--- a/tools/docker/docker-compose-dev-redis-tls.yaml
+++ b/tools/docker/docker-compose-dev-redis-tls.yaml
@@ -52,7 +52,6 @@ x-environment:
 
 services:
   podman:
-    user: ${EDA_PODMAN_USER_ID:-0}
     image: ${EDA_PODMAN_IMAGE:-quay.io/containers/podman}:${EDA_PODMAN_VERSION:-v4}
     privileged: true
     command: >-

--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -55,7 +55,6 @@ x-environment: &common-env
 
 services:
   podman-node1:
-    user: ${EDA_PODMAN_USER_ID:-0}
     image: ${EDA_PODMAN_IMAGE:-quay.io/containers/podman}:${EDA_PODMAN_VERSION:-v4}
     privileged: true
     command: >-
@@ -64,7 +63,6 @@ services:
       - "${EDA_PODMAN_NODE1_PORT:-8888}:8888"
 
   podman-node2:
-    user: ${EDA_PODMAN_USER_ID:-0}
     image: ${EDA_PODMAN_IMAGE:-quay.io/containers/podman}:${EDA_PODMAN_VERSION:-v4}
     privileged: true
     command: >-

--- a/tools/docker/docker-compose-stage.yaml
+++ b/tools/docker/docker-compose-stage.yaml
@@ -47,7 +47,6 @@ x-environment:
 
 services:
   podman:
-    user: ${EDA_PODMAN_USER_ID:-0}
     image: ${EDA_PODMAN_IMAGE:-quay.io/containers/podman}:${EDA_PODMAN_VERSION:-v4}
     privileged: true
     command: >-


### PR DESCRIPTION
This commit broke scheduled and dispathed e2e tests. Reverts https://github.com/ansible/eda-server/pull/1101