### PR TITLE
Revert "ci: split by platform the build image workflow"

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -19,10 +19,6 @@ jobs:
       contents: read
       packages: write
 
-    strategy:
-      matrix:
-        platform: [linux/amd64, linux/arm64]
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -60,7 +56,7 @@ jobs:
         with:
           context: .
           file: ${{ env.DOCKERFILE_PATH }}
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Reverts https://github.com/ansible/eda-server/pull/1104/
We can not use strategy here because the image must be built and pushed as multiplatform image, but here we are running different jobs with different platform and the last one overwrites the other. 

To support a multiplatform image built in split jobs more actions are needed that can be done in a different PR. Anyway this would be less critical. 

This reverts commit c9dd25b27e8a6d3e5ac450c13f29275952c0fcc1.