### PR TITLE
Only create websocket account locally

### DIFF
--- a/src/aap_eda/services/auth.py
+++ b/src/aap_eda/services/auth.py
@@ -16,6 +16,7 @@ from datetime import datetime, timedelta
 from itertools import groupby
 
 import jwt
+from ansible_base.resource_registry.signals.handlers import no_reverse_sync
 from django.conf import settings
 
 from aap_eda.core.models.user import User
@@ -46,10 +47,11 @@ def create_jwt_token() -> tuple[str, str]:
 
     They can be sent to rulebook clients through command line arguments.
     """
-    user, new = User.objects.get_or_create(
-        username="_token_service_user",
-        is_service_account=True,
-    )
+    with no_reverse_sync():
+        user, new = User.objects.get_or_create(
+            username="_token_service_user",
+            is_service_account=True,
+        )
     if new:
         user.set_unusable_password()
         user.save(update_fields=["password"])


### PR DESCRIPTION
Formally, this is a problem for the dev environment right now, so don't panic. See:

```
Traceback (most recent call last):
  File "/app/src/src/aap_eda/services/activation/activation_manager.py", line 213, in _start_activation_instance
    container_request = self._get_container_request()
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/src/src/aap_eda/services/activation/activation_manager.py", line 1033, in _get_container_request
    return self.db_instance.get_container_request()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/src/src/aap_eda/services/activation/engine/common.py", line 168, in get_container_request
    cmdline=self._build_cmdline(),
            ^^^^^^^^^^^^^^^^^^^^^
  File "/app/src/src/aap_eda/services/activation/engine/common.py", line 189, in _build_cmdline
    access_token, refresh_token = create_jwt_token()
                                  ^^^^^^^^^^^^^^^^^^
  File "/app/src/src/aap_eda/services/auth.py", line 49, in create_jwt_token
    user, new = User.objects.get_or_create(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

But eventually, this will be a real problem, that comes from related issue AAP-33341.

I tested manually with the dev environment, and found it fix the problem.