### PR TITLE
fix: set error message for project importing from a folder with no rulebooks

### DIFF
--- a/tests/integration/services/data/project-06/extensions/eda/rulebooks/README
+++ b/tests/integration/services/data/project-06/extensions/eda/rulebooks/README
@@ -1,0 +1,1 @@
+This folder purposely contains no rulebooks


### PR DESCRIPTION

AAP-34555: A message should be recorded when a project does not contain any rulebooks