### PR TITLE
fix: continue to sync rulebooks when previous sync failed

### DIFF
--- a/src/aap_eda/services/project/imports.py
+++ b/src/aap_eda/services/project/imports.py
@@ -105,7 +105,14 @@ class ProjectImportService:
     @_project_import_wrapper
     def sync_project(self, project: models.Project) -> None:
         with self._clone_and_process(project) as (repo_dir, git_hash):
-            if project.git_hash == git_hash:
+            # At this point project.import_state and
+            # project.import_error have been cleared. We are relying on
+            # project.rulebook_set to determine whether previous sync
+            # succeeded or not
+            if (
+                project.git_hash == git_hash
+                and project.rulebook_set.count() > 0
+            ):
                 logger.info(
                     "Project (id=%s, name=%s) is up to date. Nothing to sync.",
                     project.id,

--- a/tests/integration/services/test_project_import.py
+++ b/tests/integration/services/test_project_import.py
@@ -200,6 +200,17 @@ def test_project_import_rulebook_directory_missing(
     assert project.import_state == models.Project.ImportState.FAILED
     assert project.import_error == message_expected
 
+    # resync the project does not clear the import_state and import_error
+    with pytest.raises(
+        ProjectImportError,
+        match=re.escape(message_expected),
+    ):
+        service.sync_project(project)
+
+    project.refresh_from_db()
+    assert project.import_state == models.Project.ImportState.FAILED
+    assert project.import_error == message_expected
+
 
 @pytest.mark.django_db
 def test_project_import_with_no_rulebooks(


### PR DESCRIPTION
It helps to reset properly the import state and error message.

AAP-34744: Sync a previously failed project importing falsely changes the state to completed