### PR TITLE
fix: retrieve project using web browser

### DIFF
--- a/src/aap_eda/api/serializers/project.py
+++ b/src/aap_eda/api/serializers/project.py
@@ -241,40 +241,41 @@ class ProjectReadSerializer(serializers.ModelSerializer, ProxyFieldMixin):
 
     def to_representation(self, project):
         eda_credential = (
-            EdaCredentialRefSerializer(project["eda_credential"]).data
-            if project["eda_credential"]
+            EdaCredentialRefSerializer(project.eda_credential).data
+            if project.eda_credential
             else None
         )
         signature_validation_credential = (
             EdaCredentialRefSerializer(
-                project["signature_validation_credential"]
+                project.signature_validation_credential
             ).data
-            if project["signature_validation_credential"]
+            if project.signature_validation_credential
             else None
         )
         organization = (
-            OrganizationRefSerializer(project["organization"]).data
-            if project["organization"]
+            OrganizationRefSerializer(project.organization).data
+            if project.organization
             else None
         )
+
         return {
-            "id": project["id"],
-            "name": project["name"],
-            "description": project["description"],
-            "url": project["url"],
-            "proxy": project["proxy"],
-            "scm_type": project["scm_type"],
-            "scm_branch": project["scm_branch"],
-            "scm_refspec": project["scm_refspec"],
-            "git_hash": project["git_hash"],
-            "verify_ssl": project["verify_ssl"],
+            "id": project.id,
+            "name": project.name,
+            "description": project.description,
+            "url": project.url,
+            "proxy": self.get_proxy(project),
+            "scm_type": project.scm_type,
+            "scm_branch": project.scm_branch,
+            "scm_refspec": project.scm_refspec,
+            "git_hash": project.git_hash,
+            "verify_ssl": project.verify_ssl,
             "organization": organization,
             "eda_credential": eda_credential,
             "signature_validation_credential": signature_validation_credential,
-            "import_state": project["import_state"],
-            "import_error": project["import_error"],
-            "created_at": project["created_at"],
-            "modified_at": project["modified_at"],
+            "import_state": project.import_state,
+            "import_error": project.import_error,
+            "created_at": project.created_at,
+            "modified_at": project.modified_at,
         }
 
 

--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -171,38 +171,19 @@ class ProjectViewSet(
         },
     )
     def retrieve(self, request, pk):
-        project = super().retrieve(request, pk)
-        project.data["eda_credential"] = (
-            models.EdaCredential.objects.get(
-                pk=project.data["eda_credential_id"]
-            )
-            if project.data["eda_credential_id"]
-            else None
-        )
-        project.data["signature_validation_credential"] = (
-            models.EdaCredential.objects.get(
-                pk=project.data["signature_validation_credential_id"]
-            )
-            if project.data["signature_validation_credential_id"]
-            else None
-        )
-        project.data["organization"] = (
-            models.Organization.objects.get(pk=project.data["organization_id"])
-            if project.data["organization_id"]
-            else None
-        )
+        project = self.get_object()
 
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Read",
                 resource_name,
-                project.data["name"],
-                project.data["id"],
-                project.data["organization"].name,
+                project.name,
+                project.id,
+                project.organization.name,
             )
         )
 
-        return Response(serializers.ProjectReadSerializer(project.data).data)
+        return Response(serializers.ProjectReadSerializer(project).data)
 
     @extend_schema(
         description="Partial update of a project",

--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -83,7 +83,6 @@ class DestroyProjectMixin(mixins.DestroyModelMixin):
 class ProjectViewSet(
     ResponseSerializerMixin,
     mixins.CreateModelMixin,
-    mixins.RetrieveModelMixin,
     DestroyProjectMixin,
     mixins.ListModelMixin,
     viewsets.GenericViewSet,


### PR DESCRIPTION
Utilize project instance as input to project retrieve read serializer.
https://issues.redhat.com/browse/AAP-29995
---
The current EDA code when retrieving a project passes a dictionary as the `instance` of the instantiated read serializer.  In the context of a web browser request (`rest_framework. renderers.BrowsableAPIRenderer`) this results in the issues as described in https://issues.redhat.com/browse/AAP-29995.

One of these issues is the logging of
```
ansible_base.rbac.api.permissions INFO Object-permission check called with non-object <class 'rest_framework.utils.serializer_helpers.ReturnDict'> 
```
which occurs when constructing a `PATCH` section of the page.

The other is
```
 File "/usr/lib/python3.11/site-packages/aap_eda/api/serializers/project.py", line 31, in get_proxy
    if not obj.proxy:
           ^^^^^^^^^
AttributeError: 'ReturnDict' object has no attribute 'proxy'
```
which results from `proxy` being declared as a `SerializerFieldMethod` and the read serializer using a mixin to provide the `get_proxy` functionality which expects its input to be a project instance.  

To address both issues this change modifies the project retrieve and project read serializer code to utilize a project instance as input to the read serializer.