### PR TITLE
fix: disallow updating credential type on credential patch endpoint

### DIFF
--- a/src/aap_eda/api/serializers/__init__.py
+++ b/src/aap_eda/api/serializers/__init__.py
@@ -37,6 +37,7 @@ from .decision_environment import (
 from .eda_credential import (
     EdaCredentialCreateSerializer,
     EdaCredentialSerializer,
+    EdaCredentialUpdateSerializer,
 )
 from .event_stream import EventStreamInSerializer, EventStreamOutSerializer
 from .organization import (
@@ -120,6 +121,7 @@ __all__ = (
     "CredentialTypeRefSerializer",
     "EdaCredentialSerializer",
     "EdaCredentialCreateSerializer",
+    "EdaCredentialUpdateSerializer",
     # decision environment
     "DecisionEnvironmentSerializer",
     # organizations

--- a/src/aap_eda/api/serializers/eda_credential.py
+++ b/src/aap_eda/api/serializers/eda_credential.py
@@ -115,23 +115,12 @@ class EdaCredentialCreateSerializer(serializers.ModelSerializer):
     inputs = serializers.JSONField()
 
     def validate(self, data):
-        credential_type_id = data.get("credential_type_id")
-        if credential_type_id:
-            credential_type = models.CredentialType.objects.get(
-                id=credential_type_id
-            )
-        else:
-            # for update
-            credential_type = self.instance.credential_type
+        credential_type = models.CredentialType.objects.get(
+            id=data.get("credential_type_id")
+        )
 
         inputs = data.get("inputs", {})
-
-        # allow emtpy inputs during updating
-        if self.partial and not bool(inputs):
-            return data
-
         errors = validate_inputs(credential_type.inputs, inputs)
-
         if bool(errors):
             raise serializers.ValidationError(errors)
 
@@ -144,6 +133,38 @@ class EdaCredentialCreateSerializer(serializers.ModelSerializer):
             "description",
             "inputs",
             "credential_type_id",
+            "organization_id",
+        ]
+
+
+class EdaCredentialUpdateSerializer(serializers.ModelSerializer):
+    organization_id = serializers.IntegerField(
+        required=True,
+        allow_null=False,
+        validators=[validators.check_if_organization_exists],
+    )
+    inputs = serializers.JSONField()
+
+    def validate(self, data):
+        credential_type = self.instance.credential_type
+
+        inputs = data.get("inputs", {})
+        # allow empty inputs during updating
+        if self.partial and not bool(inputs):
+            return data
+
+        errors = validate_inputs(credential_type.inputs, inputs)
+        if bool(errors):
+            raise serializers.ValidationError(errors)
+
+        return data
+
+    class Meta:
+        model = models.EdaCredential
+        fields = [
+            "name",
+            "description",
+            "inputs",
             "organization_id",
         ]
 

--- a/src/aap_eda/api/views/eda_credential.py
+++ b/src/aap_eda/api/views/eda_credential.py
@@ -184,7 +184,7 @@ class EdaCredentialViewSet(
 
     @extend_schema(
         description="Partial update of an EDA credential",
-        request=serializers.EdaCredentialCreateSerializer,
+        request=serializers.EdaCredentialUpdateSerializer,
         responses={
             status.HTTP_200_OK: OpenApiResponse(
                 serializers.EdaCredentialSerializer,
@@ -202,7 +202,7 @@ class EdaCredentialViewSet(
             data.get("inputs", {}), eda_credential.inputs
         )
 
-        serializer = serializers.EdaCredentialCreateSerializer(
+        serializer = serializers.EdaCredentialUpdateSerializer(
             eda_credential, data=data, partial=True
         )
         serializer.is_valid(raise_exception=True)

--- a/tests/integration/api/test_eda_credential.py
+++ b/tests/integration/api/test_eda_credential.py
@@ -500,6 +500,32 @@ def test_partial_update_eda_credential_with_invalid_inputs(
     )
 
 
+@pytest.mark.django_db
+def test_partial_update_eda_credential_type_not_changed(
+    admin_client: APIClient,
+    default_registry_credential: models.EdaCredential,
+    preseed_credential_types,
+):
+    aap_cred_type = models.CredentialType.objects.get(
+        name=enums.DefaultCredentialType.AAP
+    )
+    data = {"credential_type_id": aap_cred_type.id}
+    response = admin_client.patch(
+        f"{api_url_v1}/eda-credentials/{default_registry_credential.id}/",
+        data=data,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    result = response.data
+    assert (
+        result["credential_type"]["id"]
+        == default_registry_credential.credential_type.id
+    )
+    assert (
+        result["credential_type"]["name"]
+        == default_registry_credential.credential_type.name
+    )
+
+
 @pytest.mark.parametrize(
     ("credential_type", "old_inputs", "inputs", "expected_inputs"),
     [


### PR DESCRIPTION
This PR disallows changing Credential Type when updating an Eda Credential. 

## Testing

1. Create a new Eda Credential with type Container Registry
2. Try patching the credential with a payload of just the `credential_type_id` corresponding to the RHAAP Credential Type
3. Assert Credential Type has not been changed

**NOTE**: The UI already disables updating Credential Type; this issue exists only on the API. 

JIRA: [AAP-34968](https://issues.redhat.com/browse/AAP-34968)