### PR TITLE
feat: allow empty injectors/inputs in creating/updating credential types

### DIFF
--- a/src/aap_eda/api/serializers/credential_type.py
+++ b/src/aap_eda/api/serializers/credential_type.py
@@ -40,14 +40,14 @@ class CredentialTypeSerializer(serializers.ModelSerializer):
 
 class CredentialTypeCreateSerializer(serializers.ModelSerializer):
     inputs = serializers.JSONField(
-        required=True,
-        allow_null=False,
+        required=False,
+        default=dict,
         help_text="Inputs of the credential type",
         validators=[validators.check_if_schema_valid],
     )
     injectors = serializers.JSONField(
-        required=True,
-        allow_null=False,
+        required=False,
+        default=dict,
         help_text="Injectors of the credential type",
     )
 

--- a/src/aap_eda/api/views/credential_type.py
+++ b/src/aap_eda/api/views/credential_type.py
@@ -96,7 +96,7 @@ class CredentialTypeViewSet(
 
         serializer.is_valid(raise_exception=True)
         serializer.validated_data["kind"] = "cloud"
-        for field in serializer.validated_data["inputs"]["fields"]:
+        for field in serializer.validated_data["inputs"].get("fields", []):
             if "type" not in field:
                 field["type"] = "string"
 

--- a/src/aap_eda/core/utils/credentials.py
+++ b/src/aap_eda/core/utils/credentials.py
@@ -172,10 +172,10 @@ def validate_schema(schema: dict) -> list[str]:
         return errors
 
     fields = schema.get("fields")
-
     if not fields:
-        errors.append("'fields' must exist and non empty")
-    elif not isinstance(fields, list):
+        return errors
+
+    if not isinstance(fields, list):
         errors.append("'fields' must be a list")
     else:
         id_fields = _get_id_fields(schema)
@@ -245,7 +245,8 @@ def validate_injectors(schema: dict, injectors: dict) -> dict:
     if not isinstance(injectors, dict):
         errors.append("Injectors must be in Key-Value pairs format")
 
-    if not any(
+    injector_keys = injectors.keys()
+    if bool(injector_keys) and not any(
         support_key in injectors.keys()
         for support_key in SUPPORTED_KEYS_IN_INJECTORS
     ):

--- a/tests/integration/api/test_credential_type.py
+++ b/tests/integration/api/test_credential_type.py
@@ -17,6 +17,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from aap_eda.core import enums, models
+from aap_eda.core.utils.credentials import SUPPORTED_KEYS_IN_INJECTORS
 from tests.integration.constants import api_url_v1
 
 INPUT = {
@@ -77,19 +78,37 @@ INPUT_SANS_TYPE = {
 
 
 @pytest.mark.django_db
-def test_create_credential_type(superuser_client: APIClient):
-    injectors = {
-        "extra_vars": {
-            "host": "localhost",
-            "username": "adam",
-            "password": "password",
-            "verify_ssl": False,
-        }
-    }
+@pytest.mark.parametrize(
+    ("inputs", "injectors"),
+    [
+        (
+            {},
+            {},
+        ),
+        (
+            INPUT,
+            {},
+        ),
+        (
+            {},
+            {
+                "extra_vars": {
+                    "host": "localhost",
+                    "username": "adam",
+                    "password": "password",
+                    "verify_ssl": False,
+                }
+            },
+        ),
+    ],
+)
+def test_create_credential_type(
+    superuser_client: APIClient, inputs, injectors
+):
     data_in = {
         "name": "credential_type_1",
         "description": "desc here",
-        "inputs": INPUT,
+        "inputs": inputs,
         "injectors": injectors,
     }
 
@@ -98,30 +117,6 @@ def test_create_credential_type(superuser_client: APIClient):
     )
     assert response.status_code == status.HTTP_201_CREATED
     assert response.data["name"] == "credential_type_1"
-
-    data_in = {
-        "name": "credential_type_2",
-        "description": "desc here",
-        "inputs": INPUT,
-    }
-
-    response = superuser_client.post(
-        f"{api_url_v1}/credential-types/", data=data_in
-    )
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert "This field is required." in response.data["injectors"]
-
-    data_in = {
-        "name": "credential_type_3",
-        "description": "desc here",
-        "injectors": injectors,
-    }
-
-    response = superuser_client.post(
-        f"{api_url_v1}/credential-types/", data=data_in
-    )
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert "This field is required." in response.data["inputs"]
 
 
 @pytest.mark.django_db
@@ -192,30 +187,51 @@ def test_create_credential_type_sans_type(superuser_client: APIClient):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    ("inputs", "injectors", "status_code", "error_message"),
+    ("inputs", "injectors", "error_key", "error_message"),
     [
         (
             {"a": "b"},
             {"a": "b"},
-            status.HTTP_400_BAD_REQUEST,
-            "'fields' must exist and non empty",
+            "injectors",
+            "Injectors must have keys defined in "
+            f"{SUPPORTED_KEYS_IN_INJECTORS}",
         ),
         (
             {"fields": {"id": "username"}},
             {"username": "fred"},
-            status.HTTP_400_BAD_REQUEST,
+            "inputs",
             "'fields' must be a list",
         ),
         (
             {"fields": [{"id": "username"}]},
             {"username": "fred"},
-            status.HTTP_400_BAD_REQUEST,
+            "inputs",
             "label must exist and be a string",
+        ),
+        (
+            {
+                "fields": [
+                    {
+                        "id": "username",
+                        "label": "Username",
+                        "type": "string",
+                        "default": "adam",
+                    },
+                ]
+            },
+            {
+                "extra_vars": {
+                    "keyfile": "{{ keyfile  }}",
+                },
+            },
+            "injectors",
+            "Injector key: keyfile has a value which refers to an undefined "
+            "key error",
         ),
     ],
 )
 def test_create_credential_type_with_schema_validate_errors(
-    superuser_client: APIClient, inputs, injectors, status_code, error_message
+    superuser_client: APIClient, inputs, injectors, error_key, error_message
 ):
     data_in = {
         "name": "credential_type_1",
@@ -227,8 +243,8 @@ def test_create_credential_type_with_schema_validate_errors(
     response = superuser_client.post(
         f"{api_url_v1}/credential-types/", data=data_in
     )
-    assert response.status_code == status_code
-    assert error_message in response.data["inputs"]
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert error_message in str(response.data[error_key])
 
 
 @pytest.mark.django_db
@@ -327,42 +343,16 @@ def test_delete_credential_type_with_credentials(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    ("old_inputs", "new_inputs", "status_code", "passed", "message"),
-    [
-        (
-            {"fields": [{"id": "username", "label": "Username"}]},
-            {},
-            status.HTTP_400_BAD_REQUEST,
-            False,
-            "'fields' must exist and non empty",
-        ),
-        (
-            {"fields": [{"id": "username", "label": "Username"}]},
-            {"c": "d"},
-            status.HTTP_400_BAD_REQUEST,
-            False,
-            "'fields' must exist and non empty",
-        ),
-        (
-            {"username": "fred"},
-            {"fields": [{"id": "username", "label": "Username"}]},
-            status.HTTP_200_OK,
-            True,
-            {"id": "username", "label": "Username"},
-        ),
-    ],
+    "new_inputs",
+    [{}, {"c": "d"}, {"username": "fred"}],
 )
 def test_partial_update_inputs_credential_type(
     superuser_client: APIClient,
-    old_inputs,
     new_inputs,
-    status_code,
-    passed,
-    message,
 ):
     obj = models.CredentialType.objects.create(
         name="type",
-        inputs=old_inputs,
+        inputs={"fields": [{"id": "username", "label": "Username"}]},
         injectors={},
         managed=False,
     )
@@ -373,36 +363,36 @@ def test_partial_update_inputs_credential_type(
     response = superuser_client.patch(
         f"{api_url_v1}/credential-types/{obj.id}/", data=data
     )
-    assert response.status_code == status_code
+    assert response.status_code == status.HTTP_200_OK
 
-    if passed:
-        obj.refresh_from_db()
-        assert obj.inputs == new_inputs
-    else:
-        assert message in response.data["inputs"]
+    obj.refresh_from_db()
+    assert obj.inputs == new_inputs
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    ("new_injectors", "status_code", "key", "message"),
+    ("new_injectors", "status_code", "message"),
     [
         (
             {},
-            status.HTTP_400_BAD_REQUEST,
-            "injectors",
-            "Injectors must have keys defined in ['extra_vars']",
-        ),
-        (
-            {"c": "d"},
-            status.HTTP_400_BAD_REQUEST,
-            "injectors",
-            "Injectors must have keys defined in ['extra_vars']",
+            status.HTTP_200_OK,
+            None,
         ),
         (
             {"extra_vars": {"username": "Adam"}},
             status.HTTP_200_OK,
             None,
-            None,
+        ),
+        (
+            {"c": "d"},
+            status.HTTP_400_BAD_REQUEST,
+            "Injectors must have keys defined in ['extra_vars']",
+        ),
+        (
+            {"extra_vars": {"username": "{{ name }}"}},
+            status.HTTP_400_BAD_REQUEST,
+            "Injector key: username has a value which refers to an undefined "
+            "key error",
         ),
     ],
 )
@@ -410,7 +400,6 @@ def test_partial_update_injectors_credential_type(
     superuser_client: APIClient,
     new_injectors,
     status_code,
-    key,
     message,
 ):
     obj = models.CredentialType.objects.create(
@@ -429,7 +418,7 @@ def test_partial_update_injectors_credential_type(
         obj.refresh_from_db()
         assert obj.injectors == new_injectors
     else:
-        assert message in response.data[key]
+        assert message in str(response.data["injectors"])
 
 
 @pytest.mark.django_db

--- a/tests/unit/test_credential_validation.py
+++ b/tests/unit/test_credential_validation.py
@@ -39,15 +39,6 @@ def test_validate_schema():
     errors = validate_schema(bad_schema_format)
     assert "schema must be in dict format" in errors
 
-    no_fields_schema = {
-        "id": "username",
-        "label": "Username",
-        "type": "string",
-    }
-
-    errors = validate_schema(no_fields_schema)
-    assert "'fields' must exist and non empty" in errors
-
     eda_prefix_id_schema = {
         "fields": [
             {


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-35882

To parity with controllers, empty injectors/inputs are allowed when creating/updating credential types.