### PR TITLE
fix: retrieve decision environment using web browser

### DIFF
--- a/src/aap_eda/api/serializers/decision_environment.py
+++ b/src/aap_eda/api/serializers/decision_environment.py
@@ -97,28 +97,22 @@ class DecisionEnvironmentReadSerializer(serializers.ModelSerializer):
     def to_representation(self, decision_environment):
         eda_credential = (
             EdaCredentialRefSerializer(
-                decision_environment["eda_credential"]
+                decision_environment.eda_credential
             ).data
-            if decision_environment["eda_credential"]
+            if decision_environment.eda_credential
             else None
         )
         organization = (
-            OrganizationRefSerializer(
-                decision_environment["organization"]
-            ).data
-            if decision_environment["organization"]
+            OrganizationRefSerializer(decision_environment.organization).data
+            if decision_environment.organization
             else None
         )
-        return {
-            "id": decision_environment["id"],
-            "name": decision_environment["name"],
-            "description": decision_environment["description"],
-            "image_url": decision_environment["image_url"],
+        result = super().to_representation(decision_environment)
+        result |= {
             "organization": organization,
             "eda_credential": eda_credential,
-            "created_at": decision_environment["created_at"],
-            "modified_at": decision_environment["modified_at"],
         }
+        return result
 
 
 class DecisionEnvironmentRefSerializer(serializers.ModelSerializer):

--- a/src/aap_eda/api/views/decision_environment.py
+++ b/src/aap_eda/api/views/decision_environment.py
@@ -108,7 +108,6 @@ class DecisionEnvironmentViewSet(
     ResponseSerializerMixin,
     CreateDecisionEnvironmentMixin,
     PartialUpdateOnlyDecisionEnvironmentMixin,
-    mixins.RetrieveModelMixin,
     mixins.DestroyModelMixin,
     mixins.ListModelMixin,
     viewsets.GenericViewSet,
@@ -140,35 +139,21 @@ class DecisionEnvironmentViewSet(
         },
     )
     def retrieve(self, request, pk):
-        decision_environment = super().retrieve(request, pk)
-        decision_environment.data["eda_credential"] = (
-            models.EdaCredential.objects.get(
-                pk=decision_environment.data["eda_credential_id"]
-            )
-            if decision_environment.data["eda_credential_id"]
-            else None
-        )
-        decision_environment.data["organization"] = (
-            models.Organization.objects.get(
-                pk=decision_environment.data["organization_id"]
-            )
-            if decision_environment.data["organization_id"]
-            else None
-        )
+        decision_environment = self.get_object()
 
         logger.info(
             logging_utils.generate_simple_audit_log(
                 "Read",
                 resource_name,
-                decision_environment.data["name"],
-                decision_environment.data["id"],
-                decision_environment.data["organization"],
+                decision_environment.name,
+                decision_environment.id,
+                decision_environment.organization.name,
             )
         )
 
         return Response(
             serializers.DecisionEnvironmentReadSerializer(
-                decision_environment.data
+                decision_environment
             ).data
         )
 


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-36030

The current EDA code when retrieving a decision environment passes a dictionary as the instance of the instantiated read serializer. In the context of a web browser request (rest_framework. renderers.BrowsableAPIRenderer) this results in logging of the following...

```
ansible_base.rbac.api.permissions INFO Object-permission check called with non-object <class 'rest_framework.utils.serializer_helpers.ReturnDict'> 
```

To address this issue this change modifies the decision environment retrieve and decision environment read serializer code to utilize a decision environment instance as input to the read serializer.