### PR TITLE
feat: for file injectors prevent mixing of keys

### DIFF
--- a/src/aap_eda/core/utils/credentials.py
+++ b/src/aap_eda/core/utils/credentials.py
@@ -280,7 +280,7 @@ def validate_injectors(schema: dict, injectors: dict) -> dict:
                     )
 
                 if field == "file":
-                    _validate_file_template_key(k)
+                    _validate_file_template_key(k, key_names)
                 if isinstance(v, str):
                     _check_jinja_string(v, context)
                 key_names.append(k)
@@ -407,7 +407,7 @@ def _validate_gpg_public_key(key_data: str) -> list[str]:
     return errors
 
 
-def _validate_file_template_key(key: str) -> None:
+def _validate_file_template_key(key: str, key_names: list[str]) -> None:
     keys = key.split(".")
     if keys[0] != "template":
         raise InjectorInvalidTemplateKey(
@@ -425,3 +425,24 @@ def _validate_file_template_key(key: str) -> None:
             )
             % {"injector_type": "file", "key": key}
         )
+
+    if len(keys) == 1:
+        for known_key in key_names:
+            if known_key.startswith("template"):
+                raise InjectorInvalidTemplateKey(
+                    _(
+                        "Injector %(injector_type)s key: %(key)s "
+                        "cannot be mixed with fully qualified keys"
+                    )
+                    % {"injector_type": "file", "key": key}
+                )
+    if len(keys) == 2:
+        for known_key in key_names:
+            if known_key == "template":
+                raise InjectorInvalidTemplateKey(
+                    _(
+                        "Injector %(injector_type)s key: %(key)s "
+                        "cannot be mixed with template key"
+                    )
+                    % {"injector_type": "file", "key": key}
+                )

--- a/tests/integration/api/test_credential_type.py
+++ b/tests/integration/api/test_credential_type.py
@@ -604,6 +604,46 @@ def test_credential_types_based_on_namespace(
                 "cannot contain multiple dots"
             ),
         ),
+        (
+            {
+                "fields": [
+                    {"id": "cert", "label": "Certificate", "type": "string"},
+                    {"id": "key", "label": "Key", "type": "string"},
+                ]
+            },
+            {
+                "file": {
+                    "template.cert_file": "[mycert]\n{{ cert }}",
+                    "template": "[mykey]\n{{ key }}",
+                },
+            },
+            status.HTTP_400_BAD_REQUEST,
+            "injectors",
+            (
+                "Injector file key: template cannot be mixed "
+                "with fully qualified keys"
+            ),
+        ),
+        (
+            {
+                "fields": [
+                    {"id": "cert", "label": "Certificate", "type": "string"},
+                    {"id": "key", "label": "Key", "type": "string"},
+                ]
+            },
+            {
+                "file": {
+                    "template": "[mykey]\n{{ key }}",
+                    "template.cert_file": "[mycert]\n{{ cert }}",
+                },
+            },
+            status.HTTP_400_BAD_REQUEST,
+            "injectors",
+            (
+                "Injector file key: template.cert_file "
+                "cannot be mixed with template key"
+            ),
+        ),
     ],
 )
 def test_create_credential_type_with_file(


### PR DESCRIPTION
Prevent users from mixing template keys

template : "{{ data }}"       <-- partially qualified
template.certfile: "{{ other_data }}"  <-- fully qualified

You can either use fully qualified keys which is recommended but you cannot mix partially qualified and fully qualified keys

https://issues.redhat.com/browse/AAP-25518