### PR TITLE
feat: prevent ansible, eda keys to be used in extra vars

### DIFF
--- a/src/aap_eda/core/validators.py
+++ b/src/aap_eda/core/validators.py
@@ -24,7 +24,10 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
 from aap_eda.core import enums, models
-from aap_eda.core.utils.credentials import validate_schema
+from aap_eda.core.utils.credentials import (
+    check_reserved_keys_in_extra_vars,
+    validate_schema,
+)
 from aap_eda.core.utils.k8s_service_name import is_rfc_1035_compliant
 
 logger = logging.getLogger(__name__)
@@ -310,6 +313,7 @@ def is_extra_var_dict(extra_var: str):
             raise serializers.ValidationError(
                 "Extra var is not in object format"
             )
+        check_reserved_keys_in_extra_vars(data)
     except yaml.YAMLError:
         raise serializers.ValidationError(
             "Extra var must be in JSON or YAML format"

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -236,6 +236,20 @@ NOT_YAML_JSON_ERROR_MSG = "Extra var must be in JSON or YAML format"
         ("John, ", NOT_OBJECT_ERROR_MSG),
         ("[John, 3,]", NOT_OBJECT_ERROR_MSG),
         ('{"name": "John" - 2 }', NOT_YAML_JSON_ERROR_MSG),
+        (
+            '{"eda": "Fred"}',
+            (
+                "Extra vars key 'eda' cannot be one of these reserved keys "
+                "'ansible, eda'"
+            ),
+        ),
+        (
+            '{"ansible": "Fred"}',
+            (
+                "Extra vars key 'ansible' cannot be one of these reserved "
+                "keys 'ansible, eda'"
+            ),
+        ),
     ],
 )
 @pytest.mark.django_db

--- a/tests/integration/api/test_credential_type.py
+++ b/tests/integration/api/test_credential_type.py
@@ -230,6 +230,32 @@ def test_create_credential_type_sans_type(superuser_client: APIClient):
             "Injector key: keyfile has a value which refers to an undefined "
             "key error",
         ),
+        (
+            {},
+            {
+                "extra_vars": {
+                    "eda": "123",
+                },
+            },
+            "injectors",
+            (
+                "Extra vars key 'eda' cannot be one of these "
+                "reserved keys 'ansible, eda'"
+            ),
+        ),
+        (
+            {},
+            {
+                "extra_vars": {
+                    "ansible": "123",
+                },
+            },
+            "injectors",
+            (
+                "Extra vars key 'ansible' cannot be one of "
+                "these reserved keys 'ansible, eda'"
+            ),
+        ),
     ],
 )
 def test_create_credential_type_with_schema_validate_errors(


### PR DESCRIPTION
Prevent users from using reserved attribute names when creating extra vars which are
  1. eda
  2. ansible

  * eda is used when we create file name for injectors e.g "{{ eda.filename.certfile }}"
  * ansible is used by ansible rulebook to send events to extra vars Controller e.g ansible.eda.events

We check the extra_vars in Activation as well as extra_vars in Credential Type injectors for reserved names

https://issues.redhat.com/browse/AAP-25518