### PR TITLE
feat: enable custom podman socket timeout

### DIFF
--- a/src/aap_eda/services/activation/engine/podman.py
+++ b/src/aap_eda/services/activation/engine/podman.py
@@ -48,9 +48,7 @@ def _get_podman_socket_url() -> str:
 
 def get_podman_client() -> PodmanClient:
     """Podman client factory."""
-    params = {}
-    if settings.PODMAN_SOCKET_TIMEOUT:
-        params["timeout"] = settings.PODMAN_SOCKET_TIMEOUT
+    params = {"timeout": settings.PODMAN_SOCKET_TIMEOUT}
     podman_url = _get_podman_socket_url()
     params["base_url"] = podman_url
     LOGGER.info(f"Using podman socket: {podman_url}")

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -362,6 +362,7 @@ if WEBSOCKET_TOKEN_BASE_URL is None:
         "ws://", "http://"
     ).replace("wss://", "https://")
 PODMAN_SOCKET_URL = settings.get("PODMAN_SOCKET_URL", None)
+PODMAN_SOCKET_TIMEOUT = settings.get("PODMAN_SOCKET_TIMEOUT", None)
 PODMAN_MEM_LIMIT = settings.get("PODMAN_MEM_LIMIT", "200m")
 PODMAN_ENV_VARS = settings.get("PODMAN_ENV_VARS", {})
 PODMAN_MOUNTS = settings.get("PODMAN_MOUNTS", [])

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -362,7 +362,10 @@ if WEBSOCKET_TOKEN_BASE_URL is None:
         "ws://", "http://"
     ).replace("wss://", "https://")
 PODMAN_SOCKET_URL = settings.get("PODMAN_SOCKET_URL", None)
-PODMAN_SOCKET_TIMEOUT = settings.get("PODMAN_SOCKET_TIMEOUT", None)
+PODMAN_SOCKET_TIMEOUT = settings.get("PODMAN_SOCKET_TIMEOUT", default=0)
+# zero raises an exception, None takes the socket default
+if PODMAN_SOCKET_TIMEOUT == 0:
+    PODMAN_SOCKET_TIMEOUT = None
 PODMAN_MEM_LIMIT = settings.get("PODMAN_MEM_LIMIT", "200m")
 PODMAN_ENV_VARS = settings.get("PODMAN_ENV_VARS", {})
 PODMAN_MOUNTS = settings.get("PODMAN_MOUNTS", [])

--- a/tests/integration/services/activation/engine/test_podman.py
+++ b/tests/integration/services/activation/engine/test_podman.py
@@ -39,7 +39,11 @@ from aap_eda.services.activation.engine.exceptions import (
     ContainerStartError,
     ContainerUpdateLogsError,
 )
-from aap_eda.services.activation.engine.podman import Engine, get_podman_client
+from aap_eda.services.activation.engine.podman import (
+    Engine,
+    _get_podman_socket_url,
+    get_podman_client,
+)
 
 from .utils import InitData, get_ansible_rulebook_cmdline, get_request
 
@@ -102,6 +106,48 @@ def podman_engine(init_podman_data):
         )
 
         yield engine
+
+
+def test_podman_socket_url_from_settings(settings):
+    """Test when PODMAN_SOCKET_URL is set in settings."""
+    settings.PODMAN_SOCKET_URL = "custom_socket_url"
+    result = _get_podman_socket_url()
+    assert result == "custom_socket_url"
+
+
+def test_podman_socket_url_as_root(settings):
+    """Test when the user is root (uid=0)."""
+    settings.PODMAN_SOCKET_URL = None
+    with mock.patch("os.getuid", return_value=0):
+        result = _get_podman_socket_url()
+        assert result == "unix:///run/podman/podman.sock"
+
+
+def test_podman_socket_url_non_root_with_xdg_runtime_dir(settings):
+    """Test for a non-root user with XDG_RUNTIME_DIR set."""
+    settings.PODMAN_SOCKET_URL = None
+    with mock.patch("os.getuid", return_value=1000), mock.patch(
+        "os.getenv",
+        return_value="/custom/runtime/dir",
+    ):
+        result = _get_podman_socket_url()
+        assert result == "unix:///custom/runtime/dir/podman/podman.sock"
+
+
+@mock.patch.dict(os.environ, clear=True)
+def test_podman_socket_url_non_root_without_xdg_runtime_dir(settings):
+    """Test for a non-root user without XDG_RUNTIME_DIR set."""
+    settings.PODMAN_SOCKET_URL = None
+    with mock.patch("os.getuid", return_value=1000):
+        result = _get_podman_socket_url()
+        assert result == "unix:///run/user/1000/podman/podman.sock"
+
+
+def test_get_podman_client_with_timeout(settings):
+    """Test setting the timeout for the Podman client."""
+    settings.PODMAN_SOCKET_TIMEOUT = 10
+    client = get_podman_client()
+    assert client.api.timeout == 10
 
 
 def test_get_podman_client(settings):

--- a/tests/integration/services/activation/engine/test_podman.py
+++ b/tests/integration/services/activation/engine/test_podman.py
@@ -44,6 +44,7 @@ from aap_eda.services.activation.engine.podman import (
     _get_podman_socket_url,
     get_podman_client,
 )
+from aap_eda.settings.default import settings as orig_dynaconf_settings
 
 from .utils import InitData, get_ansible_rulebook_cmdline, get_request
 
@@ -148,6 +149,20 @@ def test_get_podman_client_with_timeout(settings):
     settings.PODMAN_SOCKET_TIMEOUT = 10
     client = get_podman_client()
     assert client.api.timeout == 10
+
+
+def test_get_podman_client_with_zero_timeout():
+    """Test setting the timeout for the Podman client to zero."""
+    with mock.patch("aap_eda.settings.default.settings.get") as get_mock:
+
+        def get_side_effect(*args, **kwargs):
+            if args[0] == "PODMAN_SOCKET_TIMEOUT":
+                return 0
+            return orig_dynaconf_settings.get(*args, **kwargs)
+
+        get_mock.side_effect = get_side_effect
+        client = get_podman_client()
+        assert client.api.timeout is None
 
 
 def test_get_podman_client(settings):


### PR DESCRIPTION
Adds PODMAN_SOCKET_TIMEOUT to the system settings to allow custom timeout for podman socket.
Includes a little refactor of the `get_podman_client` and extends tests. 