### PR TITLE
Demonstrate DAB version generation problem

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -621,7 +621,7 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-ansible-base"
-version = "2024.11.8.0.dev7+gfe4ee752"
+version = "2024.4.25"
 description = "A Django app used by ansible services"
 optional = false
 python-versions = ">=3.9"
@@ -631,31 +631,28 @@ develop = false
 [package.dependencies]
 channels = {version = "*", optional = true, markers = "extra == \"channel-auth\""}
 cryptography = "*"
-Django = ">=4.2.16,<4.3.0"
+Django = ">=4.2.5,<4.3.0"
 django-crum = "*"
 django-redis = {version = "*", optional = true, markers = "extra == \"redis-client\""}
 django-split-settings = "*"
 djangorestframework = "*"
 inflection = "*"
 redis = {version = "*", optional = true, markers = "extra == \"redis-client\""}
-sqlparse = ">=0.5.0"
 
 [package.extras]
-all = ["asgiref", "channels", "cryptography", "django-auth-ldap", "django-oauth-toolkit (<2.4.0)", "django-redis", "drf-spectacular", "pyjwt", "pyjwt", "pyrad", "pytest", "pytest-django", "python-ldap", "python3-saml", "redis", "requests", "requests", "social-auth-app-django (==5.4.1)", "tabulate", "tacacs_plus", "urllib3", "xmlsec (==1.3.13)"]
+all = ["channels", "cryptography", "django-auth-ldap", "django-redis", "drf-spectacular", "pyjwt", "pytest", "pytest-django", "python-ldap", "python3-saml", "redis", "requests", "social-auth-app-django", "tabulate", "tacacs_plus", "xmlsec (==1.3.13)"]
 api-documentation = ["drf-spectacular"]
-authentication = ["django-auth-ldap", "pyrad", "python-ldap", "python3-saml", "social-auth-app-django (==5.4.1)", "tabulate", "tacacs_plus", "xmlsec (==1.3.13)"]
+authentication = ["django-auth-ldap", "python-ldap", "python3-saml", "social-auth-app-django", "tabulate", "tacacs_plus", "xmlsec (==1.3.13)"]
 channel-auth = ["channels"]
 jwt-consumer = ["pyjwt", "requests"]
-oauth2-provider = ["django-oauth-toolkit (<2.4.0)"]
 redis-client = ["django-redis", "redis"]
-resource-registry = ["asgiref", "pyjwt", "requests", "urllib3"]
 testing = ["cryptography", "pytest", "pytest-django"]
 
 [package.source]
 type = "git"
 url = "https://github.com/ansible/django-ansible-base.git"
 reference = "devel"
-resolved_reference = "3dc1dca437ee594211ec33bfb4c3fa1c6d39d11a"
+resolved_reference = "7c71771fbd2ca54dcb400ab12fe0f7a4ee655eed"
 
 [[package]]
 name = "django-crum"

--- a/poetry.lock
+++ b/poetry.lock
@@ -652,7 +652,7 @@ testing = ["cryptography", "pytest", "pytest-django"]
 type = "git"
 url = "https://github.com/ansible/django-ansible-base.git"
 reference = "devel"
-resolved_reference = "7c71771fbd2ca54dcb400ab12fe0f7a4ee655eed"
+resolved_reference = "f9efc89b056ae82a7e05a1782b427e4de8e5f189"
 
 [[package]]
 name = "django-crum"


### PR DESCRIPTION
I mean to show here how it generates a commit hash _from today_ but gives it the `2024.4.25` version.

Also see how it adds feature flags as a dependency, which is super duper recent stuff from @john-westcott-iv, and I create this to show how something is broken on a more basic level of packaging for DAB (in addition to the release job, https://issues.redhat.com/browse/AAP-36569).

I also want the DAB folks to review the other dependency changes, because they seem to raise some red flags.

Produced with

```
poetry lock --no-update
```

If it's a problem with my computer, then fine, but the more I looked at this, I don't think it is.