### PR TITLE
feat: [AAP-35878] add copy endpoint for EDA Credentials

### DIFF
--- a/src/aap_eda/api/views/eda_credential.py
+++ b/src/aap_eda/api/views/eda_credential.py
@@ -25,6 +25,7 @@ from drf_spectacular.utils import (
     extend_schema,
 )
 from rest_framework import mixins, status, viewsets
+from rest_framework.decorators import action
 from rest_framework.filters import BaseFilterBackend
 from rest_framework.response import Response
 
@@ -32,6 +33,7 @@ from aap_eda.api import exceptions, filters, serializers
 from aap_eda.api.serializers.eda_credential import get_references
 from aap_eda.core import models
 from aap_eda.core.utils.credentials import (
+    build_copy_post_data,
     inputs_to_store,
     inputs_to_store_dict,
 )
@@ -277,3 +279,43 @@ class EdaCredentialViewSet(
             )
         self.perform_destroy(eda_credential)
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @extend_schema(
+        description="Copy an EDA credential.",
+        request=None,
+        responses={
+            status.HTTP_201_CREATED: OpenApiResponse(
+                serializers.EdaCredentialSerializer,
+                description="Return the copied EDA credential.",
+            ),
+            status.HTTP_404_NOT_FOUND: OpenApiResponse(
+                None, description="EDA credential not found."
+            ),
+        },
+    )
+    @action(methods=["post"], detail=True)
+    def copy(self, request, pk):
+        eda_credential = self.get_object()
+        post_data = build_copy_post_data(eda_credential)
+
+        serializer = serializers.EdaCredentialCreateSerializer(data=post_data)
+        serializer.is_valid(raise_exception=True)
+        serializer.validated_data["inputs"] = inputs_to_store(
+            serializer.validated_data["inputs"]
+        )
+        with transaction.atomic():
+            response = serializer.create(serializer.validated_data)
+            check_related_permissions(
+                request.user,
+                serializer.Meta.model,
+                {},
+                model_to_dict(response),
+            )
+            RoleDefinition.objects.give_creator_permissions(
+                request.user, response
+            )
+
+        return Response(
+            serializers.EdaCredentialSerializer(response).data,
+            status=status.HTTP_201_CREATED,
+        )

--- a/src/aap_eda/api/views/eda_credential.py
+++ b/src/aap_eda/api/views/eda_credential.py
@@ -32,6 +32,7 @@ from rest_framework.response import Response
 from aap_eda.api import exceptions, filters, serializers
 from aap_eda.api.serializers.eda_credential import get_references
 from aap_eda.core import models
+from aap_eda.core.enums import Action
 from aap_eda.core.utils.credentials import (
     build_copy_post_data,
     inputs_to_store,
@@ -79,6 +80,7 @@ class EdaCredentialViewSet(
     )
     filterset_class = filters.EdaCredentialFilter
     ordering_fields = ["name"]
+    rbac_action = None
 
     def filter_queryset(self, queryset):
         if queryset.model is models.EdaCredential:
@@ -293,7 +295,7 @@ class EdaCredentialViewSet(
             ),
         },
     )
-    @action(methods=["post"], detail=True)
+    @action(methods=["post"], detail=True, rbac_action=Action.READ)
     def copy(self, request, pk):
         eda_credential = self.get_object()
         post_data = build_copy_post_data(eda_credential)

--- a/src/aap_eda/core/enums.py
+++ b/src/aap_eda/core/enums.py
@@ -56,9 +56,9 @@ class ResourceType(DjangoStrEnum):
 
 
 class Action(DjangoStrEnum):
-    CREATE = "create"
-    READ = "read"
-    UPDATE = "update"
+    CREATE = "add"
+    READ = "view"
+    UPDATE = "change"
     DELETE = "delete"
     ENABLE = "enable"
     DISABLE = "disable"

--- a/src/aap_eda/core/utils/credentials.py
+++ b/src/aap_eda/core/utils/credentials.py
@@ -15,18 +15,21 @@
 import re
 import tempfile
 import typing
+from datetime import datetime
 
 import gnupg
 import jinja2
 import validators
 import yaml
 from django.core.exceptions import ValidationError
+from django.forms import model_to_dict
 from django.utils.translation import gettext_lazy as _
 from jinja2.nativetypes import NativeTemplate
 from rest_framework import serializers
 
 from aap_eda.api.constants import EDA_SERVER_VAULT_LABEL
 from aap_eda.core import enums
+from aap_eda.core.utils.crypto.base import SecretValue
 
 if typing.TYPE_CHECKING:
     from aap_eda.core import models
@@ -513,3 +516,30 @@ def check_reserved_keys_in_extra_vars(data: dict[str, any]) -> None:
                     "reserved": ", ".join(sorted((RESERVED_EXTRA_VAR_KEYS))),
                 }
             )
+
+
+def build_copy_post_data(eda_credential: "models.EdaCredential") -> dict:
+    """Build a POST payload data from an existing EDA Credential object."""
+    post_data = model_to_dict(eda_credential)
+    # Remove 'id' field from post data
+    post_data.pop("id")
+    # Form a new name for the new credential
+    current_time = datetime.now().strftime("%H:%M:%S")
+    post_data["name"] = " @ ".join([post_data["name"], current_time])
+    # Update foreign key fields
+    post_data["organization_id"] = post_data.pop("organization")
+    post_data["credential_type_id"] = post_data.pop("credential_type")
+    # Decrypt 'inputs' field value for post data
+    if (
+        eda_credential.credential_type
+        and eda_credential.credential_type.inputs
+    ):
+        inputs = (
+            eda_credential.inputs.get_secret_value()
+            if isinstance(eda_credential.inputs, SecretValue)
+            else eda_credential.inputs
+        )
+        decoded_inputs = inputs_from_store(inputs)
+        post_data["inputs"] = decoded_inputs
+
+    return post_data

--- a/tests/integration/api/test_eda_credential.py
+++ b/tests/integration/api/test_eda_credential.py
@@ -6,7 +6,11 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from aap_eda.core import enums, models
-from aap_eda.core.utils.credentials import ENCRYPTED_STRING, inputs_to_store
+from aap_eda.core.utils.credentials import (
+    ENCRYPTED_STRING,
+    inputs_to_display,
+    inputs_to_store,
+)
 from tests.integration.conftest import DUMMY_GPG_KEY
 from tests.integration.constants import api_url_v1
 
@@ -1107,6 +1111,10 @@ def test_copy_eda_credential_success(
         == default_registry_credential.credential_type.id
     )
     assert default_registry_credential.name in new_credential["name"]
+    assert new_credential["inputs"] == inputs_to_display(
+        default_registry_credential.credential_type.inputs,
+        default_registry_credential.inputs,
+    )
 
 
 @pytest.mark.django_db

--- a/tests/integration/api/test_eda_credential.py
+++ b/tests/integration/api/test_eda_credential.py
@@ -1089,3 +1089,29 @@ def test_custom_credential_type_empty_inputs(
     assert response.status_code == status.HTTP_201_CREATED
     result = response.data
     assert result["name"] == "demo-credential"
+
+
+@pytest.mark.django_db
+def test_copy_eda_credential_success(
+    admin_client: APIClient,
+    default_registry_credential,
+):
+    response = admin_client.post(
+        f"{api_url_v1}/eda-credentials/{default_registry_credential.id}/copy/"
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    new_credential = response.data
+    assert new_credential["id"] != default_registry_credential.id
+    assert (
+        new_credential["credential_type"]["id"]
+        == default_registry_credential.credential_type.id
+    )
+    assert default_registry_credential.name in new_credential["name"]
+
+
+@pytest.mark.django_db
+def test_copy_eda_credential_not_found(
+    admin_client: APIClient,
+):
+    response = admin_client.post(f"{api_url_v1}/eda-credentials/0/copy/")
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -856,6 +856,7 @@ def default_registry_credential(
                 "username": "dummy-user",
                 "password": "dummy-password",
                 "host": "quay.io",
+                "verify_ssl": False,
             }
         ),
         organization=default_organization,


### PR DESCRIPTION
This PR adds a new endpoint `/eda-credentials/<id>/copy` to create a new copy of the given EDA Credential.

![image](https://github.com/user-attachments/assets/22a31399-cc5b-4e35-8576-e4341fc30f0c)


JIRA: [AAP-35878](https://issues.redhat.com/browse/AAP-35878)