### PR TITLE
fix: [AAP-36058] correct the default log_timestamp of RulebookProcessLog records

### DIFF
--- a/src/aap_eda/services/activation/db_log_handler.py
+++ b/src/aap_eda/services/activation/db_log_handler.py
@@ -51,6 +51,10 @@ class DBLogger(LogHandler):
         ):
             self.flush()
 
+        # set default value of log_timestamp
+        if log_timestamp == 0:
+            log_timestamp = int(datetime.now().timestamp())
+
         if not isinstance(lines, list):
             lines = [lines]
 

--- a/tests/integration/services/activation/engine/test_podman.py
+++ b/tests/integration/services/activation/engine/test_podman.py
@@ -174,6 +174,8 @@ def test_engine_start(
 
     engine.client.containers.run.assert_called_once()
     assert models.RulebookProcessLog.objects.count() == 4
+    for log in models.RulebookProcessLog.objects.all():
+        assert log.log_timestamp > 0
     assert models.RulebookProcessLog.objects.last().log.endswith("is running.")
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-36058

Correct the default value of log_timestamp with the right timestamp.