### PR TITLE
fix: injected env referencing to injected file

### DIFF
--- a/tests/integration/api/test_credential_type.py
+++ b/tests/integration/api/test_credential_type.py
@@ -739,8 +739,38 @@ def test_create_credential_type_with_file(
                     "name": "{{ name }}",
                     "age": "{{ age }}",
                 },
-                "file": {"template.filename": "Name = {{ name }}"},
-                "env": {"NAME": "{{ name }}", "AGE": "{{ age }}"},
+                "file": {"template": "Name = {{ name }}"},
+                "env": {
+                    "NAME": "{{ name }}",
+                    "AGE": "{{ age }}",
+                    "FNAME": "{{ eda.filename }}",
+                },
+            },
+            status.HTTP_201_CREATED,
+            "",
+            "",
+        ),
+        (
+            {
+                "fields": [
+                    {"id": "name", "label": "Name", "type": "string"},
+                    {"id": "age", "label": "Age", "type": "string"},
+                ]
+            },
+            {
+                "extra_vars": {
+                    "name": "{{ name }}",
+                    "age": "{{ age }}",
+                },
+                "file": {
+                    "template.file1": "Name = {{ name }}",
+                    "template.file2": "Age = {{ age }}",
+                },
+                "env": {
+                    "NAME": "{{ eda.filename.file1 }}",
+                    "AGE": "{{ eda.filename.file2 }}",
+                    "FNAME": "X",
+                },
             },
             status.HTTP_201_CREATED,
             "",

--- a/tests/integration/wsapi/test_consumer.py
+++ b/tests/integration/wsapi/test_consumer.py
@@ -1108,16 +1108,20 @@ def _create_event(data, uuid):
                 "fields": [
                     {"id": "cert", "label": "Certificate", "type": "string"},
                     {"id": "key", "label": "Key", "type": "string"},
+                    {"id": "optional", "label": "Optional", "type": "string"},
                 ]
             },
             {
                 "file": {
                     "template.cert_file": "[mycert]\n{{ cert }}",
+                    "template.empty": "",
+                    "template.optional": "{{ optional }}",
                 },
             },
             {
                 "cert": "This is a certificate",
                 "key": "This is a key",
+                "optional": "",
             },
             [
                 {


### PR DESCRIPTION
This fix solves the exception when creating a credential_type with injected envs referencing to injected files, and the exception when creating a credential based on such types.

The root cause is that {{ eda.filename.abc }} is not substituable. We need to make this allowable during validation and skip substitution for non extra_vars at credential creation time.

A slight enhancement is not to send files to rulebook via websocket if the file content is empty.

Related to AAP-35595

To test the fix we can create this type and credential:
```
---
fields:
   - id: host
     label: Kafka Host
     help_text: Address of Kafka Host
   - id: port
     label: Kafka Port
     help_text: Kafka Port
   - id: topic
     label: Kafka Topic
     help_text: Kafka Topic
   - id: group_id
     label: Group ID
     help_text: Kafka Group ID
   - id: offset
     label: Offset to read
     help_text: Offset to read message from
     choices:
       - latest
       - earliest
     default: latest
   - id: sasl_mechanism
     label: SASL Mechanism 
     help_text: SASL Mechanism
     default: GSSAPI
     hidden: true
   - id: security_protocol
     label: Security Protocol
     help_text: Security Protocol
     default: SASL_PLAINTEXT
     hidden: true
   - id: keytab
     label: Kerberos Keytab
     help_text: Kerberos Keytab file
     secret: true
     format: binary_base64
     multiline: true
   - id: kerberos_config
     label: Kerberos Config
     help_text: Kerberos Config file
     multiline: true
   - id: sasl_kerberos_service_name
     label: Kerberos Service Name
     help_text: Kerberos Service Name
   - id: sasl_kerberos_domain_name
     label: Kerberos Domain Name
     help_text: Kerberos Realm
required:
   - host
   - port
   - topic
   - group_id
   - sasl_kerberos_service_name
   - sasl_kerberos_domain_name
   - keytab
   - kerberos_config
injectors:
   extra_vars:
       sasl_kerberos_service_name: "{{ sasl_kerberos_service_name }}"
       sasl_kerberos_domain_name: "{{ sasl_kerberos_domain_name }}"
       security_protocol : "{{ security_protocol  }}"
       sasl_mechanism : "{{ sasl_mechanism  }}"
       offset : "{{ offset  }}"
       topic : "{{ topic  }}"
       group_id : "{{ group_id  }}"
       host : "{{ host  }}"
       port : "{{ port  }}"
   file:
       template.keytab_file: "{{ keytab }}"
       template.kerberos_config_file: "{{ kerberos_config }}"
   env:
       KRB5_KTNAME: "{{ eda.filename.keytab_file }}"
       KRB5_CLIENT_KTNAME: "{{ eda.filename.keytab_file }}"
       KRB5_CONFIG: "{{ eda.filename.kerberos_config_file }}"
```