### PR TITLE
feat: [AAP-22893] add filtering by activation instance name to audit rules list view

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -621,7 +621,7 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-ansible-base"
-version = "2024.12.3.0.dev41+gb309891d"
+version = "2024.12.13"
 description = "A Django app used by ansible services"
 optional = false
 python-versions = ">=3.9"
@@ -641,7 +641,7 @@ inflection = "*"
 pyjwt = {version = "*", optional = true, markers = "extra == \"jwt-consumer\" or extra == \"resource-registry\""}
 redis = {version = "*", optional = true, markers = "extra == \"redis-client\""}
 requests = {version = "*", optional = true, markers = "extra == \"jwt-consumer\" or extra == \"resource-registry\""}
-sqlparse = ">=0.5.0"
+sqlparse = ">=0.5.2"
 urllib3 = {version = "*", optional = true, markers = "extra == \"resource-registry\""}
 
 [package.extras]
@@ -659,7 +659,7 @@ testing = ["cryptography", "pytest", "pytest-django"]
 type = "git"
 url = "https://github.com/ansible/django-ansible-base.git"
 reference = "devel"
-resolved_reference = "b309891d4722fd4064c2b85657c119bdcc1b315a"
+resolved_reference = "b37fdd2ce8baa21cd2a40c96ff3a871e97363b14"
 
 [[package]]
 name = "django-crum"
@@ -2451,13 +2451,13 @@ files = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.1"
+version = "0.5.3"
 description = "A non-validating SQL parser."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "sqlparse-0.5.1-py3-none-any.whl", hash = "sha256:773dcbf9a5ab44a090f3441e2180efe2560220203dc2f8c0b0fa141e18b505e4"},
-    {file = "sqlparse-0.5.1.tar.gz", hash = "sha256:bb6b4df465655ef332548e24f08e205afc81b9ab86cb1c45657a7ff173a3a00e"},
+    {file = "sqlparse-0.5.3-py3-none-any.whl", hash = "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca"},
+    {file = "sqlparse-0.5.3.tar.gz", hash = "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272"},
 ]
 
 [package.extras]
@@ -2813,4 +2813,4 @@ dev = ["psycopg-binary"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.13"
-content-hash = "ca04e75950fd717a864ab650a4ca440f13a2c1535999d5364afb590c6df46159"
+content-hash = "b131a46faf49e555ababdbf206306625dc7473a70948a1fc042df350a50c6a21"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,12 +41,13 @@ cryptography = ">=42,<43"
 kubernetes = "26.1.*"
 podman = "4.9.*"
 rq-scheduler = "^0.10"
-django-ansible-base = { git = "https://github.com/ansible/django-ansible-base.git", branch = "devel", extras = [
+django-ansible-base = { git = "https://github.com/ansible/django-ansible-base.git", tag = "2024.12.13", extras = [
     "channel-auth",
     "rbac",
     "redis-client",
     "resource-registry",
     "jwt-consumer",
+    "rest-filters",
 ] }
 jinja2 = ">=3.1.3,<3.2"
 django-split-settings = "^1.2.0"

--- a/src/aap_eda/api/filters/__init__.py
+++ b/src/aap_eda/api/filters/__init__.py
@@ -23,12 +23,7 @@ from .eda_credential import EdaCredentialFilter
 from .event_stream import EventStreamFilter
 from .organization import OrganizationFilter
 from .project import ProjectFilter
-from .rulebook import (
-    AuditRuleActionFilter,
-    AuditRuleEventFilter,
-    AuditRuleFilter,
-    RulebookFilter,
-)
+from .rulebook import RulebookFilter
 from .team import OrganizationTeamFilter, TeamFilter
 from .user import UserFilter
 
@@ -37,9 +32,6 @@ __all__ = (
     "ProjectFilter",
     # rulebook
     "RulebookFilter",
-    "AuditRuleFilter",
-    "AuditRuleActionFilter",
-    "AuditRuleEventFilter",
     # credential type
     "CredentialTypeFilter",
     "EdaCredentialFilter",

--- a/src/aap_eda/api/filters/rulebook.py
+++ b/src/aap_eda/api/filters/rulebook.py
@@ -33,39 +33,3 @@ class RulebookFilter(django_filters.FilterSet):
     class Meta:
         model = models.Rulebook
         fields = ["name", "project_id"]
-
-
-class AuditRuleFilter(django_filters.FilterSet):
-    name = django_filters.CharFilter(
-        field_name="name",
-        lookup_expr="istartswith",
-        label="Filter by rule audit name.",
-    )
-
-    class Meta:
-        model = models.AuditRule
-        fields = ["name"]
-
-
-class AuditRuleActionFilter(django_filters.FilterSet):
-    name = django_filters.CharFilter(
-        field_name="name",
-        lookup_expr="istartswith",
-        label="Filter by rule audit action name.",
-    )
-
-    class Meta:
-        model = models.AuditAction
-        fields = ["name"]
-
-
-class AuditRuleEventFilter(django_filters.FilterSet):
-    source_name = django_filters.CharFilter(
-        field_name="source_name",
-        lookup_expr="istartswith",
-        label="Filter by rule audit event source name.",
-    )
-
-    class Meta:
-        model = models.AuditEvent
-        fields = ["source_name"]

--- a/src/aap_eda/api/views/rulebook.py
+++ b/src/aap_eda/api/views/rulebook.py
@@ -24,7 +24,6 @@ from drf_spectacular.utils import (
 )
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
-from rest_framework.filters import OrderingFilter
 from rest_framework.response import Response
 
 from aap_eda.api import exceptions as api_exc, filters, serializers
@@ -152,15 +151,6 @@ class AuditRuleViewSet(
     viewsets.ReadOnlyModelViewSet,
 ):
     queryset = models.AuditRule.objects.all()
-    filter_backends = (defaultfilters.DjangoFilterBackend, OrderingFilter)
-    filterset_class = filters.AuditRuleFilter
-    ordering_fields = [
-        "id",
-        "name",
-        "status",
-        "activation_instance__name",
-        "fired_at",
-    ]
 
     def filter_queryset(self, queryset):
         if queryset.model is models.AuditRule:
@@ -200,13 +190,6 @@ class AuditRuleViewSet(
     @action(
         detail=False,
         queryset=models.AuditAction.objects.order_by("id"),
-        filterset_class=filters.AuditRuleActionFilter,
-        ordering_fields=[
-            "name",
-            "status",
-            "url",
-            "fired_at",
-        ],
         rbac_action=Action.READ,
         url_path="(?P<id>[^/.]+)/actions",
     )
@@ -243,12 +226,6 @@ class AuditRuleViewSet(
     @action(
         detail=False,
         queryset=models.AuditEvent.objects.order_by("-received_at"),
-        filterset_class=filters.AuditRuleEventFilter,
-        ordering_fields=[
-            "source_name",
-            "source_type",
-            "received_at",
-        ],
         rbac_action=Action.READ,
         url_path="(?P<id>[^/.]+)/events",
     )

--- a/src/aap_eda/api/views/rulebook.py
+++ b/src/aap_eda/api/views/rulebook.py
@@ -16,6 +16,7 @@ import yaml
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 from django_filters import rest_framework as defaultfilters
+from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     OpenApiParameter,
     OpenApiResponse,
@@ -145,6 +146,16 @@ class RulebookViewSet(
                 description="Return a list of fired rules.",
             ),
         },
+        parameters=[
+            OpenApiParameter(
+                name="search",
+                type=OpenApiTypes.OBJECT,
+                location=OpenApiParameter.QUERY,
+                style="form",
+                explode=True,
+                description="A free formatted query string with Django semantics for filtering and ordering",  # noqa: E501
+            ),
+        ],
     ),
 )
 class AuditRuleViewSet(
@@ -184,7 +195,15 @@ class AuditRuleViewSet(
                 type=int,
                 location=OpenApiParameter.PATH,
                 description="A unique integer value identifying this rule audit.",  # noqa: E501
-            )
+            ),
+            OpenApiParameter(
+                name="search",
+                type=OpenApiTypes.OBJECT,
+                location=OpenApiParameter.QUERY,
+                style="form",
+                explode=True,
+                description="A free formatted query string with Django semantics for filtering and ordering",  # noqa: E501
+            ),
         ],
     )
     @action(
@@ -220,7 +239,15 @@ class AuditRuleViewSet(
                 type=int,
                 location=OpenApiParameter.PATH,
                 description="A unique integer value identifying this Audit Rule.",  # noqa: E501
-            )
+            ),
+            OpenApiParameter(
+                name="search",
+                type=OpenApiTypes.OBJECT,
+                location=OpenApiParameter.QUERY,
+                style="form",
+                explode=True,
+                description="A free formatted query string with Django semantics for filtering and ordering",  # noqa: E501
+            ),
         ],
     )
     @action(

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -194,6 +194,7 @@ INSTALLED_APPS = [
     "ansible_base.rbac",
     "ansible_base.resource_registry",
     "ansible_base.jwt_consumer",
+    "ansible_base.rest_filters",
     # Local apps
     "aap_eda.api",
     "aap_eda.core",

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -563,6 +563,7 @@ SPECTACULAR_SETTINGS = {
     "PREPROCESSING_HOOKS": [
         "aap_eda.api.openapi.preprocess_filter_api_routes"
     ],
+    "GENERIC_ADDITIONAL_PROPERTIES": "bool",
 }
 
 # ---------------------------------------------------------

--- a/tests/integration/api/test_rulebook.py
+++ b/tests/integration/api/test_rulebook.py
@@ -302,7 +302,7 @@ def test_list_audit_rules_ordering(
     ordering_field,
 ):
     response = admin_client.get(
-        f"{api_url_v1}/audit-rules/?ordering={ordering_field}"
+        f"{api_url_v1}/audit-rules/?order={ordering_field}"
     )
     assert response.status_code == status.HTTP_200_OK
     audit_rules = response.data["results"]
@@ -312,7 +312,7 @@ def test_list_audit_rules_ordering(
     )
 
     response = admin_client.get(
-        f"{api_url_v1}/audit-rules/?ordering=-{ordering_field}"
+        f"{api_url_v1}/audit-rules/?order=-{ordering_field}"
     )
     assert response.status_code == status.HTTP_200_OK
     audit_rules = response.data["results"]
@@ -330,7 +330,7 @@ def test_list_audit_rules_ordering_activation_name(
 ):
     ordering_field = "activation_instance__name"
     response = admin_client.get(
-        f"{api_url_v1}/audit-rules/?ordering={ordering_field}"
+        f"{api_url_v1}/audit-rules/?order={ordering_field}"
     )
     assert response.status_code == status.HTTP_200_OK
     audit_rules = response.data["results"]
@@ -341,7 +341,7 @@ def test_list_audit_rules_ordering_activation_name(
     )
 
     response = admin_client.get(
-        f"{api_url_v1}/audit-rules/?ordering=-{ordering_field}"
+        f"{api_url_v1}/audit-rules/?order=-{ordering_field}"
     )
     assert response.status_code == status.HTTP_200_OK
     audit_rules = response.data["results"]
@@ -350,6 +350,34 @@ def test_list_audit_rules_ordering_activation_name(
         audit_rules[0]["activation_instance"]["name"]
         == audit_rule_2.activation_instance.name
     )
+
+
+@pytest.mark.django_db
+def test_list_audit_rules_filter_activation_instance_name(
+    audit_rule_1: models.AuditRule,
+    audit_rule_2: models.AuditRule,
+    admin_client: APIClient,
+):
+    filter_name = audit_rule_1.activation_instance.name
+    response = admin_client.get(
+        f"{api_url_v1}/audit-rules/?activation_instance__name={filter_name}"
+    )
+    assert response.status_code == status.HTTP_200_OK
+    audit_rules = response.data["results"]
+
+    assert len(audit_rules) == 1
+    assert (
+        audit_rules[0]["activation_instance"]["name"]
+        == audit_rule_1.activation_instance.name
+    )
+    assert list(audit_rules[0]) == [
+        "id",
+        "name",
+        "status",
+        "activation_instance",
+        "organization",
+        "fired_at",
+    ]
 
 
 @pytest.mark.django_db
@@ -426,7 +454,7 @@ def test_list_actions_from_audit_rule_ordering(
     ordering_field,
 ):
     response = admin_client.get(
-        f"{api_url_v1}/audit-rules/{audit_rule_2.id}/actions/?ordering="
+        f"{api_url_v1}/audit-rules/{audit_rule_2.id}/actions/?order="
         f"{ordering_field}"
     )
     assert response.status_code == status.HTTP_200_OK
@@ -437,7 +465,7 @@ def test_list_actions_from_audit_rule_ordering(
     )
 
     response = admin_client.get(
-        f"{api_url_v1}/audit-rules/{audit_rule_2.id}/actions/?ordering="
+        f"{api_url_v1}/audit-rules/{audit_rule_2.id}/actions/?order="
         f"-{ordering_field}"
     )
     assert response.status_code == status.HTTP_200_OK
@@ -495,7 +523,7 @@ def test_list_events_from_audit_rule_ordering(
     ordering_field,
 ):
     response = admin_client.get(
-        f"{api_url_v1}/audit-rules/{audit_rule_2.id}/events/?ordering="
+        f"{api_url_v1}/audit-rules/{audit_rule_2.id}/events/?order="
         f"{ordering_field}"
     )
     assert response.status_code == status.HTTP_200_OK
@@ -504,7 +532,7 @@ def test_list_events_from_audit_rule_ordering(
     assert events[0][ordering_field] == getattr(audit_event_2, ordering_field)
 
     response = admin_client.get(
-        f"{api_url_v1}/audit-rules/{audit_rule_2.id}/events/?ordering="
+        f"{api_url_v1}/audit-rules/{audit_rule_2.id}/events/?order="
         f"-{ordering_field}"
     )
     assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
- pin DAB to [2024.12.13](https://github.com/ansible/django-ansible-base/releases/tag/2024.12.13) release tag
- change to using `rest-filters` app from DAB as a default filter backend for filtering and ordering
- add unit test for filtering audit rules by activation instance name

NOTE: Using `rest-filters` changes the keyword `ordering` for sorting to `order` and `order_by`. Also, this change will transfer the freedom to the UI to build the query param with the correct lookup expression, e.g. `/audit-rules/?name__contains=Test`.

JIRA: [AAP-22893](https://issues.redhat.com/browse/AAP-22893)