### PR TITLE
fix: [AAP-38148] import utils module properly to solve AttributeError in get_default_organization

### DIFF
--- a/src/aap_eda/core/management/commands/create_initial_data.py
+++ b/src/aap_eda/core/management/commands/create_initial_data.py
@@ -24,6 +24,7 @@ from django.db import transaction
 from django.db.models import Q
 
 from aap_eda.core import enums, models
+from aap_eda.core.models.utils import get_default_organization
 from aap_eda.core.tasking import enable_redis_prefix
 from aap_eda.core.utils.credentials import inputs_to_store
 
@@ -1072,7 +1073,7 @@ class Command(BaseCommand):
         if not credentials:
             return
 
-        default_organization = models.utils.get_default_organization()
+        default_organization = get_default_organization()
 
         cred_type = models.CredentialType.objects.filter(
             name=enums.DefaultCredentialType.REGISTRY
@@ -1129,7 +1130,7 @@ class Command(BaseCommand):
         if not credentials:
             return
 
-        default_organization = models.utils.get_default_organization()
+        default_organization = get_default_organization()
 
         cred_type = models.CredentialType.objects.filter(
             name=enums.DefaultCredentialType.SOURCE_CONTROL


### PR DESCRIPTION
Fix the AttributeError raised in `models.utils.get_default_organization()`

```
     models.utils.get_default_organization()

    AttributeError: module 'aap_eda.core.models' has no attribute 'utils'
```
https://issues.redhat.com/browse/AAP-38148