### PR TITLE
[AAP-37476] - Allow scheme in container registry credential

### DIFF
--- a/src/aap_eda/core/utils/credentials.py
+++ b/src/aap_eda/core/utils/credentials.py
@@ -342,6 +342,11 @@ def _validate_registry_host_name(host: str) -> list[str]:
     # pass muster (it returns True otherwise).  Consequently we have to check
     # the class of the return to know what happened and if it's not validators'
     # validation exception raise whatever the heck it is.
+
+    # Remove http:// or https:// scheme prefix if present,
+    # before conducting hostname validation
+    host = host.removeprefix("http://")
+    host = host.removeprefix("https://")
     validity = validators.hostname(host)
     if isinstance(validity, Exception):
         if not isinstance(validity, validators.ValidationError):

--- a/tests/integration/api/test_eda_credential.py
+++ b/tests/integration/api/test_eda_credential.py
@@ -256,8 +256,8 @@ def test_create_eda_credential_with_gpg_key_data(
             "invalid@name",
         ),
         (
-            status.HTTP_400_BAD_REQUEST,
-            "https://invalid.name",
+            status.HTTP_201_CREATED,
+            "https://valid.name",
         ),
     ],
 )


### PR DESCRIPTION
If `http://` or `https://` are present, remove these before conducting hostname validation.

This can be tested by attempting to add a container registry credential, with the `http://` or `https://` schemes in the registry URL