### PR TITLE
fix: [AAP-34609] - change created_by/modified_by into object type in openapi.json

### DIFF
--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -32,6 +32,7 @@ from aap_eda.api.serializers.decision_environment import (
 )
 from aap_eda.api.serializers.eda_credential import EdaCredentialSerializer
 from aap_eda.api.serializers.event_stream import EventStreamOutSerializer
+from aap_eda.api.serializers.fields.basic_user import BasicUserFieldSerializer
 from aap_eda.api.serializers.fields.yaml import YAMLSerializerField
 from aap_eda.api.serializers.organization import OrganizationRefSerializer
 from aap_eda.api.serializers.project import (
@@ -290,6 +291,8 @@ class ActivationListSerializer(serializers.ModelSerializer):
         allow_null=True,
         child=EventStreamOutSerializer(),
     )
+    created_by = BasicUserFieldSerializer()
+    modified_by = BasicUserFieldSerializer()
 
     class Meta:
         model = models.Activation
@@ -312,6 +315,8 @@ class ActivationListSerializer(serializers.ModelSerializer):
             "rules_fired_count",
             "created_at",
             "modified_at",
+            "created_by",
+            "modified_by",
             "status_message",
             "awx_token_id",
             "log_level",
@@ -565,6 +570,8 @@ class ActivationReadSerializer(serializers.ModelSerializer):
         allow_null=True,
         child=EventStreamOutSerializer(),
     )
+    created_by = BasicUserFieldSerializer()
+    modified_by = BasicUserFieldSerializer()
 
     class Meta:
         model = models.Activation
@@ -590,6 +597,8 @@ class ActivationReadSerializer(serializers.ModelSerializer):
             "rules_fired_count",
             "created_at",
             "modified_at",
+            "created_by",
+            "modified_by",
             "restarted_at",
             "status_message",
             "awx_token_id",
@@ -660,8 +669,6 @@ class ActivationReadSerializer(serializers.ModelSerializer):
             if activation.ruleset_stats
             else ""
         )
-        created_by = BasicUserSerializer(activation.created_by).data
-        modified_by = BasicUserSerializer(activation.modified_by).data
 
         return {
             "id": activation.id,
@@ -696,8 +703,8 @@ class ActivationReadSerializer(serializers.ModelSerializer):
             "event_streams": event_streams,
             "source_mappings": activation.source_mappings,
             "skip_audit_events": activation.skip_audit_events,
-            "created_by": created_by,
-            "modified_by": modified_by,
+            "created_by": BasicUserSerializer(activation.created_by).data,
+            "modified_by": BasicUserSerializer(activation.modified_by).data,
         }
 
 

--- a/src/aap_eda/api/serializers/decision_environment.py
+++ b/src/aap_eda/api/serializers/decision_environment.py
@@ -15,20 +15,22 @@
 from rest_framework import serializers
 
 from aap_eda.api.serializers.eda_credential import EdaCredentialRefSerializer
+from aap_eda.api.serializers.fields.basic_user import BasicUserFieldSerializer
 from aap_eda.api.serializers.organization import OrganizationRefSerializer
 from aap_eda.api.serializers.user import BasicUserSerializer
 from aap_eda.core import models, validators
 
 
 class DecisionEnvironmentSerializer(serializers.ModelSerializer):
+    created_by = BasicUserFieldSerializer()
+    modified_by = BasicUserFieldSerializer()
+
     class Meta:
         model = models.DecisionEnvironment
         read_only_fields = [
             "id",
             "created_at",
             "modified_at",
-            "created_by",
-            "modified_by",
         ]
         fields = [
             "name",
@@ -36,6 +38,8 @@ class DecisionEnvironmentSerializer(serializers.ModelSerializer):
             "image_url",
             "organization_id",
             "eda_credential_id",
+            "created_by",
+            "modified_by",
             *read_only_fields,
         ]
 
@@ -93,6 +97,8 @@ class DecisionEnvironmentReadSerializer(serializers.ModelSerializer):
         required=False, allow_null=True
     )
     organization = OrganizationRefSerializer()
+    created_by = BasicUserFieldSerializer()
+    modified_by = BasicUserFieldSerializer()
 
     class Meta:
         model = models.DecisionEnvironment
@@ -112,8 +118,6 @@ class DecisionEnvironmentReadSerializer(serializers.ModelSerializer):
             "id",
             "created_at",
             "modified_at",
-            "created_by",
-            "modified_by",
         ]
 
     def to_representation(self, decision_environment):

--- a/src/aap_eda/api/serializers/eda_credential.py
+++ b/src/aap_eda/api/serializers/eda_credential.py
@@ -17,6 +17,7 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from aap_eda.api.serializers.credential_type import CredentialTypeRefSerializer
+from aap_eda.api.serializers.fields.basic_user import BasicUserFieldSerializer
 from aap_eda.api.serializers.organization import OrganizationRefSerializer
 from aap_eda.api.serializers.user import BasicUserSerializer
 from aap_eda.core import models, validators
@@ -51,6 +52,8 @@ class EdaCredentialSerializer(serializers.ModelSerializer):
     )
     organization = OrganizationRefSerializer()
     references = EdaCredentialReferenceField(required=False, allow_null=True)
+    created_by = BasicUserFieldSerializer()
+    modified_by = BasicUserFieldSerializer()
 
     class Meta:
         model = models.EdaCredential
@@ -58,8 +61,6 @@ class EdaCredentialSerializer(serializers.ModelSerializer):
             "id",
             "created_at",
             "modified_at",
-            "created_by",
-            "modified_by",
             "managed",
             "organization",
         ]
@@ -69,6 +70,8 @@ class EdaCredentialSerializer(serializers.ModelSerializer):
             "inputs",
             "credential_type",
             "references",
+            "created_by",
+            "modified_by",
             *read_only_fields,
         ]
 

--- a/src/aap_eda/api/serializers/event_stream.py
+++ b/src/aap_eda/api/serializers/event_stream.py
@@ -20,6 +20,7 @@ from django.urls import reverse
 from rest_framework import serializers
 
 from aap_eda.api.serializers.eda_credential import EdaCredentialRefSerializer
+from aap_eda.api.serializers.fields.basic_user import BasicUserFieldSerializer
 from aap_eda.api.serializers.organization import OrganizationRefSerializer
 from aap_eda.api.serializers.user import BasicUserSerializer
 from aap_eda.core import enums, models, validators
@@ -83,6 +84,8 @@ class EventStreamOutSerializer(serializers.ModelSerializer):
         required=True, allow_null=False
     )
     url = serializers.SerializerMethodField()
+    created_by = BasicUserFieldSerializer()
+    modified_by = BasicUserFieldSerializer()
 
     class Meta:
         model = models.EventStream
@@ -98,8 +101,6 @@ class EventStreamOutSerializer(serializers.ModelSerializer):
             "test_headers",
             "events_received",
             "last_event_received_at",
-            "created_by",
-            "modified_by",
         ]
         fields = [
             "name",
@@ -108,6 +109,8 @@ class EventStreamOutSerializer(serializers.ModelSerializer):
             "organization",
             "eda_credential",
             "event_stream_type",
+            "created_by",
+            "modified_by",
             *read_only_fields,
         ]
 

--- a/src/aap_eda/api/serializers/fields/basic_user.py
+++ b/src/aap_eda/api/serializers/fields/basic_user.py
@@ -1,0 +1,34 @@
+#  Copyright 2025 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
+
+
+@extend_schema_field(
+    {
+        "type": "object",
+        "properties": {
+            "id": {"type": "integer"},
+            "username": {"type": "string"},
+            "first_name": {"type": "string"},
+            "last_name": {"type": "string"},
+        },
+    }
+)
+class BasicUserFieldSerializer(serializers.JSONField):
+    """Serializer for Basic User Field."""
+
+    def to_representation(self, value) -> dict:
+        return value

--- a/src/aap_eda/api/serializers/project.py
+++ b/src/aap_eda/api/serializers/project.py
@@ -18,6 +18,7 @@ from rest_framework import serializers
 from rest_framework.validators import UniqueValidator
 
 from aap_eda.api.serializers.eda_credential import EdaCredentialRefSerializer
+from aap_eda.api.serializers.fields.basic_user import BasicUserFieldSerializer
 from aap_eda.api.serializers.organization import OrganizationRefSerializer
 from aap_eda.api.serializers.user import BasicUserSerializer
 from aap_eda.core import models, validators
@@ -43,6 +44,8 @@ class ProjectSerializer(serializers.ModelSerializer, ProxyFieldMixin):
     )
 
     proxy = serializers.SerializerMethodField()
+    created_by = BasicUserFieldSerializer()
+    modified_by = BasicUserFieldSerializer()
 
     class Meta:
         model = models.Project
@@ -55,8 +58,6 @@ class ProjectSerializer(serializers.ModelSerializer, ProxyFieldMixin):
             "import_error",
             "created_at",
             "modified_at",
-            "created_by",
-            "modified_by",
         ]
         fields = [
             "name",
@@ -68,6 +69,8 @@ class ProjectSerializer(serializers.ModelSerializer, ProxyFieldMixin):
             "scm_refspec",
             "verify_ssl",
             "proxy",
+            "created_by",
+            "modified_by",
             *read_only_fields,
         ]
 
@@ -187,6 +190,8 @@ class ProjectUpdateRequestSerializer(serializers.ModelSerializer):
         allow_null=True,
         help_text="Proxy server for http or https connection",
     )
+    created_by = BasicUserFieldSerializer()
+    modified_by = BasicUserFieldSerializer()
 
     class Meta:
         model = models.Project
@@ -238,6 +243,8 @@ class ProjectReadSerializer(serializers.ModelSerializer, ProxyFieldMixin):
         required=False, allow_null=True
     )
     proxy = serializers.SerializerMethodField()
+    created_by = BasicUserFieldSerializer()
+    modified_by = BasicUserFieldSerializer()
 
     class Meta:
         model = models.Project
@@ -250,8 +257,6 @@ class ProjectReadSerializer(serializers.ModelSerializer, ProxyFieldMixin):
             "import_error",
             "created_at",
             "modified_at",
-            "created_by",
-            "modified_by",
         ]
         fields = [
             "name",
@@ -263,6 +268,8 @@ class ProjectReadSerializer(serializers.ModelSerializer, ProxyFieldMixin):
             "scm_branch",
             "scm_refspec",
             "proxy",
+            "created_by",
+            "modified_by",
             *read_only_fields,
         ]
 


### PR DESCRIPTION
Change `created_by` and `modified_by` to the type of `object` in the auto-generated schema file. 
It will solve the failures in https://github.com/ansible/eda-qa/pull/447

https://issues.redhat.com/browse/AAP-34609