### PR TITLE
[AAP-39136] - Register DAB Feature Flags endpoint

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2943,4 +2943,4 @@ dev = ["psycopg-binary"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "d81184ff715da76e80c07faa50c6e6630731748e4023231a1b2ba2d369bb620d"
+content-hash = "f66825754b1b17bf21cb189e8f1a9ff466b0e6a8ff8d38b7a4511ca9c4d3363d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -649,7 +649,7 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-ansible-base"
-version = "25.1.29.1.dev612+g3c5f84b"
+version = "2025.1.31"
 description = "A Django app used by ansible services"
 optional = false
 python-versions = ">=3.9"
@@ -689,7 +689,7 @@ testing = ["cryptography", "pytest", "pytest-django"]
 [package.source]
 type = "git"
 url = "https://github.com/ansible/django-ansible-base.git"
-reference = "devel"
+reference = "2025.1.31"
 resolved_reference = "26c318ae41659e7f702fab4ed9aa2727db2e583d"
 
 [[package]]
@@ -2943,4 +2943,4 @@ dev = ["psycopg-binary"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "86b45cee2e9d65cbcc30de4a41f4c315834add11553696c08c6b35bef6ffc73f"
+content-hash = "af92edac99cd98dd22a6900a9e34f57dc4ee061730f49471aef763936b6dafef"

--- a/poetry.lock
+++ b/poetry.lock
@@ -688,9 +688,9 @@ testing = ["cryptography", "pytest", "pytest-django"]
 
 [package.source]
 type = "git"
-url = "https://github.com/zkayyali812/django-ansible-base.git"
-reference = "zk/feature-flag/api"
-resolved_reference = "20b234bee8bf068f8439f38ccdf19440ab6494e2"
+url = "https://github.com/ansible/django-ansible-base.git"
+reference = "devel"
+resolved_reference = "26c318ae41659e7f702fab4ed9aa2727db2e583d"
 
 [[package]]
 name = "django-crum"
@@ -2943,4 +2943,4 @@ dev = ["psycopg-binary"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "f66825754b1b17bf21cb189e8f1a9ff466b0e6a8ff8d38b7a4511ca9c4d3363d"
+content-hash = "86b45cee2e9d65cbcc30de4a41f4c315834add11553696c08c6b35bef6ffc73f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -649,7 +649,7 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-ansible-base"
-version = "25.1.23.1.dev605+gec6afef"
+version = "25.1.24.1.dev608+gaad4fcf"
 description = "A Django app used by ansible services"
 optional = false
 python-versions = ">=3.9"
@@ -690,7 +690,7 @@ testing = ["cryptography", "pytest", "pytest-django"]
 type = "git"
 url = "https://github.com/zkayyali812/django-ansible-base.git"
 reference = "zk/feature-flag/api"
-resolved_reference = "ec6afef39c20748f1a4644f9a85f0be8c1ccf37e"
+resolved_reference = "aad4fcfa5e15e4a5cc291bd4233ed859784129f7"
 
 [[package]]
 name = "django-crum"

--- a/poetry.lock
+++ b/poetry.lock
@@ -690,7 +690,7 @@ testing = ["cryptography", "pytest", "pytest-django"]
 type = "git"
 url = "https://github.com/zkayyali812/django-ansible-base.git"
 reference = "zk/feature-flag/api"
-resolved_reference = "3c5f84bb8862397fbd5ed932359214efcdbd6c07"
+resolved_reference = "20b234bee8bf068f8439f38ccdf19440ab6494e2"
 
 [[package]]
 name = "django-crum"

--- a/poetry.lock
+++ b/poetry.lock
@@ -649,7 +649,7 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-ansible-base"
-version = "25.1.24.1.dev608+gaad4fcf"
+version = "25.1.29.1.dev612+g3c5f84b"
 description = "A Django app used by ansible services"
 optional = false
 python-versions = ">=3.9"
@@ -690,7 +690,7 @@ testing = ["cryptography", "pytest", "pytest-django"]
 type = "git"
 url = "https://github.com/zkayyali812/django-ansible-base.git"
 reference = "zk/feature-flag/api"
-resolved_reference = "aad4fcfa5e15e4a5cc291bd4233ed859784129f7"
+resolved_reference = "3c5f84bb8862397fbd5ed932359214efcdbd6c07"
 
 [[package]]
 name = "django-crum"

--- a/poetry.lock
+++ b/poetry.lock
@@ -649,7 +649,7 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-ansible-base"
-version = "2025.1.3"
+version = "25.1.23.1.dev605+gec6afef"
 description = "A Django app used by ansible services"
 optional = false
 python-versions = ">=3.9"
@@ -663,6 +663,7 @@ channels = {version = "*", optional = true, markers = "extra == \"channel-auth\"
 cryptography = "*"
 Django = ">=4.2.16,<4.3.0"
 django-crum = "*"
+django-flags = {version = "*", optional = true, markers = "extra == \"feature-flags\""}
 django-redis = {version = "*", optional = true, markers = "extra == \"redis-client\""}
 django-split-settings = "*"
 djangorestframework = "*"
@@ -674,10 +675,11 @@ sqlparse = ">=0.5.2"
 urllib3 = {version = "*", optional = true, markers = "extra == \"resource-registry\""}
 
 [package.extras]
-all = ["asgiref", "channels", "cryptography", "django-auth-ldap", "django-oauth-toolkit (<2.4.0)", "django-redis", "drf-spectacular", "pyjwt", "pyjwt", "pyrad", "pytest", "pytest-django", "python-ldap", "python3-saml", "redis", "requests", "requests", "social-auth-app-django (==5.4.1)", "tabulate", "tacacs_plus", "urllib3", "xmlsec (==1.3.13)"]
+all = ["asgiref", "channels", "cryptography", "django-auth-ldap", "django-flags", "django-oauth-toolkit (<2.4.0)", "django-redis", "drf-spectacular", "pyjwt", "pyjwt", "pyrad", "pytest", "pytest-django", "python-ldap", "python3-saml", "redis", "requests", "requests", "social-auth-app-django (==5.4.1)", "tabulate", "tacacs_plus", "urllib3", "xmlsec (==1.3.13)"]
 api-documentation = ["drf-spectacular"]
 authentication = ["django-auth-ldap", "pyrad", "python-ldap", "python3-saml", "social-auth-app-django (==5.4.1)", "tabulate", "tacacs_plus", "xmlsec (==1.3.13)"]
 channel-auth = ["channels"]
+feature-flags = ["django-flags"]
 jwt-consumer = ["pyjwt", "requests"]
 oauth2-provider = ["django-oauth-toolkit (<2.4.0)"]
 redis-client = ["django-redis", "redis"]
@@ -686,9 +688,9 @@ testing = ["cryptography", "pytest", "pytest-django"]
 
 [package.source]
 type = "git"
-url = "https://github.com/ansible/django-ansible-base.git"
-reference = "2025.1.3"
-resolved_reference = "1cf551b7834453dcfd09de1a18b44f9538f93852"
+url = "https://github.com/zkayyali812/django-ansible-base.git"
+reference = "zk/feature-flag/api"
+resolved_reference = "ec6afef39c20748f1a4644f9a85f0be8c1ccf37e"
 
 [[package]]
 name = "django-crum"
@@ -2941,4 +2943,4 @@ dev = ["psycopg-binary"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "251eadccfba62009fe7d755c3284f25c33f16451a0044b90ee7b1de453b34704"
+content-hash = "d81184ff715da76e80c07faa50c6e6630731748e4023231a1b2ba2d369bb620d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,13 +48,14 @@ cryptography = ">=42,<43"
 kubernetes = "26.1.*"
 podman = "5.2.*"
 rq-scheduler = "^0.10"
-django-ansible-base = { git = "https://github.com/ansible/django-ansible-base.git", tag = "2025.1.3", extras = [
+django-ansible-base = { git = "https://github.com/zkayyali812/django-ansible-base.git", branch = "zk/feature-flag/api", extras = [
     "channel-auth",
     "rbac",
     "redis-client",
     "resource-registry",
     "jwt-consumer",
     "rest-filters",
+    "feature-flags",
 ] }
 jinja2 = ">=3.1.3,<3.2"
 django-split-settings = "^1.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ cryptography = ">=42,<43"
 kubernetes = "26.1.*"
 podman = "5.2.*"
 rq-scheduler = "^0.10"
-django-ansible-base = { git = "https://github.com/zkayyali812/django-ansible-base.git", branch = "zk/feature-flag/api", extras = [
+django-ansible-base = { git = "https://github.com/ansible/django-ansible-base.git", branch = "devel", extras = [
     "channel-auth",
     "rbac",
     "redis-client",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ cryptography = ">=42,<43"
 kubernetes = "26.1.*"
 podman = "5.2.*"
 rq-scheduler = "^0.10"
-django-ansible-base = { git = "https://github.com/ansible/django-ansible-base.git", branch = "devel", extras = [
+django-ansible-base = { git = "https://github.com/ansible/django-ansible-base.git", tag = "2025.1.31", extras = [
     "channel-auth",
     "rbac",
     "redis-client",

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -202,10 +202,10 @@ INSTALLED_APPS = [
 ]
 
 
-def toggle_feature_flags(_flags, _settings):
-    for feature in _flags.keys():
-        if feature in _settings:
-            _flags[feature][0]["value"] = _settings.get(feature)
+def toggle_feature_flags(flags, settings):
+    for feature in flags.keys():
+        if feature in settings:
+            flags[feature][0]["value"] = settings.get(feature)
 
 
 # Defines feature flags, and their conditions.

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -201,12 +201,17 @@ INSTALLED_APPS = [
     "aap_eda.core",
 ]
 
+
+def toggle_feature_flags(_flags, _settings):
+    for feature in _flags.keys():
+        if feature in _settings:
+            _flags[feature][0]["value"] = _settings.get(feature)
+
+
 # Defines feature flags, and their conditions.
 # See https://cfpb.github.io/django-flags/
 FLAGS = {}
-for feature in FLAGS.keys():
-    if feature in settings:
-        FLAGS[feature][0]["value"] = settings.get(feature)
+toggle_feature_flags(FLAGS, settings)
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -195,6 +195,7 @@ INSTALLED_APPS = [
     "ansible_base.resource_registry",
     "ansible_base.jwt_consumer",
     "ansible_base.rest_filters",
+    "ansible_base.feature_flags",
     # Local apps
     "aap_eda.api",
     "aap_eda.core",

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -205,6 +205,10 @@ INSTALLED_APPS = [
 # See https://cfpb.github.io/django-flags/
 FLAGS = {}
 
+for feature in list(FLAGS.keys()):
+    if feature in settings:
+        FLAGS[feature][0]["value"] = settings.get(feature)
+
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -204,8 +204,7 @@ INSTALLED_APPS = [
 # Defines feature flags, and their conditions.
 # See https://cfpb.github.io/django-flags/
 FLAGS = {}
-
-for feature in list(FLAGS.keys()):
+for feature in FLAGS.keys():
     if feature in settings:
         FLAGS[feature][0]["value"] = settings.get(feature)
 

--- a/tests/integration/api/test_feature_flags.py
+++ b/tests/integration/api/test_feature_flags.py
@@ -7,7 +7,7 @@ from tests.integration.constants import api_url_v1
 
 @pytest.mark.django_db
 def test_feature_flags_list_endpoint(admin_client):
-    response = admin_client.get(f"{api_url_v1}/feature_flags_definition/")
+    response = admin_client.get(f"{api_url_v1}/feature_flags_state/")
     assert response.status_code == status.HTTP_200_OK, response.data
     # Test number of feature flags.
     # Modify each time a flag is added to default settings
@@ -19,14 +19,17 @@ def test_feature_flags_list_endpoint(admin_client):
         "FEATURE_SOME_PLATFORM_FLAG_ENABLED": [
             {"condition": "boolean", "value": False, "required": True},
             {"condition": "before date", "value": "2022-06-01T12:00Z"},
-        ]
+        ],
+        "FEATURE_SOME_PLATFORM_FLAG_FOO_ENABLED": [
+            {"condition": "boolean", "value": True},
+            {"condition": "before date", "value": "2022-06-01T12:00Z"},
+        ],
     }
 )
 @pytest.mark.django_db
 def test_feature_flags_override_flags(admin_client):
-    response = admin_client.get(f"{api_url_v1}/feature_flags_definition/")
+    response = admin_client.get(f"{api_url_v1}/feature_flags_state/")
     assert response.status_code == status.HTTP_200_OK, response.data
-    assert len(response.data) == 1  # Validates number of feature flags
-    assert (
-        len(response.data["FEATURE_SOME_PLATFORM_FLAG_ENABLED"]) == 2
-    )  # Validates number of conditions
+    assert len(response.data) == 2  # Validates number of feature flags
+    assert response.data["FEATURE_SOME_PLATFORM_FLAG_ENABLED"] is False
+    assert response.data["FEATURE_SOME_PLATFORM_FLAG_FOO_ENABLED"] is True

--- a/tests/integration/api/test_feature_flags.py
+++ b/tests/integration/api/test_feature_flags.py
@@ -1,7 +1,11 @@
 import pytest
+from django.conf import settings
 from django.test import override_settings
+from dynaconf import settings as dynaconf
+from flags.state import flag_state
 from rest_framework import status
 
+from aap_eda.settings.default import toggle_feature_flags
 from tests.integration.constants import api_url_v1
 
 
@@ -33,3 +37,17 @@ def test_feature_flags_override_flags(admin_client):
     assert len(response.data) == 2  # Validates number of feature flags
     assert response.data["FEATURE_SOME_PLATFORM_FLAG_ENABLED"] is False
     assert response.data["FEATURE_SOME_PLATFORM_FLAG_FOO_ENABLED"] is True
+
+
+@override_settings(
+    FLAGS={
+        "FEATURE_SOME_PLATFORM_FLAG_ENABLED": [
+            {"condition": "boolean", "value": False},
+        ],
+    },
+)
+@pytest.mark.django_db
+def test_feature_flags_toggle():
+    dynaconf.configure(FEATURE_SOME_PLATFORM_FLAG_ENABLED=True)
+    toggle_feature_flags(settings.FLAGS, dynaconf)
+    assert flag_state("FEATURE_SOME_PLATFORM_FLAG_ENABLED") is True

--- a/tests/integration/api/test_feature_flags.py
+++ b/tests/integration/api/test_feature_flags.py
@@ -1,0 +1,30 @@
+import pytest
+from django.test import override_settings
+from rest_framework import status
+
+from tests.integration.constants import api_url_v1
+
+
+@pytest.mark.django_db
+def test_feature_flags_list_endpoint(admin_client):
+    response = admin_client.get(f"{api_url_v1}/feature-flags/definition")
+    assert response.status_code == status.HTTP_200_OK, response.data
+    assert len(response.data) == 0  # Test number of feature flags. Modify each time a flag is added to default settings
+
+
+@override_settings(
+    FLAGS={
+        "FEATURE_SOME_PLATFORM_FLAG_ENABLED": [
+            {"condition": "boolean", "value": False, "required": True},
+            {"condition": "before date", "value": "2022-06-01T12:00Z"},
+        ]
+    }
+)
+@pytest.mark.django_db
+def test_feature_flags_override_flags(admin_client):
+    response = admin_client.get(f"{api_url_v1}/feature-flags/definition")
+    assert response.status_code == status.HTTP_200_OK, response.data
+    assert len(response.data) == 1  # Validates number of feature flags
+    assert (
+        len(response.data["FEATURE_SOME_PLATFORM_FLAG_ENABLED"]) == 2
+    )  # Validates number of conditions

--- a/tests/integration/api/test_feature_flags.py
+++ b/tests/integration/api/test_feature_flags.py
@@ -7,7 +7,7 @@ from tests.integration.constants import api_url_v1
 
 @pytest.mark.django_db
 def test_feature_flags_list_endpoint(admin_client):
-    response = admin_client.get(f"{api_url_v1}/feature-flags/definition")
+    response = admin_client.get(f"{api_url_v1}/feature_flags_definition/")
     assert response.status_code == status.HTTP_200_OK, response.data
     # Test number of feature flags.
     # Modify each time a flag is added to default settings
@@ -24,7 +24,7 @@ def test_feature_flags_list_endpoint(admin_client):
 )
 @pytest.mark.django_db
 def test_feature_flags_override_flags(admin_client):
-    response = admin_client.get(f"{api_url_v1}/feature-flags/definition")
+    response = admin_client.get(f"{api_url_v1}/feature_flags_definition/")
     assert response.status_code == status.HTTP_200_OK, response.data
     assert len(response.data) == 1  # Validates number of feature flags
     assert (

--- a/tests/integration/api/test_feature_flags.py
+++ b/tests/integration/api/test_feature_flags.py
@@ -9,7 +9,9 @@ from tests.integration.constants import api_url_v1
 def test_feature_flags_list_endpoint(admin_client):
     response = admin_client.get(f"{api_url_v1}/feature-flags/definition")
     assert response.status_code == status.HTTP_200_OK, response.data
-    assert len(response.data) == 0  # Test number of feature flags. Modify each time a flag is added to default settings
+    # Test number of feature flags.
+    # Modify each time a flag is added to default settings
+    assert len(response.data) == 0
 
 
 @override_settings(

--- a/tests/integration/api/test_root.py
+++ b/tests/integration/api/test_root.py
@@ -83,7 +83,7 @@ from tests.integration.constants import api_url_v1
                 "/organizations/",
                 "/teams/",
                 "/event-streams/",
-                "/feature_flags_definition/",
+                "/feature_flags_state/",
             ],
             False,
             id="no_shared_resource",

--- a/tests/integration/api/test_root.py
+++ b/tests/integration/api/test_root.py
@@ -83,7 +83,7 @@ from tests.integration.constants import api_url_v1
                 "/organizations/",
                 "/teams/",
                 "/event-streams/",
-                "feature-flags/",
+                "/feature_flags_definition/",
             ],
             False,
             id="no_shared_resource",

--- a/tests/integration/api/test_root.py
+++ b/tests/integration/api/test_root.py
@@ -83,6 +83,7 @@ from tests.integration.constants import api_url_v1
                 "/organizations/",
                 "/teams/",
                 "/event-streams/",
+                "feature-flags/",
             ],
             False,
             id="no_shared_resource",


### PR DESCRIPTION
- Adds feature-flag API from the django-ansible-base.
- Currently only LIST endpoint is added

API is accessible at - `/api/eda/v1/feature_flags_state/`.

To test, deploy EDA and ensure API is accessible at above endpoint. One can modify the FLAGS variable to see the state reflected at the API endpoint at installtime.

Also satisfies - https://issues.redhat.com/browse/AAP-39595
