### PR TITLE
chore: upgrade podman dependency - AAP-38110

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1709,18 +1709,17 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "podman"
-version = "4.9.0"
+version = "5.2.0"
 description = "Bindings for Podman RESTful API"
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
 files = [
-    {file = "podman-4.9.0-py3-none-any.whl", hash = "sha256:0613314edb8f51b791e2818438e4b386da3937ae73cf0187b27a1f8bb096ac64"},
-    {file = "podman-4.9.0.tar.gz", hash = "sha256:48683485a5bbcb3f6b2e9e93aa8647faadc5c27918f8b86e04bff1d0822691af"},
+    {file = "podman-5.2.0-py3-none-any.whl", hash = "sha256:e42e907b44af3e8578ac3bd4838040f7dd6b4af091f787e51462b979746703eb"},
+    {file = "podman-5.2.0.tar.gz", hash = "sha256:6a064a3e9dbfc4ee0ee0c51604164e1f58d9d00b10f702c3e570651aee722ec7"},
 ]
 
 [package.dependencies]
-pyxdg = ">=0.26"
 requests = ">=2.24"
 urllib3 = "*"
 
@@ -2245,18 +2244,6 @@ groups = ["main"]
 files = [
     {file = "python-gnupg-0.5.2.tar.gz", hash = "sha256:01d8013931c9fa3f45824bbea7054c03d6e11f258a72e7e086e168dbcb91854c"},
     {file = "python_gnupg-0.5.2-py2.py3-none-any.whl", hash = "sha256:72ce142af6da7f07e433fef148b445fb3e07854acd2f88739008838745c0e9f5"},
-]
-
-[[package]]
-name = "pyxdg"
-version = "0.28"
-description = "PyXDG contains implementations of freedesktop.org standards in python."
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "pyxdg-0.28-py2.py3-none-any.whl", hash = "sha256:bdaf595999a0178ecea4052b7f4195569c1ff4d344567bccdc12dfdf02d545ab"},
-    {file = "pyxdg-0.28.tar.gz", hash = "sha256:3267bb3074e934df202af2ee0868575484108581e6f3cb006af1da35395e88b4"},
 ]
 
 [[package]]
@@ -2954,4 +2941,4 @@ dev = ["psycopg-binary"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "902ea6b1c05edfe9e701560a92e6d049060c56bf65a835cfc6b10e72310b1181"
+content-hash = "251eadccfba62009fe7d755c3284f25c33f16451a0044b90ee7b1de453b34704"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ django-filter = ">23.2,<24"
 pydantic = ">=1.8.1,<1.11"
 cryptography = ">=42,<43"
 kubernetes = "26.1.*"
-podman = "4.9.*"
+podman = "5.2.*"
 rq-scheduler = "^0.10"
 django-ansible-base = { git = "https://github.com/ansible/django-ansible-base.git", tag = "2025.1.3", extras = [
     "channel-auth",


### PR DESCRIPTION
This PR will update us to the latest version of podman. 
It does not fix the port issue, but helps us sets us at the latest version of podman, so we can more easily update when we the fix is available.
Jira: https://issues.redhat.com/browse/AAP-38110
Replaces https://github.com/ansible/eda-server/pull/1180/