### PR TITLE
fix: prevent race conditions when dispatching start requests - AAP-36642

### DIFF
--- a/src/aap_eda/services/activation/activation_manager.py
+++ b/src/aap_eda/services/activation/activation_manager.py
@@ -179,7 +179,6 @@ class ActivationManager(StatusManager):
                 LOGGER.warning(msg)
                 self._cleanup()
                 self.set_latest_instance_status(ActivationStatus.STOPPED)
-                self._set_activation_pod_id(pod_id=None)
 
     def _start_activation_instance(self):
         """Start a new activation instance.
@@ -187,8 +186,6 @@ class ActivationManager(StatusManager):
         Update the status of the activation, latest instance, logs,
         counters and pod id.
         """
-        self.set_status(ActivationStatus.STARTING)
-
         # Ensure status of previous instances
         # For consistency, we should not have previous instances in
         # wrong status. If we create a new instance, it means that
@@ -1033,6 +1030,7 @@ class ActivationManager(StatusManager):
 
     @transaction.atomic
     def _create_activation_instance(self):
+        self.set_status(ActivationStatus.STARTING)
         git_hash = (
             self.db_instance.git_hash
             if hasattr(self.db_instance, "git_hash")

--- a/src/aap_eda/services/activation/engine/podman.py
+++ b/src/aap_eda/services/activation/engine/podman.py
@@ -406,7 +406,7 @@ class Engine(ContainerEngine):
                 pod_args[key] = value
 
         for key, value in pod_args.items():
-            LOGGER.debug("Key %s Value %s", key, value)
+            LOGGER.debug("Pod arg %s: %s", key, value)
 
         LOGGER.info(pod_args)
         return pod_args

--- a/src/aap_eda/tasks/orchestrator.py
+++ b/src/aap_eda/tasks/orchestrator.py
@@ -172,6 +172,15 @@ def dispatch(
         return
     status_manager = StatusManager(process_parent)
 
+    job = tasking.get_pending_job(job_id)
+    if job:
+        LOGGER.info(
+            f"Request {request_type} for {process_parent_type} "
+            f"{process_parent_id} can not be processed "
+            f"because there is already a job {job_id} ",
+        )
+        return
+
     # new processes
     if request_type in [
         ActivationRequest.START,
@@ -299,6 +308,10 @@ def dispatch(
                     msg,
                 )
                 return
+    LOGGER.info(
+        f"Trying to enqueue {process_parent_type} {process_parent_id} "
+        f"request {request_type} to queue {queue_name}"
+    )
 
     tasking.unique_enqueue(
         queue_name,

--- a/tests/integration/core/test_tasking.py
+++ b/tests/integration/core/test_tasking.py
@@ -22,6 +22,7 @@ from aap_eda.core.tasking import (
     DefaultWorker,
     Queue,
     _create_url_from_parameters,
+    get_pending_job,
     get_redis_client,
     logger,
     unique_enqueue,
@@ -65,6 +66,20 @@ def test_unique_enqueue_new_job(default_queue, eda_caplog):
     job = unique_enqueue(default_queue.name, "fake_task", fake_task, number=2)
     assert job.kwargs["number"] == 2
     assert "Enqueing unique job" in eda_caplog.text
+
+
+def test_get_pending_job_existing_job(default_queue):
+    job_id = "fake_task"
+    job = default_queue.enqueue(fake_task, job_id=job_id, number=1)
+    result = get_pending_job(job_id)
+    assert result is not None
+    assert result.id == job.id
+
+
+def test_get_pending_job_non_existing_job():
+    job_id = "fake_task"
+    result = get_pending_job(job_id)
+    assert result is None
 
 
 @patch("aap_eda.settings.default.REDIS_UNIX_SOCKET_PATH", "path/to/socket")


### PR DESCRIPTION
The (eda) dispatcher dispatches the start request (chooses the node) and enqueue the manager at the end. The request is processed again in the next loop of the monitor if it takes time and the request can be assigned to another node, then the first time the monitor is executed for the activation, causes the following error:
```
2024-11-22 21:33:49,363 Container args ['ansible-rulebook', '--worker', '--websocket-ssl-verify', 'yes', '--websocket-url', 'wss://f34-h10-000-r640.rdu2.scalelab.redhat.com:443/api/eda/ws/ansible-rulebook', '--websocket-access-token', '******', '--websocket-refresh-token', '******', '--websocket-token-url', 'https://f34-h10-000-r640.rdu2.scalelab.redhat.com:443/api/eda/v1/auth/token/refresh/', '--id', '1388', '--heartbeat', '300']
2024-11-22 21:33:49,464 Container 52b40cfb987c96cc8577cfc0e742b86ffca32441d29dcca10252181675329d03 is running.
2024-11-22 21:34:06,671 Missing container for running activation. Restart policy is applied. 
```

This issue can be reproduced easily by adding a `time.sleep(6)` in any point of the start flow, to force the monitor to be executed again. 

This PR fixes the problem by ensuring at the beginning of the dispatcher that no request is processed if there is already a RQ JOB in a not finished state. This has been observed and addressed in a similar manner (but with advisory locks) in the PoC of ansible-dispatcher. 

Also fixes a race condition when there is a window where the activation instance is in STARTING state but it has not activation_instance created yet. 

Jira: https://issues.redhat.com/browse/AAP-36642


