### PR TITLE
fix: eda_credentials field cannot be null

### DIFF
--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -445,7 +445,7 @@ class ActivationCreateSerializer(serializers.ModelSerializer):
     )
     eda_credentials = serializers.ListField(
         required=False,
-        allow_null=True,
+        allow_null=False,
         child=serializers.IntegerField(),
         validators=[
             validators.check_multiple_credentials,
@@ -607,7 +607,7 @@ class ActivationUpdateSerializer(serializers.ModelSerializer):
     )
     eda_credentials = serializers.ListField(
         required=False,
-        allow_null=True,
+        allow_null=False,
         child=serializers.IntegerField(),
         validators=[
             validators.check_multiple_credentials,

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -326,6 +326,27 @@ def test_create_activation_with_vault_extra_var(
 
 
 @pytest.mark.django_db
+def test_create_activation_with_null_credentials(
+    activation_payload: Dict[str, Any],
+    admin_awx_token: models.AwxToken,
+    admin_client: APIClient,
+    preseed_credential_types,
+):
+    response = admin_client.post(
+        f"{api_url_v1}/activations/",
+        data={
+            **activation_payload,
+            "eda_credentials": None,
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert (
+        str(response.data["eda_credentials"][0])
+        == "This field may not be null."
+    )
+
+
+@pytest.mark.django_db
 def test_list_activations(
     default_activation: models.Activation,
     admin_client: APIClient,


### PR DESCRIPTION
fix AAP-39630.
eda_credentials cannot be null when create or update an activation. empty list [] is allowed.