### PR TITLE
fix: Remove edited_at from read_only_fields

### DIFF
--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -268,7 +268,6 @@ class ActivationSerializer(serializers.ModelSerializer):
             "id",
             "created_at",
             "modified_at",
-            "edited_at",
             "rulebook_name",
         ]
 
@@ -865,7 +864,6 @@ class ActivationReadSerializer(serializers.ModelSerializer):
             "id",
             "created_at",
             "modified_at",
-            "edited_at",
             "restarted_at",
         ]
 
@@ -1027,7 +1025,6 @@ class PostActivationSerializer(serializers.ModelSerializer):
             "id",
             "created_at",
             "modified_at",
-            "edited_at",
         ]
 
 


### PR DESCRIPTION
Doing this will exclude edited_at from the required list of the Activation objects in openapi.json

fixes AAP-40348