### PR TITLE
Fix GH PR Checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,13 +34,13 @@ jobs:
         run: poetry install --no-root --only=lint
 
       - name: Lint with black
-        run: poetry run black --check -- .
+        run: poetry run black --check .
 
       - name: Lint with isort
-        run: poetry run isort --check -- .
+        run: poetry run isort --check .
 
       - name: Lint with ruff
-        run: poetry run ruff --show-source -- .
+        run: poetry run ruff --show-source .
 
       - name: Lint with flake8
         run: poetry run flake8 . --count --show-source --statistics


### PR DESCRIPTION
Linters are failing with error - 
```
The option "--check" does not exist
```

Removing `--` allows them to function as expect. The `--check` argument still does exist, but the appearance of `--` causes the call to not function as intended.

This failure can be seen in this PR - 
https://github.com/ansible/eda-server/pull/1201