### PR TITLE
fix: increase activation readiness timeout AAP-40490

### DIFF
--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -642,7 +642,7 @@ EDA_CONTROLLER_SSL_VERIFY = settings.get("CONTROLLER_SSL_VERIFY", "yes")
 # ---------------------------------------------------------
 
 RULEBOOK_READINESS_TIMEOUT_SECONDS = int(
-    settings.get("RULEBOOK_READINESS_TIMEOUT_SECONDS", 30)
+    settings.get("RULEBOOK_READINESS_TIMEOUT_SECONDS", 60)
 )
 RULEBOOK_LIVENESS_CHECK_SECONDS = int(
     settings.get("RULEBOOK_LIVENESS_CHECK_SECONDS", 300)


### PR DESCRIPTION
# [ AAP-40490]  increase activation readiness timeout 

## Description
We have detected that ansible-rulebook might be slow at starting when decrypting vaulted variables. 
After https://github.com/ansible/eda-server/pull/1088 we have received several reports for activations being restarted as unresponsive after not receive the heartbeat in time. In combination with https://github.com/ansible/ansible-rulebook/pull/733 we agreed to increase the default value of RULEBOOK_READINESS_TIMEOUT_SECONDS for safeness. 

Jira: https://issues.redhat.com/browse/AAP-40490

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change
- [ ] CI change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment
- [ ] I have run the linters and test suite locally
- [ ] I have tested the changes on integration environment

## Testing Instructions
Create an activation with multiple credentials. 

### Prerequisites
None

### Expected Results
The activation is not set as unresponsive and it is set as running by the system

## Additional Context
None

### Required Actions
None

