### PR TITLE
AAP-38110 - Respect custom ports for authentication (Update Podman Dependancy)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1711,14 +1711,14 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "podman"
-version = "5.2.0"
+version = "5.4.0.1"
 description = "Bindings for Podman RESTful API"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "podman-5.2.0-py3-none-any.whl", hash = "sha256:e42e907b44af3e8578ac3bd4838040f7dd6b4af091f787e51462b979746703eb"},
-    {file = "podman-5.2.0.tar.gz", hash = "sha256:6a064a3e9dbfc4ee0ee0c51604164e1f58d9d00b10f702c3e570651aee722ec7"},
+    {file = "podman-5.4.0.1-py3-none-any.whl", hash = "sha256:abd32e49a66bf18a680d9a0ac3989a3f4a3cc7293bc2a5060653276d8ee712f4"},
+    {file = "podman-5.4.0.1.tar.gz", hash = "sha256:ee537aaa44ba530fad7cd939d886a7632f9f7018064e7831e8cb614c54cb1789"},
 ]
 
 [package.dependencies]
@@ -1726,7 +1726,9 @@ requests = ">=2.24"
 urllib3 = "*"
 
 [package.extras]
+docs = ["sphinx"]
 progress-bar = ["rich (>=12.5.1)"]
+test = ["coverage", "fixtures", "pytest", "requests-mock", "tox"]
 
 [[package]]
 name = "prompt-toolkit"
@@ -2943,4 +2945,4 @@ dev = ["psycopg-binary"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "af92edac99cd98dd22a6900a9e34f57dc4ee061730f49471aef763936b6dafef"
+content-hash = "2c8e496182c292958311628238a8154b36ed479d16435b80f4f8e2bb05dd5081"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ django-filter = ">23.2,<24"
 pydantic = ">=1.8.1,<1.11"
 cryptography = ">=42,<43"
 kubernetes = "26.1.*"
-podman = "5.2.*"
+podman = "5.4.*"
 rq-scheduler = "^0.10"
 django-ansible-base = { git = "https://github.com/ansible/django-ansible-base.git", tag = "2025.1.31", extras = [
     "channel-auth",

--- a/src/aap_eda/services/activation/engine/podman.py
+++ b/src/aap_eda/services/activation/engine/podman.py
@@ -379,6 +379,13 @@ class Engine(ContainerEngine):
             log_handler.write(msg, True)
             raise exceptions.ContainerImagePullError(msg) from e
         except APIError as e:
+            if e.status_code == 401:
+                msg = messages.IMAGE_PULL_ERROR.format(
+                    image_url=request.image_url,
+                )
+                LOGGER.error(msg)
+                log_handler.write(msg, True)
+                raise exceptions.ContainerImagePullError(msg)
             LOGGER.error(f"Failed to pull image {request.image_url}: {e}")
             raise exceptions.ContainerStartError(str(e))
         except rq.timeouts.JobTimeoutException as e:

--- a/src/aap_eda/services/activation/engine/podman.py
+++ b/src/aap_eda/services/activation/engine/podman.py
@@ -363,14 +363,6 @@ class Engine(ContainerEngine):
                 }
             image = self.client.images.pull(request.image_url, **kwargs)
 
-            # https://github.com/containers/podman-py/issues/301
-            if not image.id:
-                msg = messages.IMAGE_PULL_ERROR.format(
-                    image_url=request.image_url,
-                )
-                LOGGER.error(msg)
-                log_handler.write(msg, True)
-                raise exceptions.ContainerImagePullError(msg)
             LOGGER.info("Downloaded image")
             return image
         except ImageNotFound as e:


### PR DESCRIPTION
# [[AAP-38110](https://issues.redhat.com/browse/AAP-38110)] Respect custom ports for authentication (Update Podman Dependancy)

**Will be timing the merge of this PR with PDE**

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
Updates podman dependancy to 5.4.0.1, where the upstream fix is available to ensure custom ports can be used with tags and are respected.
- Why is this change needed?
To ensure containerized/RPM installers can use custom ports for decision environments.
- How does this change address the issue?
The fix was merged in the upstream. This PR updates our podman dependency to 5.4.0.1 where the fix is available.


Closes #XXX (if applicable)
Jira: [AAP-38110](https://issues.redhat.com/browse/AAP-38110) (if applicable)

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change
- [ ] CI change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment
- [x] I have run the linters and test suite locally
- [x] I have tested the changes on integration environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test

1. Run locally using docker-compose
2. Validate a rulebook can be run using an image like - 
```
registry.redhat.io:443/ansible-automation-platform-25/de-supported-rhel9:latest
```
Both the port, and the tag must be present to validate.
3. Ensure rulebook runs successfully.

### Expected Results
Decision environment can be pulled successfully when running a rulebook activation.

## Additional Context
Before this change, decision environments using custom ports were unable to be pulled.  An error like the one below, would appear -
```
2024-12-26 20:21:26,131 Image registry.redhat.io:443/ansible-automation-platform-24/de-supported-rhel8:latest pull failed. The image url or the credentials may be incorrect. 
```

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX | <https://github.com/example/repo/pull/XXX>
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
