### PR TITLE
add logger messages to activation-worker log

### DIFF
--- a/src/aap_eda/services/activation/activation_manager.py
+++ b/src/aap_eda/services/activation/activation_manager.py
@@ -36,10 +36,10 @@ from aap_eda.services.activation.restart_helper import (
     system_restart_activation,
 )
 
-from .db_log_handler import DBLogger
 from .engine.common import ContainerableInvalidError, ContainerEngine
 from .engine.factory import new_container_engine
 from .status_manager import StatusManager, run_with_lock
+from .tee_log_handler import TeeSystemLogger
 
 LOGGER = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ class ActivationManager(StatusManager):
         self,
         db_instance: models.Activation,
         container_engine: tp.Optional[ContainerEngine] = None,
-        container_logger_class: type[DBLogger] = DBLogger,
+        container_logger_class: type[TeeSystemLogger] = TeeSystemLogger,
     ):
         """Initialize the Activation Manager.
 
@@ -749,7 +749,7 @@ class ActivationManager(StatusManager):
         container_logger = self.container_logger_class(self.latest_instance.id)
         container_logger.write(user_msg, flush=True)
         LOGGER.info(
-            f"Stop operation activation id: {self.db_instance.id} "
+            f"Stop operation activation id: {self.db_instance.id, LOGGER} "
             "Activation stopped.",
         )
 

--- a/src/aap_eda/services/activation/tee_log_handler.py
+++ b/src/aap_eda/services/activation/tee_log_handler.py
@@ -1,0 +1,67 @@
+#  Copyright 2025 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+from datetime import datetime, timezone
+from typing import Union
+
+from aap_eda.services.activation.db_log_handler import DBLogger
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TeeSystemLogger(DBLogger):
+    """
+    A logging class that extends DBLogger to log messages both to the database
+    and the system logger.
+    """
+
+    def __init__(self, activation_instance_id: int):
+        super().__init__(activation_instance_id)
+
+    @staticmethod
+    def _convert_to_asctime(timestamp: int) -> str:
+        """Convert a UNIX timestamp to asctime format in UTC."""
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc).strftime(
+            "%Y-%m-%d %H:%M:%S,%f"
+        )[:-3]
+
+    def flush(self):
+        try:
+            for buffer in self.activation_instance_log_buffer:
+                line = buffer.log
+                rulebook_timestamp = self._convert_to_asctime(
+                    buffer.log_timestamp
+                )
+                # Determine the log level
+                if "ERROR" in line:
+                    log_level = logging.ERROR
+                elif "WARN" in line:
+                    log_level = logging.WARNING
+                elif "DEBUG" in line:
+                    log_level = logging.DEBUG
+                elif "CRITICAL" in line or "FATAL" in line:
+                    log_level = logging.CRITICAL
+                else:
+                    log_level = logging.INFO
+
+                extra_data = {
+                    "rulebook_timestamp": rulebook_timestamp,
+                    "activation_instance_id": self.activation_instance_id,
+                }
+                LOGGER.log(log_level, f"{line}", extra=extra_data)
+        except Exception as e:
+            LOGGER.error(f"Exception caught while writing {e}")
+        finally:
+            super().flush()

--- a/tests/integration/services/activation/test_tee_log_handler.py
+++ b/tests/integration/services/activation/test_tee_log_handler.py
@@ -1,0 +1,46 @@
+#  Copyright 2025 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+
+from aap_eda.settings.post_load import configure_logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+def test_configure_logging():
+    """Test that configure_logging sets the correct log level and format."""
+    configure_logging()
+
+    # Verify logging level is set to DEBUG
+    assert LOGGER.level == logging.DEBUG, "Logging level should be DEBUG"
+
+    # Ensure the format includes 'rulebook_timestamp'
+    formatter = LOGGER.handlers[0].formatter
+    assert (
+        formatter._fmt
+        == "%(rulebook_timestamp)s - %(levelname)s - %(message)s"
+    ), "Log format is incorrect"
+
+
+def test_logging_output(caplog):
+    """Test that a log message follows the expected format."""
+    configure_logging()
+
+    with caplog.at_level(logging.DEBUG):
+        LOGGER.debug("This is a debug log")
+
+    # Verify the logged message is captured
+    assert "This is a debug log" in caplog.text
+    assert "DEBUG" in caplog.text


### PR DESCRIPTION
Ensure error and info logs are written to the activation-worker logs, as well as the DB/UI logs. 
[AAP-41782](https://issues.redhat.com/browse/AAP-41782)


