### PR TITLE
[AAP-41917] fix: default EDA_MODE to production

### DIFF
--- a/tests/integration/api/test_feature_flags.py
+++ b/tests/integration/api/test_feature_flags.py
@@ -1,10 +1,10 @@
 import pytest
+from ansible_base.lib.dynamic_config import toggle_feature_flags
 from django.conf import settings
 from django.test import override_settings
 from flags.state import flag_state
 from rest_framework import status
 
-from aap_eda.settings.post_load import toggle_feature_flags
 from tests.integration.constants import api_url_v1
 
 

--- a/tests/unit/data/demo_settings.yaml
+++ b/tests/unit/data/demo_settings.yaml
@@ -1,0 +1,1 @@
+SECRET_KEY: "dev.key"

--- a/tests/unit/test_import_settings.py
+++ b/tests/unit/test_import_settings.py
@@ -1,0 +1,69 @@
+#  Copyright 2025 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import importlib
+import os
+
+from django import conf
+
+from aap_eda.settings import default
+
+
+def test_eda_mode():
+    # pytest defaults
+    assert conf.settings.MODE == "development"
+    dev_sec_key = conf.settings.SECRET_KEY
+    sec_env_var = os.getenv("EDA_SECRET_KEY")
+
+    # default to production mode (need to provide SECRET_KEY)
+    os.environ.pop("EDA_MODE")
+    os.environ["EDA_SECRET_KEY"] = "product"
+    importlib.reload(default)
+    importlib.reload(conf)
+    assert conf.settings.MODE == "production"
+    assert conf.settings.SECRET_KEY == "product"
+
+    # roll back to pytest defaults
+    os.environ["EDA_MODE"] = "development"
+    if sec_env_var:
+        os.environ["EDA_SECRET_KEY"] = sec_env_var
+    else:
+        os.environ.pop("EDA_SECRET_KEY")
+    importlib.reload(default)
+    importlib.reload(conf)
+    assert conf.settings.MODE == "development"
+    assert conf.settings.SECRET_KEY == dev_sec_key
+
+
+def test_import_from_yaml():
+    dev_sec_key = conf.settings.SECRET_KEY
+    sec_env_var = os.getenv("EDA_SECRET_KEY")
+    if sec_env_var:
+        os.environ.pop("EDA_SECRET_KEY")
+
+    file_path = os.path.abspath(__file__)
+    file_dir = os.path.dirname(file_path)
+    user_settings_file = os.path.join(file_dir, "data/demo_settings.yaml")
+    os.environ["EDA_SETTINGS_FILE"] = user_settings_file
+    importlib.reload(default)
+    importlib.reload(conf)
+    assert conf.settings.SECRET_KEY == "dev.key"
+
+    # roll back
+    os.environ.pop("EDA_SETTINGS_FILE", None)
+    if sec_env_var:
+        os.environ["EDA_SECRET_KEY"] = sec_env_var
+    importlib.reload(default)
+    importlib.reload(conf)
+    assert conf.settings.SECRET_KEY == dev_sec_key


### PR DESCRIPTION
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
env EDA_MODE was not set. All settings from production/development/testing are imported.
This fix sets EDA_MODE to production by default to avoid conflict settings from different modes. Different mode can still be set by the env var.

Also directly call toggle_feature_flags function from DAB.

<!-- If applicable, provide a link to the issue that is being addressed -->
[AAP-41917](https://issues.redhat.com/browse/AAP-41917)

<!-- What is being changed? -->
<!-- Why is this change needed? -->
<!-- How does this change address the issue? -->
<!-- Does this change introduce any new dependencies, blockers or breaking changes? -->
<!-- How it can be tested? -->
For testing pick a setting and set to different value in /etc/eda/settings.yaml under production/development/testing sections and prove the value is selected according to explicitly set EDA_MODE. When EDA_MODE is not set, the value under production is selected.