### PR TITLE
fix: WEBSOCKET_SSL_VERIFY and CONTROLLER_SSL_VERIFY to be a bool type

### DIFF
--- a/src/aap_eda/settings/defaults.py
+++ b/src/aap_eda/settings/defaults.py
@@ -138,7 +138,7 @@ RENAMED_USERNAME_PREFIX: str = "eda_"
 # ---------------------------------------------------------
 DEPLOYMENT_TYPE: str = "podman"
 WEBSOCKET_BASE_URL: str = "ws://localhost:8000"
-WEBSOCKET_SSL_VERIFY: str = "yes"
+WEBSOCKET_SSL_VERIFY: Union[bool, str] = "yes"
 WEBSOCKET_TOKEN_BASE_URL: Optional[str] = None
 PODMAN_SOCKET_URL: Optional[str] = None
 PODMAN_SOCKET_TIMEOUT: int = 0
@@ -193,7 +193,7 @@ SCHEDULER_JOB_INTERVAL: int = 5
 # ---------------------------------------------------------
 CONTROLLER_URL: str = "default_controller_url"
 CONTROLLER_TOKEN: str = "default_controller_token"
-CONTROLLER_SSL_VERIFY: str = "yes"
+CONTROLLER_SSL_VERIFY: Union[bool, str] = "yes"
 
 # ---------------------------------------------------------
 # RULEBOOK LIVENESS SETTINGS


### PR DESCRIPTION
AAP-42126

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
WEBSOCKET_SSL_VERIFY and CONTROLLER_SSL_VERIFY in defaults.py were set to str type because they can be strings like "yes" or "no". But a value of true or false fails the type validation, preventing the server from starting up.
<!-- If applicable, provide a link to the issue that is being addressed -->
[AAP-42126](https://issues.redhat.com/browse/AAP-42126)

<!-- What is being changed? -->
The fix changes the type from `str` to `Union[bool, str]`. The eda-server has code to convert `yes` or `no` to a bool. When they are sent to ansible-rulebook, they become `"True"` or `"False"` which are valid and expected.
<!-- Why is this change needed? -->
<!-- How does this change address the issue? -->
<!-- Does this change introduce any new dependencies, blockers or breaking changes? -->
<!-- How it can be tested? -->
Different inputs (`true`, `yes`, `True`) have been tested and proved working in activation.
