### PR TITLE
fix: process k8s_service_name during activation update

### DIFF
--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -643,6 +643,10 @@ class ActivationUpdateSerializer(serializers.ModelSerializer):
         self.validated_data["user_id"] = self.context["request"].user.id
         self.validated_data["edited_at"] = timezone.now()
         self.validated_data["edited_by"] = self.context["request"].user
+        if settings.DEPLOYMENT_TYPE == "k8s":
+            self.validated_data["k8s_service_name"] = _update_k8s_service_name(
+                self.validated_data
+            )
         if rulebook_id:
             rulebook = models.Rulebook.objects.get(id=rulebook_id)
             self.validated_data["rulebook_name"] = rulebook.name

--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -162,8 +162,13 @@ class ActivationViewSet(
                 ),
                 status=status.HTTP_409_CONFLICT,
             )
+        data = request.data
+        if "name" not in data:
+            data["name"] = activation.name
+        if "k8s_service_name" not in data:
+            data["k8s_service_name"] = activation.k8s_service_name
         serializer = self.get_serializer(
-            instance=activation, data=request.data, partial=True
+            instance=activation, data=data, partial=True
         )
         serializer.is_valid(raise_exception=True)
         serializer.prepare_update(activation)


### PR DESCRIPTION
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
Fix an internal 500 error when calling api to update an activation on k8s
<!-- If applicable, provide a link to the issue that is being addressed -->
[AAP-42437](https://issues.redhat.com/browse/AAP-42437)

<!-- What is being changed? -->
If no new name or k8s_service_name is provided when request updating the activation, the values from the existing activation are pulled. They are needed for validation. 
In addition, when the k8s_service_name is cleared through the update request, it will be regenerated with the default value.

<!-- How it can be tested? -->
To test the fix
1. Update an activation without changing name on k8s, it no longer raises a 500 internal error.
2. Create an activation with a customized k8s_service_name and clear it through an update, verify the activation's k8s_service_name is assigned to a default value generated based on the activation name.
