### PR TITLE
chore: update docker-compose-dev to set multiple workers AAP-42483

### DIFF
--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -150,10 +150,8 @@ services:
     volumes:
       - '../../:/app/src:z'
 
-  eda-default-worker:
+  eda-default-worker1:
     image: ${EDA_IMAGE:-localhost/aap-eda}
-    deploy:
-      replicas: ${EDA_DEFAULT_WORKERS:-1}
     environment: *common-env
     command:
       - /bin/bash
@@ -166,7 +164,21 @@ services:
       - '../../:/app/src:z'
     restart: always
 
-  eda-activation-worker-node1:
+  eda-default-worker2:
+    image: ${EDA_IMAGE:-localhost/aap-eda}
+    environment: *common-env
+    command:
+      - /bin/bash
+      - -c
+      - aap-eda-manage run_worker_dispatcher
+    depends_on:
+      eda-api:
+        condition: service_healthy
+    volumes:
+      - '../../:/app/src:z'
+    restart: always
+
+  eda-activation-worker1-node1:
     image: ${EDA_IMAGE:-localhost/aap-eda}
     environment:
       <<: *common-env
@@ -183,7 +195,41 @@ services:
       - '../../:/app/src:z'
     restart: always
 
-  eda-activation-worker-node2:
+  eda-activation-worker2-node1:
+    image: ${EDA_IMAGE:-localhost/aap-eda}
+    environment:
+      <<: *common-env
+      EDA_RULEBOOK_QUEUE_NAME: 'activation-node1'
+      EDA_PODMAN_SOCKET_URL: tcp://podman-node1:8888
+    command:
+      - /bin/bash
+      - -c
+      - aap-eda-manage run_activation_dispatcher
+    depends_on:
+      eda-api:
+        condition: service_healthy
+    volumes:
+      - '../../:/app/src:z'
+    restart: always
+
+  eda-activation-worker1-node2:
+    image: ${EDA_IMAGE:-localhost/aap-eda}
+    environment:
+      <<: *common-env
+      EDA_RULEBOOK_QUEUE_NAME: 'activation-node2'
+      EDA_PODMAN_SOCKET_URL: tcp://podman-node2:8888
+    command:
+      - /bin/bash
+      - -c
+      - aap-eda-manage run_activation_dispatcher
+    depends_on:
+      eda-api:
+        condition: service_healthy
+    volumes:
+      - '../../:/app/src:z'
+    restart: always
+
+  eda-activation-worker2-node2:
     image: ${EDA_IMAGE:-localhost/aap-eda}
     environment:
       <<: *common-env


### PR DESCRIPTION
The purpose of this PR is to set multiple default workers and default activation workers per node to simulate the scenario that we will have in OCP with multiple main processes of dispatcher listening in the same channel. 
I don't use `replicas` of the compose spec because it has some limitations, like for example the capability of opening a port, so it is better a little copy-paste of the number of desired services. 
Jira: https://issues.redhat.com/browse/AAP-42483
