### PR TITLE
fix: cleanup podman containers and handle not found exceptions AAP-42708

### DIFF
--- a/tests/integration/services/activation/engine/test_podman.py
+++ b/tests/integration/services/activation/engine/test_podman.py
@@ -296,7 +296,7 @@ def test_engine_start_with_credential(
         command=request.cmdline.command_and_args(),
         stdout=True,
         stderr=True,
-        remove=True,
+        remove=False,
         detach=True,
         name=request.name,
         ports={"8080/tcp": 8080},


### PR DESCRIPTION
We were creating the container with "remove=True". This was due to the first design where we had a worker attached to the container and we relied on podman to get deleted the container once it is stopped. We found that this parameter did not work properly in the podman client, so we added a cleanup logic anyway. After the refactor of activations, this was never needed, since we fetch the logs in the monitor after stop the container, before remove it. 

Now after the upgrade of the podman client, this [has been fixed ](https://github.com/containers/podman-py/pull/435)and the container is actually removed when it is stopped. Our cleanup logic run under a conditional "if container.exists()" so we can incur in race conditions since there is a time window between podman stops the container and it is get deleted, then, we can enter in the conditional and later raises an exception because the container was deleted in the meantime. 

Even in the successful case (we don't enter in the condition) now the container gets deleted once it is stopped there is a potential loss of the last output not gathered by the monitor. 

1. Remove nested try/except block, it is a bug because NotFound exception is also an ApiError exception. 
2. Don't create the container with "remove=True"
3. Consolidate log level messages to warning. 

Jira: https://issues.redhat.com/browse/AAP-42708

