### PR TITLE
fix: update credentials in an activation

### DIFF
--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -162,14 +162,10 @@ class ActivationViewSet(
                 ),
                 status=status.HTTP_409_CONFLICT,
             )
-        data = request.data
-        if "name" not in data:
-            data["name"] = activation.name
-        if "k8s_service_name" not in data:
-            data["k8s_service_name"] = activation.k8s_service_name
         serializer = self.get_serializer(
-            instance=activation, data=data, partial=True
+            instance=activation, data=request.data, partial=True
         )
+        serializer.refill_needed_data(request.data, activation)
         serializer.is_valid(raise_exception=True)
         serializer.prepare_update(activation)
 

--- a/tests/integration/api/test_activation_with_event_stream.py
+++ b/tests/integration/api/test_activation_with_event_stream.py
@@ -835,6 +835,7 @@ def test_update_activation_with_everything(
         assert getattr(activation, key) == val
 
     # test unchanged event stream mapping
+    extra_var = response.data["extra_var"]
     test_activation3 = {"name": "name3"}
     response = admin_client.patch(
         f"{api_url_v1}/activations/{activation_id}/", data=test_activation3
@@ -845,6 +846,7 @@ def test_update_activation_with_everything(
         test_activation2["source_mappings"],
         "demo-2",
     )
+    assert response.data["extra_var"] == extra_var
 
     # test only changing event stream mapping
     source_mappings = []
@@ -869,13 +871,18 @@ def test_update_activation_with_everything(
     )
 
     # test clearing event stream mapping
-    test_activation5 = {"rulebook_id": fks2["rulebook_id"]}
+    test_activation5 = {
+        "rulebook_id": fks2["rulebook_id"],
+        "source_mappings": "",
+    }
     response = admin_client.patch(
         f"{api_url_v1}/activations/{activation_id}/", data=test_activation5
     )
     assert_updated_event_stream_mapping(
         response, ["ansible.eda.range"], "", ""
     )
+    assert response.data["extra_var"] != extra_var
+    assert response.data["extra_var"] in extra_var
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
Rework how to update credentials and extra_vars in an activation
<!-- If applicable, provide a link to the issue that is being addressed -->
[AAP-42639](https://issues.redhat.com/browse/AAP-42639)
<!-- What is being changed? -->
If an activation contains credentials that have extra_vars injector in their type schemas, for example, the credential automatically attached when an event_stream is used, the code will automatically insert extra vars to the activation's extra_var field. When such credentials are added/removed/updated in the activation, the corresponding extra_var is not updated properly.

To fix the problem we now restore the extra_var to its origin before credential insertion. Then re-insert additional extra vars to this attribute one by one iterating through new credentials in the activation. In order to work properly for all possible updates, we pull all required attributes from the DB if they are not given by the update API.

<!-- How it can be tested? -->
To test the fix try to add/remove/update the credentials with extra_vars injector or event_stream and verify the extra_var field in the activation is updated correctly
