### PR TITLE
Add AAP Injectors

### DIFF
--- a/src/aap_eda/core/management/commands/create_initial_data.py
+++ b/src/aap_eda/core/management/commands/create_initial_data.py
@@ -294,11 +294,30 @@ AAP_INPUTS = {
             "type": "boolean",
             "secret": False,
         },
+        {
+            "id": "request_timeout",
+            "label": ("Request Timeout"),
+            "type": "string",
+            "secret": False,
+            "default": "10",
+            "help_text": (
+                "Specify the timeout Ansible should use in requests to"
+                "the host. Defaults to 10s",
+            ),
+        },
     ],
     "required": ["host"],
 }
 
 AAP_INJECTORS = {
+    "extra_vars": {
+        "aap_hostname": "{{host}}",
+        "aap_username": "{{username}}",
+        "aap_password": "{{password}}",
+        "aap_token": "{{oauth_token}}",
+        "aap_request_timeout": "{{request_timeout}}",
+        "aap_verify_ssl": "{{verify_ssl}}",
+    },
     "env": {
         "TOWER_HOST": "{{host}}",
         "TOWER_USERNAME": "{{username}}",
@@ -310,7 +329,14 @@ AAP_INJECTORS = {
         "CONTROLLER_PASSWORD": "{{password}}",
         "CONTROLLER_VERIFY_SSL": "{{verify_ssl}}",
         "CONTROLLER_OAUTH_TOKEN": "{{oauth_token}}",
-    }
+        "CONTROLLER_REQUEST_TIMEOUT": "{{request_timeout}}",
+        "AAP_HOSTNAME": "{{host}}",
+        "AAP_USERNAME": "{{username}}",
+        "AAP_PASSWORD": "{{password}}",
+        "AAP_VERIFY_SSL": "{{verify_ssl}}",
+        "AAP_TOKEN": "{{oauth_token}}",
+        "AAP_REQUEST_TIMEOUT": "{{request_timeout}}",
+    },
 }
 
 VAULT_INPUTS = {

--- a/tests/integration/wsapi/test_consumer.py
+++ b/tests/integration/wsapi/test_consumer.py
@@ -189,7 +189,7 @@ async def test_handle_workers_with_controller_info(
             ]
             assert response["token"] == AAP_INPUTS["oauth_token"]
         elif type == "EnvVars":
-            assert response["data"].startswith("Q09OVFJPTExFUl9IT1NUOiBodHRwc")
+            assert response["data"].startswith("QUFQX0hPU1ROQU1FOiBodHRwczovL")
 
 
 @pytest.mark.django_db(transaction=True)
@@ -1284,7 +1284,7 @@ async def test_handle_workers_with_env_vars(
         response = await ws_communicator.receive_json_from(timeout=TIMEOUT)
         assert response["type"] == type
         if type == "EnvVars":
-            assert response["data"].startswith("Q09OVFJPTExFUl9IT1NUOiBodHRwc")
+            assert response["data"].startswith("QUFQX0hPU1ROQU1FOiBodHRwczovL")
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
Adds AAP injectors, following up on the collection update. Enables them as extra_vars, and as environment variables

Duplicate of: https://github.com/ansible/eda-server/pull/1162 with updated env var values.

EDAQA Tests are fixed by: https://github.com/ansible/eda-qa/pull/465

e2e test run - https://github.com/ansible/eda-server/actions/runs/14172609841