### PR TITLE
[AAP-42756] fix: Generate default request id when it's not available

### DIFF
--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -112,11 +112,10 @@ class ActivationViewSet(
             )
 
         if response.is_enabled:
-            request_id = request.headers.get("x-request-id", "")
             start_rulebook_process(
                 process_parent_type=ProcessParentType.ACTIVATION,
                 process_parent_id=response.id,
-                request_id=request_id,
+                request_id=request.headers.get("x-request-id"),
             )
 
         logger.info(
@@ -230,11 +229,10 @@ class ActivationViewSet(
                 activation.save(update_fields=["status"])
                 name = activation.name
 
-                request_id = request.headers.get("x-request-id", "")
                 delete_rulebook_process(
                     process_parent_type=ProcessParentType.ACTIVATION,
                     process_parent_id=activation.id,
-                    request_id=request_id,
+                    request_id=request.headers.get("x-request-id"),
                 )
                 logger.info(f"Now deleting {name} ...")
         except redis.ConnectionError:
@@ -405,11 +403,10 @@ class ActivationViewSet(
             ]
         )
 
-        request_id = request.headers.get("x-request-id", "")
         start_rulebook_process(
             process_parent_type=ProcessParentType.ACTIVATION,
             process_parent_id=activation.id,
-            request_id=request_id,
+            request_id=request.headers.get("x-request-id"),
         )
 
         logger.info(
@@ -450,11 +447,10 @@ class ActivationViewSet(
             activation.save(
                 update_fields=["is_enabled", "status", "modified_at"]
             )
-            request_id = request.headers.get("x-request-id", "")
             stop_rulebook_process(
                 process_parent_type=ProcessParentType.ACTIVATION,
                 process_parent_id=activation.id,
-                request_id=request_id,
+                request_id=request.headers.get("x-request-id"),
             )
 
         logger.info(
@@ -498,12 +494,11 @@ class ActivationViewSet(
         self.redis_is_available()
 
         valid, error = is_activation_valid(activation)
-        request_id = request.headers.get("x-request-id", "")
         if not valid:
             stop_rulebook_process(
                 process_parent_type=ProcessParentType.ACTIVATION,
                 process_parent_id=activation.id,
-                request_id=request_id,
+                request_id=request.headers.get("x-request-id"),
             )
             activation.status = ActivationStatus.ERROR
             activation.status_message = error
@@ -517,7 +512,7 @@ class ActivationViewSet(
         restart_rulebook_process(
             process_parent_type=ProcessParentType.ACTIVATION,
             process_parent_id=activation.id,
-            request_id=request_id,
+            request_id=request.headers.get("x-request-id"),
         )
 
         logger.info(

--- a/src/aap_eda/middleware/request_log_middleware.py
+++ b/src/aap_eda/middleware/request_log_middleware.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import uuid
 from contextvars import ContextVar
 
 from django.utils.deprecation import MiddlewareMixin
@@ -21,7 +22,13 @@ request_id_var = ContextVar("request_id", default="")
 
 class RequestLogMiddleware(MiddlewareMixin):
     def process_request(self, request):
-        req_id = request.headers.get("X-Request-ID", "")
+        req_id = request.headers.get("X-Request-ID")
+
+        if not req_id:
+            req_id = str(uuid.uuid4())
+            request.META["HTTP_X_REQUEST_ID"] = req_id
+            request.__dict__.pop("headers", None)
+
         request.id = req_id
 
         request_id_var.set(req_id)

--- a/src/aap_eda/settings/post_load.py
+++ b/src/aap_eda/settings/post_load.py
@@ -299,6 +299,11 @@ def _get_logging_setup(settings: Dynaconf) -> dict:
                 "level": settings.APP_LOG_LEVEL,
                 "propagate": False,
             },
+            "aap_eda.api": {
+                "handlers": ["request_handler"],
+                "level": settings.APP_LOG_LEVEL,
+                "propagate": False,
+            },
             "aap_eda.wsapi.consumers": {
                 "handlers": ["tracking_handler"],
                 "level": settings.APP_LOG_LEVEL,

--- a/src/aap_eda/wsapi/consumers.py
+++ b/src/aap_eda/wsapi/consumers.py
@@ -28,10 +28,7 @@ from aap_eda.core.utils.credentials import (
     get_secret_fields,
 )
 from aap_eda.core.utils.strings import extract_variables, substitute_variables
-from aap_eda.middleware.request_log_middleware import (
-    assign_log_tracking_id,
-    assign_request_id,
-)
+from aap_eda.middleware.request_log_middleware import assign_log_tracking_id
 from aap_eda.tasks import orchestrator
 
 from .messages import (
@@ -105,7 +102,6 @@ class AnsibleRulebookConsumer(AsyncWebsocketConsumer):
     async def receive(self, text_data=None, bytes_data=None):
         data = json.loads(text_data)
 
-        await self._set_request_id()
         await self._set_log_tracking_id(data)
 
         logger.debug(f"AnsibleRulebookConsumer received: {data}")
@@ -195,15 +191,6 @@ class AnsibleRulebookConsumer(AsyncWebsocketConsumer):
         if activation_instance_id:
             activation = await self.get_activation(activation_instance_id)
             assign_log_tracking_id(activation.log_tracking_id)
-
-    async def _set_request_id(self):
-        headers = {
-            k.decode().lower(): v.decode()
-            for k, v in self.scope.get("headers", [])
-        }
-        request_id = headers.get("x-request-id", "")
-
-        assign_request_id(request_id)
 
     @database_sync_to_async
     def handle_heartbeat(self, message: HeartbeatMessage) -> None:

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import re
 from typing import Any, Dict, List
 from unittest import mock
 from unittest.mock import patch
@@ -1016,6 +1017,13 @@ def test_create_activation_with_invalid_token(
     )
 
 
+class IsUUID:
+    pattern = r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"  # noqa: E501
+
+    def __eq__(self, other):
+        return re.match(self.pattern, other, re.IGNORECASE) is not None
+
+
 @pytest.mark.django_db
 def test_restart_activation_with_required_token_deleted(
     admin_client: APIClient,
@@ -1050,7 +1058,7 @@ def test_restart_activation_with_required_token_deleted(
         mock_stop.assert_called_once_with(
             process_parent_type=enums.ProcessParentType.ACTIVATION,
             process_parent_id=activation_id,
-            request_id="",
+            request_id=IsUUID(),
         )
 
 

--- a/tests/unit/test_request_log_middleware.py
+++ b/tests/unit/test_request_log_middleware.py
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import uuid
+
 import pytest
 from django.http import HttpResponse
 from django.test import RequestFactory
@@ -63,8 +65,11 @@ def test_process_request_without_header(middleware, request_obj):
 
     middleware.process_request(request_obj)
 
-    assert request_obj.id == ""
-    assert get_request_id() == ""
+    request_uuid_obj = uuid.UUID(request_obj.id)
+    assert request_uuid_obj.version == 4
+
+    request_id_obj = uuid.UUID(get_request_id())
+    assert request_id_obj.version == 4
 
 
 def test_process_response(middleware, request_obj):


### PR DESCRIPTION
Request ID should have a default value when there is no Gateway.

https://issues.redhat.com/browse/AAP-42756
