### PR TITLE
limit DE creation to superusers only

### DIFF
--- a/src/aap_eda/api/views/decision_environment.py
+++ b/src/aap_eda/api/views/decision_environment.py
@@ -21,6 +21,7 @@ from drf_spectacular.utils import (
     extend_schema_view,
 )
 from rest_framework import mixins, status, viewsets
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
 from aap_eda.api import exceptions as api_exc, filters, serializers
@@ -41,6 +42,11 @@ resource_name = "DecisionEnvironment"
 
 class CreateDecisionEnvironmentMixin(CreateModelMixin):
     def create(self, request, *args, **kwargs):
+        # Restrict creation to superusers
+        if not request.user.is_superuser:
+            raise PermissionDenied(
+                "Only superusers can create a Decision Environment."
+            )
         response = super().create(request, *args, **kwargs)
 
         logger.info(


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-42682
The purpose of this pr is to limit the ability to create a Decision Environment to superusers ONLY. As noted in the ticket, this is a temporary precaution against the security weakness introduced by [AAP-40840](https://issues.redhat.com/browse/AAP-40840). To this end, I have raised a PermissionDenied  response if the req.user.is_superuser=False.


Testing:
A good way to test the change is to make a request to the DE api, either through the api ui or with the curl command. I can add a test as well in the codebase. 
