### PR TITLE
feat(dispatcherd): Add rq command wrapper AAP-43102

### DIFF
--- a/src/aap_eda/core/management/commands/rqworker.py
+++ b/src/aap_eda/core/management/commands/rqworker.py
@@ -1,0 +1,45 @@
+#  Copyright 2025 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Wrapper for rqworker command."""
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandParser
+from django_rq.management.commands import rqworker
+from flags.state import flag_enabled
+
+
+class Command(BaseCommand):
+    """Wrapper for rqworker command.
+
+    Switches between rqworker and dispatcherd commands based on
+    the dispatcherd feature flag.
+    """
+
+    args = rqworker.Command.args
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        return rqworker.Command.add_arguments(self, parser)
+
+    def handle(self, *args, **options) -> None:
+        if flag_enabled(settings.DISPATCHERD_FEATURE_FLAG_NAME):
+            self.stderr.write(
+                self.style.ERROR(
+                    "DISPATCHERD feature not implemented yet. "
+                    f"Please disable {settings.DISPATCHERD_FEATURE_FLAG_NAME} "
+                    "in your settings.",
+                )
+            )
+            raise SystemExit(1)
+        return rqworker.Command.handle(self, *args, **options)

--- a/src/aap_eda/core/management/commands/scheduler.py
+++ b/src/aap_eda/core/management/commands/scheduler.py
@@ -77,6 +77,7 @@ import django_rq
 import rq_scheduler
 from django.conf import settings
 from django_rq.management.commands import rqscheduler
+from flags.state import flag_enabled
 
 from aap_eda.core import tasking
 from aap_eda.utils.logging import startup_logging
@@ -165,6 +166,17 @@ class Command(rqscheduler.Command):
     help = "Runs RQ scheduler with configured jobs."
 
     def handle(self, *args, **options) -> None:
+        if flag_enabled(settings.DISPATCHERD_FEATURE_FLAG_NAME):
+            self.stderr.write(
+                self.style.ERROR(
+                    "This command is not supported when "
+                    f"{settings.DISPATCHERD_FEATURE_FLAG_NAME} is enabled. "
+                    "Please disable the feature flag in your settings "
+                    "or update your deployment.",
+                )
+            )
+            raise SystemExit(1)
+
         # interval can be set through the command line
         # but we want to manage it through settings
         options["interval"] = settings.RQ_SCHEDULER_JOB_INTERVAL

--- a/src/aap_eda/settings/core.py
+++ b/src/aap_eda/settings/core.py
@@ -44,7 +44,6 @@ INSTALLED_APPS = [
     # Third party apps
     "rest_framework",
     "drf_spectacular",
-    "django_rq",
     "django_filters",
     "ansible_base.rbac",
     "ansible_base.resource_registry",
@@ -54,6 +53,9 @@ INSTALLED_APPS = [
     # Local apps
     "aap_eda.api",
     "aap_eda.core",
+    # rq_worker needs to be loaded after the core app
+    # to wrap the rq worker command
+    "django_rq",
 ]
 
 

--- a/tests/unit/commands/test_rq_cmd_wrapper.py
+++ b/tests/unit/commands/test_rq_cmd_wrapper.py
@@ -1,0 +1,97 @@
+#  Copyright 2025 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from unittest import mock
+
+import pytest
+from django.conf import settings
+from django.core.management import call_command
+from django.test import override_settings
+from django_rq.management.commands import rqscheduler, rqworker
+
+
+@override_settings(
+    FLAGS={
+        settings.DISPATCHERD_FEATURE_FLAG_NAME: [
+            {"condition": "boolean", "value": True},
+        ],
+    }
+)
+@pytest.mark.django_db
+def test_rqworker_command_feature_flag_enabled(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        call_command(
+            "rqworker",
+            worker_class="aap_eda.core.tasking.ActivationWorker",
+        )
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "DISPATCHERD feature not implemented yet" in captured.err
+
+
+@override_settings(
+    FLAGS={
+        settings.DISPATCHERD_FEATURE_FLAG_NAME: [
+            {"condition": "boolean", "value": False},
+        ],
+    }
+)
+@pytest.mark.django_db
+@mock.patch.object(rqworker.Command, "handle", return_value=None)
+def test_rqworker_command_feature_flag_disabled(
+    mock_rqworker_handle,
+):
+    call_command(
+        "rqworker",
+        worker_class="aap_eda.core.tasking.ActivationWorker",
+    )
+
+    mock_rqworker_handle.assert_called_once()
+
+
+@override_settings(
+    FLAGS={
+        settings.DISPATCHERD_FEATURE_FLAG_NAME: [
+            {"condition": "boolean", "value": False},
+        ],
+    }
+)
+@pytest.mark.django_db
+@mock.patch.object(rqscheduler.Command, "handle", return_value=None)
+def test_rqscheduler_command_feature_flag_disabled(
+    mock_rqscheduler_handle,
+):
+    call_command("scheduler")
+
+    mock_rqscheduler_handle.assert_called_once()
+
+
+@override_settings(
+    FLAGS={
+        settings.DISPATCHERD_FEATURE_FLAG_NAME: [
+            {"condition": "boolean", "value": True},
+        ],
+    }
+)
+@pytest.mark.django_db
+@mock.patch.object(rqscheduler.Command, "handle", return_value=None)
+def test_rqscheduler_command_feature_flag_enabled(
+    mock_rqscheduler_handle,
+    capsys,
+):
+    with pytest.raises(SystemExit) as exc_info:
+        call_command("scheduler")
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "This command is not supported" in captured.err


### PR DESCRIPTION
Wrap rq workers commands to switch between the existing rq workers or the future dispatcherd based on the feature flag. 
depends on https://github.com/ansible/eda-server/pull/1257
Jira: https://issues.redhat.com/browse/AAP-43102