### PR TITLE
chore: align backend log levels

### DIFF
--- a/src/aap_eda/api/event_stream_authentication.py
+++ b/src/aap_eda/api/event_stream_authentication.py
@@ -74,8 +74,8 @@ class HMACAuthentication(EventStreamAuthentication):
             )
         else:
             message = (
-                f"Invalid signature encoding {self.signature_encoding} "
-                "should be either base64 or hex"
+                f"Invalid signature encoding {self.signature_encoding}. "
+                "Should be either base64 or hex"
             )
             logger.warning(message)
             raise AuthenticationFailed(message)
@@ -181,7 +181,7 @@ class Oauth2JwtAuthentication(EventStreamAuthentication):
                 options=options,
             )
         except jwt.exceptions.PyJWTError as err:
-            message = f"JWT Error {err}"
+            message = f"JWT error: {err}"
             logger.warning(message)
             raise AuthenticationFailed(message) from err
 

--- a/src/aap_eda/core/utils/rulebook.py
+++ b/src/aap_eda/core/utils/rulebook.py
@@ -126,7 +126,7 @@ def swap_event_stream_sources(
                         event_stream_name, source, event_stream_sources
                     )
                     new_sources.append(updated_source)
-                    LOGGER.debug(
+                    LOGGER.info(
                         "Source %s updated with Event Stream Source",
                         event_stream_name,
                     )
@@ -135,7 +135,7 @@ def swap_event_stream_sources(
                     LOGGER.warning(msg)
                     new_sources.append(source)
             else:
-                LOGGER.debug("Source %s left intact", src_name)
+                LOGGER.info("Source %s left intact", src_name)
                 new_sources.append(source)
 
         ruleset["sources"] = new_sources
@@ -151,5 +151,5 @@ def _updated_event_stream_source(
     updated_source[source_type] = event_stream_sources[name][source_type]
     if "filters" in source:
         updated_source["filters"] = source["filters"]
-    LOGGER.debug("Source %s updated with Event Stream Source", name)
+    LOGGER.info("Source %s updated with Event Stream Source", name)
     return updated_source

--- a/src/aap_eda/services/activation/activation_manager.py
+++ b/src/aap_eda/services/activation/activation_manager.py
@@ -157,7 +157,7 @@ class ActivationManager(StatusManager):
         if not self.latest_instance.activation_pod_id:
             # how we want to handle this case?
             # for now we raise an error and let the monitor correct it
-            msg = f"Activation {self.db_instance.id} has not pod id."
+            msg = f"Activation {self.db_instance.id} has no pod id"
             raise exceptions.ActivationInstancePodIdNotFound(msg)
 
     def _check_non_finalized_instances(self) -> None:
@@ -393,7 +393,7 @@ class ActivationManager(StatusManager):
             )
             user_msg = (
                 "Activation is unresponsive. "
-                f"{check_type} check for ansible rulebook timed out. "
+                f"{check_type} check for ansible-rulebook timed out. "
                 "Restart policy is not applicable."
             )
             container_logger.write(user_msg, flush=True)
@@ -411,7 +411,7 @@ class ActivationManager(StatusManager):
             )
             user_msg = (
                 "Activation is unresponsive. "
-                f"{check_type} check for ansible rulebook timed out. "
+                f"{check_type} check for ansible-rulebook timed out. "
                 "Activation is going to be restarted."
             )
             container_logger.write(user_msg, flush=True)
@@ -476,7 +476,7 @@ class ActivationManager(StatusManager):
             user_msg = (
                 f"Activation completed. It will attempt to restart in "
                 f"{settings.ACTIVATION_RESTART_SECONDS_ON_COMPLETE} seconds "
-                f"according to the restart policy {RestartPolicy.ALWAYS}."
+                f"according to the restart policy {RestartPolicy.ALWAYS}. "
                 "It may take longer if there is no capacity available."
             )
             if container_msg:
@@ -595,7 +595,7 @@ class ActivationManager(StatusManager):
                 f"Activation failed. It will attempt to restart {count_msg} in"
                 f" {settings.ACTIVATION_RESTART_SECONDS_ON_FAILURE} seconds "
                 "according to the restart policy "
-                f"{self.db_instance.restart_policy}."
+                f"{self.db_instance.restart_policy}. "
                 "It may take longer if there is no capacity available."
             )
             if container_msg:
@@ -682,16 +682,16 @@ class ActivationManager(StatusManager):
         try:
             if self._is_already_running():
                 msg = f"Activation {self.db_instance.id} is already running."
-                LOGGER.info(msg)
+                LOGGER.warning(msg)
                 return
         except (
             exceptions.ActivationInstanceNotFound,
             exceptions.ActivationInstancePodIdNotFound,
         ):
-            LOGGER.info(
+            LOGGER.warning(
                 f"Start operation activation id: {self.db_instance.id} "
-                "Expected activation instance or pod id but not found, "
-                "recreating.",
+                "Expected activation instance or pod id but neither "
+                "were found, recreating.",
             )
 
         self._start_activation_instance()
@@ -721,7 +721,7 @@ class ActivationManager(StatusManager):
                 LOGGER.info(msg)
                 return
         except exceptions.ActivationInstanceNotFound:
-            LOGGER.info(
+            LOGGER.error(
                 f"Stop operation activation id: {self.db_instance.id} "
                 "No instance found.",
             )
@@ -786,7 +786,7 @@ class ActivationManager(StatusManager):
         # We catch all exceptions here to ensure that the activation is deleted
         except Exception as exc:
             msg = (
-                f"Activation {self.db_instance.id} failed to cleanup. "
+                f"Activation {self.db_instance.id} failed to clean up. "
                 f"Reason: {exc}"
             )
             LOGGER.error(msg)
@@ -1027,7 +1027,7 @@ class ActivationManager(StatusManager):
         except engine_exceptions.ContainerEngineError as exc:
             msg = (
                 f"Logs for activation {self.db_instance.id} could not be "
-                f"fetch. Reason: {exc}"
+                f"retrieved. Reason: {exc}"
             )
             LOGGER.error(msg)
             log_handler.write(msg, flush=True)

--- a/src/aap_eda/services/activation/engine/kubernetes.py
+++ b/src/aap_eda/services/activation/engine/kubernetes.py
@@ -167,8 +167,8 @@ class Engine(ContainerEngine):
                     status=ActivationStatus.FAILED,
                     message=container_status.state.terminated.message or "",
                 )
-                LOGGER.info(
-                    f"Pod exited with {exit_code}, reason "
+                LOGGER.warning(
+                    f"Pod exited with {exit_code}. Reason: "
                     f"{container_status.state.terminated.reason}"
                 )
         else:
@@ -391,7 +391,7 @@ class Engine(ContainerEngine):
                 )
                 LOGGER.info(f"Created Service: {service_name}")
             else:
-                LOGGER.info(f"Service already exists: {service_name}")
+                LOGGER.warning(f"Service already exists: {service_name}")
                 opened_ports = [
                     port_item.port for port_item in service.items[0].spec.ports
                 ]

--- a/src/aap_eda/services/activation/engine/podman.py
+++ b/src/aap_eda/services/activation/engine/podman.py
@@ -321,6 +321,7 @@ class Engine(ContainerEngine):
 
         return ports
 
+    # TODO: remove this obsolete method
     def _login(self, request: ContainerRequest) -> None:
         credential = request.credential
         if not credential:
@@ -334,9 +335,7 @@ class Engine(ContainerEngine):
                 registry=registry,
             )
 
-            LOGGER.debug(
-                f"{credential.username} login succeeded to {registry}"
-            )
+            LOGGER.info(f"{credential.username} login succeeded to {registry}")
         except APIError as e:
             LOGGER.error(
                 f"Login failed: {e.explanation}",

--- a/src/aap_eda/services/activation/restart_helper.py
+++ b/src/aap_eda/services/activation/restart_helper.py
@@ -36,7 +36,7 @@ def system_cancel_restart_activation(
 
     The restart may not exist.
     """
-    LOGGER.debug(f"Cancelling auto-start for {process_parent_type} {id}")
+    LOGGER.info(f"Cancelling auto-start for {process_parent_type} {id}")
     queue_cancel_job("default", auto_start_job_id(process_parent_type, id))
 
 
@@ -48,7 +48,7 @@ def system_restart_activation(
     This function is intended to be used by the manager to schedule
     a start of the activation for restart policies.
     """
-    LOGGER.debug(
+    LOGGER.info(
         f"Queuing auto-start for {process_parent_type} {id} "
         f"in {delay_seconds} seconds",
     )

--- a/src/aap_eda/services/project/imports.py
+++ b/src/aap_eda/services/project/imports.py
@@ -235,7 +235,7 @@ class ProjectImportService:
                     )
                     continue
                 if not info:
-                    logger.debug("Not a rulebook file: %s", path)
+                    logger.warning("Not a rulebook file: %s", path)
                     continue
                 yield info
 

--- a/src/aap_eda/tasks/orchestrator.py
+++ b/src/aap_eda/tasks/orchestrator.py
@@ -213,7 +213,7 @@ def dispatch(
                 "There may be an issue with the system; please contact "
                 "the administrator."
             )
-            LOGGER.warning(msg)
+            LOGGER.error(msg)
             status_manager.set_status(
                 ActivationStatus.PENDING,
                 msg,
@@ -257,7 +257,7 @@ def dispatch(
                     "There may be an issue with the system; please "
                     "contact the administrator."
                 )
-                LOGGER.warning(msg)
+                LOGGER.error(msg)
                 status_manager.set_status(
                     ActivationStatus.PENDING,
                     msg,
@@ -294,18 +294,16 @@ def dispatch(
                     ActivationStatus.WORKERS_OFFLINE,
                     msg,
                 )
-                LOGGER.warning(msg)
+                LOGGER.error(msg)
                 return
 
             # The queue is unhealthy, but this is a restart.
             # The priority is to adhere to the restart policy and
             # execute the task.
             LOGGER.warning(
-                f"Restarting {process_parent_type} {process_parent_id} "
-                "on the least busy queue; The workers of its associated queue "
-                f"'{queue_name}' are failing liveness checks. "
-                "There may be an issue with the worker node; please contact "
-                "the administrator.",
+                f"Forcing user restart of {process_parent_type} "
+                f"{process_parent_id} on the least busy queue; "
+                "after failing liveness checks of current associated queue"
             )
             try:
                 queue_name = get_least_busy_queue_name()
@@ -316,7 +314,7 @@ def dispatch(
                     f"{process_parent_id}. There may be an issue "
                     "with the system; please contact the administrator."
                 )
-                LOGGER.warning(msg)
+                LOGGER.error(msg)
                 status_manager.set_status(
                     ActivationStatus.PENDING,
                     msg,

--- a/src/aap_eda/utils/__init__.py
+++ b/src/aap_eda/utils/__init__.py
@@ -26,5 +26,9 @@ def get_package_version(package_name: str) -> str:
     try:
         return importlib.metadata.version(package_name)
     except importlib.metadata.PackageNotFoundError:
-        logger.error("Cannot read version from %s package", package_name)
+        logger.error(
+            "The package '%s' is not installed; returning 'unknown' "
+            "version for it",
+            package_name,
+        )
         return "unknown"

--- a/src/aap_eda/wsapi/consumers.py
+++ b/src/aap_eda/wsapi/consumers.py
@@ -226,7 +226,7 @@ class AnsibleRulebookConsumer(AsyncWebsocketConsumer):
             )
 
             # TODO: broadcasting
-            logger.debug(f"Job instance {job_instance.id} is broadcasting.")
+            logger.info(f"Job instance {job_instance.id} is broadcasting.")
 
         created = event_data.get("created")
         if created:
@@ -452,7 +452,7 @@ class AnsibleRulebookConsumer(AsyncWebsocketConsumer):
                         password=inputs.get("password", ""),
                     )
         except ObjectDoesNotExist:
-            logger.debug("AAP credential type not found")
+            logger.warning('"AAP" credential type not found')
             return None
 
     @database_sync_to_async
@@ -521,7 +521,7 @@ class AnsibleRulebookConsumer(AsyncWebsocketConsumer):
                 urlparts.fragment,
             ]
         )
-        logger.debug("Updated Job URL %s", result)
+        logger.info("Updated Job URL %s", result)
         return result
 
     @database_sync_to_async
@@ -549,7 +549,7 @@ class AnsibleRulebookConsumer(AsyncWebsocketConsumer):
                     template, binary_fields, value, inputs
                 )
                 if not message:
-                    logger.info(
+                    logger.warning(
                         f"{template} is skipped because its content is empty"
                     )
                     continue

--- a/tests/integration/services/activation/test_manager.py
+++ b/tests/integration/services/activation/test_manager.py
@@ -772,7 +772,7 @@ def test_delete_with_exception(
     activation_manager.delete()
     assert container_engine_mock.cleanup.called
     assert "Delete operation requested" in eda_caplog.text
-    assert "failed to cleanup." in eda_caplog.text
+    assert "failed to clean up." in eda_caplog.text
     assert (
         models.Activation.objects.filter(id=running_activation.id).count() == 0
     )

--- a/tests/integration/services/test_project_import.py
+++ b/tests/integration/services/test_project_import.py
@@ -314,5 +314,5 @@ def test_project_import_with_invalid_rulebooks(
 
     assert project.git_hash == "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc"
     assert project.import_state == models.Project.ImportState.COMPLETED
-    assert caplog.text.count("WARNING") == 10
+    assert caplog.text.count("WARNING") == 20
     assert project.rulebook_set.count() == 1

--- a/tests/integration/wsapi/test_consumer.py
+++ b/tests/integration/wsapi/test_consumer.py
@@ -1378,7 +1378,7 @@ async def test_get_controller_info_from_aap_cred(
     await remove_credential_type(eda_credential.credential_type)
     result = await consumer.get_controller_info_from_aap_cred(activation)
     assert result is None
-    assert "AAP credential type not found" in eda_caplog.text
+    assert '"AAP" credential type not found' in eda_caplog.text
 
 
 @database_sync_to_async

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -57,7 +57,7 @@ def test_get_package_version(caplog_factory):
     # assert outcome when package is not found
     with patch("importlib.metadata.version", side_effect=PackageNotFoundError):
         assert get_package_version("aap-eda") == "unknown"
-        assert "Cannot read version" in eda_caplog.text
+        assert "returning 'unknown' version" in eda_caplog.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Aligning logger levels in the backend to match our definitions in [AAP-41838](https://issues.redhat.com/browse/AAP-41838). An outline of the agreed definitions:
**Debug:** Detailed information for developers, useful for debugging.
**Info:** General operational messages that indicate normal progress of the application.
**Warning:** Something unexpected happened, but the application can recover and continue running.
**Error:** A failure occurred that prevents some part of the application from functioning correctly, but the system is still running.

We currently do not use "Critical" anywhere in the backend logs. 

I have also included some minor cosmetic changes to the log messages. More changes could have been done to align our messages across the board, but this would have resulted in scope creep and a lot more files modified. Further cosmetic changes should be handled separately.

<!-- What is being changed? -->

<!-- Why is this change needed? -->
<!-- How does this change address the issue? -->
<!-- Does this change introduce any new dependencies, blockers or breaking changes? -->
<!-- How it can be tested? -->
