### PR TITLE
feat(dispatcherd): add advisory lock for task uniqueness

### DIFF
--- a/src/aap_eda/settings/core.py
+++ b/src/aap_eda/settings/core.py
@@ -173,11 +173,9 @@ RQ_STARTUP_JOBS = [
 # the scheduler running to avoid duplicate jobs
 RQ_PERIODIC_JOBS = [
     {
-        "func": (
-            "aap_eda.tasks.orchestrator.enqueue_monitor_rulebook_processes"
-        ),
+        "func": ("aap_eda.tasks.orchestrator.monitor_rulebook_processes"),
         "interval": 5,
-        "id": "enqueue_monitor_rulebook_processes",
+        "id": "monitor_rulebook_processes",
     },
     {
         "func": "aap_eda.tasks.project.monitor_project_tasks",

--- a/src/aap_eda/wsapi/consumers.py
+++ b/src/aap_eda/wsapi/consumers.py
@@ -211,7 +211,7 @@ class AnsibleRulebookConsumer(AsyncWebsocketConsumer):
             activation.save(update_fields=["ruleset_stats"])
 
             if activation.status == ActivationStatus.STARTING:
-                orchestrator.enqueue_monitor_rulebook_processes()
+                orchestrator.monitor_rulebook_processes.delay()
         else:
             logger.warning(
                 f"Activation instance {message.activation_id} is not present."

--- a/tests/integration/test_advisory_lock.py
+++ b/tests/integration/test_advisory_lock.py
@@ -1,0 +1,87 @@
+import time
+from concurrent.futures import ThreadPoolExecutor, wait
+from threading import Lock
+from unittest import mock
+
+import pytest
+
+from tests.integration.utils import ThreadSafeList
+
+
+@pytest.mark.parametrize(
+    "module_data",
+    [
+        {
+            "module_path": "aap_eda.tasks.analytics",
+            "fn_mock": "_gather_analytics",
+            "fn_call": "gather_analytics",
+            "fn_args": [],
+        },
+        {
+            "module_path": "aap_eda.tasks.orchestrator",
+            "fn_mock": "monitor_rulebook_processes_no_lock",
+            "fn_call": "monitor_rulebook_processes",
+            "fn_args": [],
+        },
+        {
+            "module_path": "aap_eda.tasks.project",
+            "fn_mock": "_import_project",
+            "fn_call": "import_project",
+            "fn_args": [1],
+        },
+        {
+            "module_path": "aap_eda.tasks.project",
+            "fn_mock": "_sync_project",
+            "fn_call": "sync_project",
+            "fn_args": [1],
+        },
+        {
+            "module_path": "aap_eda.tasks.project",
+            "fn_mock": "_monitor_project_tasks",
+            "fn_call": "monitor_project_tasks",
+            "fn_args": [],
+        },
+    ],
+    ids=[
+        "gather_analytics",
+        "monitor_rulebook_processes",
+        "import_project",
+        "sync_project",
+        "monitor_project_tasks",
+    ],
+)
+@pytest.mark.django_db
+def test_job_uniqueness(module_data):
+    call_log = []
+    lock = Lock()
+
+    def gather_analytics_wrapper_call(shared_list):
+        """Patch _gather_analytics in a thread-safe way inside each thread."""
+        import importlib
+
+        module = importlib.import_module(module_data["module_path"])
+
+        importlib.reload(module)
+
+        with mock.patch(
+            f"{module_data['module_path']}.{module_data['fn_mock']}",
+        ) as fn_mock:
+
+            def record_call(void=None):
+                time.sleep(1)
+                shared_list.append("called")
+
+            fn_mock.side_effect = record_call
+            getattr(module, module_data["fn_call"])(*module_data["fn_args"])
+
+    def thread_safe_call():
+        gather_analytics_wrapper_call(ThreadSafeList(call_log, lock))
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(thread_safe_call),
+            executor.submit(thread_safe_call),
+        ]
+        wait(futures, timeout=3)
+
+    assert len(call_log) == 1

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -1,0 +1,23 @@
+#  Copyright 2025 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+class ThreadSafeList:
+    def __init__(self, base_list, lock):
+        self.base_list = base_list
+        self.lock = lock
+
+    def append(self, item):
+        with self.lock:
+            self.base_list.append(item)

--- a/tests/integration/wsapi/test_consumer.py
+++ b/tests/integration/wsapi/test_consumer.py
@@ -511,13 +511,13 @@ async def test_handle_heartbeat_running_status(
         for stat in stats
     ]
     with patch(
-        "aap_eda.tasks.orchestrator.enqueue_monitor_rulebook_processes"
+        "aap_eda.tasks.orchestrator.monitor_rulebook_processes"
     ) as mock_orchestrator:
         for payload in payloads:
             await ws_communicator.send_json_to(payload)
 
         await ws_communicator.wait()
-        mock_orchestrator.assert_called_once()
+        mock_orchestrator.delay.assert_called_once()
 
 
 @pytest.mark.django_db(transaction=True)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -497,6 +497,7 @@ def test_check_rulebook_queue_health_some_workers_alive(setup_queue_health):
     assert result is True
 
 
+@pytest.mark.django_db
 def test_manage_monitor_called_with_no_requests(
     process_parent, mock_get_parent, mock_requests_queue
 ):

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -27,7 +27,6 @@ from aap_eda.settings import default
 from aap_eda.tasks import orchestrator
 from aap_eda.tasks.exceptions import UnknownProcessParentType
 from aap_eda.tasks.orchestrator import (
-    HealthyQueueNotFoundError,
     _manage,
     check_rulebook_queue_health,
     get_least_busy_queue_name,
@@ -289,6 +288,8 @@ def test_get_least_busy_queue_name(fixture, request):
         expected_queue = min(responsive_queues, key=lambda q: q.count())
         assert get_least_busy_queue_name() == expected_queue.name
     else:
+        from aap_eda.tasks.orchestrator import HealthyQueueNotFoundError
+
         with pytest.raises(HealthyQueueNotFoundError):
             get_least_busy_queue_name()
 


### PR DESCRIPTION
For the PoC of dispatcherd we used [pg advisory_locks](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS) to ensure job uniqueness. It will be part of the final implementation. It has been so far a robust and simpler way to ensure uniqueness in comparison to existing `unique_enqueue` helper, which would not have a replacement. 

Since the use of the advisory lock is not tied to dispatcherd, this PR explores its use as well for the current implementation with RQ redis, assuming that will simplify the later implementation under a feature flag of the dispatcherd itself. 

There is no functional change and everything should work transparently. I have been testing it extensively and tomorrow will do more battery of tests, I have confidence. I leave the open the draft so the rest of the team can look at the code as well as perform their own tests if you want. 

Jira: https://issues.redhat.com/browse/AAP-43538

