### PR TITLE
[AAP-43604] fix: properly detect whether source_mappings are empty

### DIFF
--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -703,7 +703,7 @@ class ActivationUpdateSerializer(serializers.ModelSerializer):
             vault_data = VaultData(inputs["vault_password"], True)
         else:
             vault_data = VaultData()
-        if self.validated_data.get("source_mappings", []):
+        if yaml.safe_load(self.validated_data.get("source_mappings", "")):
             if not rulebook_id:
                 # load the original ruleset
                 self.validated_data[

--- a/tests/integration/api/test_activation_with_event_stream.py
+++ b/tests/integration/api/test_activation_with_event_stream.py
@@ -873,13 +873,13 @@ def test_update_activation_with_everything(
     # test clearing event stream mapping
     test_activation5 = {
         "rulebook_id": fks2["rulebook_id"],
-        "source_mappings": "",
+        "source_mappings": "[]\n",
     }
     response = admin_client.patch(
         f"{api_url_v1}/activations/{activation_id}/", data=test_activation5
     )
     assert_updated_event_stream_mapping(
-        response, ["ansible.eda.range"], "", ""
+        response, ["ansible.eda.range"], "[]", ""
     )
     assert response.data["extra_var"] != extra_var
     assert response.data["extra_var"] in extra_var


### PR DESCRIPTION
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
When the even streams are removed from an activation, the UI sends "[]\n" to the backend which were interpreted non-empty thus the event stream credential was mistakenly added.
<!-- If applicable, provide a link to the issue that is being addressed -->
[AAP-43604](https://issues.redhat.com/browse/AAP-43604)
<!-- What is being changed? -->
Parse the source_mapping string and accurately determine whether there are source mapping or empty. Only inject the extra_vars when there are true source mappings.

