### PR TITLE
[AAP-43866] fix: do not wrap with run_with_lock for _check_start_prerequirements

### DIFF
--- a/src/aap_eda/services/activation/activation_manager.py
+++ b/src/aap_eda/services/activation/activation_manager.py
@@ -106,7 +106,6 @@ class ActivationManager(StatusManager):
         self.db_instance.restart_count += 1
         self.db_instance.save(update_fields=["restart_count", "modified_at"])
 
-    @run_with_lock
     def _check_start_prerequirements(self) -> None:
         """Check if the activation can be started."""
         disallowed_statuses = [


### PR DESCRIPTION
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
The error status and status_message were rolled back by the transaction manager. User cannot get the true error.
<!-- If applicable, provide a link to the issue that is being addressed -->
[AAP-43866](https://issues.redhat.com/browse/AAP-43866)
<!-- What is being changed? -->
Remove `@run_with_lock` for `_check_start_prerequirements` otherwise the error raised by https://github.com/ansible/eda-server/blob/main/src/aap_eda/services/activation/activation_manager.py#L143 will roll back the status change in one line above. 

