### PR TITLE
chore: update tests to retrieve host var from settings

### DIFF
--- a/tests/integration/core/test_tasking.py
+++ b/tests/integration/core/test_tasking.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 
 import pytest
 import redis
+from django.conf import settings
 
 from aap_eda.core.tasking import (
     DefaultWorker,
@@ -116,7 +117,7 @@ def test_redis_ha_dab_url():
     url = _create_url_from_parameters(
         **redis_settings.rq_redis_client_instantiation_parameters()
     )
-    assert url == "rediss://localhost:6379"
+    assert url == f"rediss://{settings.REDIS_HOST}:6379"
 
 
 @patch("aap_eda.settings.redis.settings.REDIS_UNIX_SOCKET_PATH", None)

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import pytest
+from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from dynaconf import Dynaconf
 
@@ -43,7 +44,7 @@ def redis_settings(mock_settings):
     mock_settings.REDIS_USER = defaults.MQ_USER
     mock_settings.REDIS_USER_PASSWORD = defaults.MQ_USER_PASSWORD
     mock_settings.REDIS_UNIX_SOCKET_PATH = defaults.MQ_UNIX_SOCKET_PATH
-    mock_settings.REDIS_HOST = defaults.MQ_HOST
+    mock_settings.REDIS_HOST = settings.MQ_HOST
     mock_settings.REDIS_PORT = defaults.MQ_PORT
     mock_settings.REDIS_TLS = defaults.MQ_TLS
     mock_settings.REDIS_CLIENT_KEY_PATH = defaults.MQ_CLIENT_KEY_PATH


### PR DESCRIPTION
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
This PR changes tests to dynamically retrieve `REDIS_HOST` from settings in order to fix failures in case `REDIS_HOST` might be defined differently. 
<!-- If applicable, provide a link to the issue that is being addressed -->

<!-- What is being changed? -->
<!-- Why is this change needed? -->
<!-- How does this change address the issue? -->
<!-- Does this change introduce any new dependencies, blockers or breaking changes? -->
<!-- How it can be tested? -->
