### PR TITLE
[AAP-43742] fix: auto generate service name. Do not throw error

### DIFF
--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Install dependencies
         working-directory: ${{ env.EDA_QA_PATH }}
@@ -154,7 +154,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Install dependencies
         working-directory: ${{ env.EDA_QA_PATH }}

--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -48,10 +48,7 @@ from aap_eda.core import models, validators
 from aap_eda.core.enums import DefaultCredentialType, ProcessParentType
 from aap_eda.core.exceptions import ParseError
 from aap_eda.core.utils.credentials import get_secret_fields
-from aap_eda.core.utils.k8s_service_name import (
-    InvalidRFC1035LabelError,
-    create_k8s_service_name,
-)
+from aap_eda.core.utils.k8s_service_name import create_k8s_service_name
 from aap_eda.core.utils.rulebook import (
     build_source_list,
     get_rulebook_hash,
@@ -1149,13 +1146,6 @@ def _validate_credentials_and_token_and_rulebook(
 
     # validate rulebook
     _validate_rulebook(data, awx_token is not None)
-
-    # validate if activation name is compatible with RFC 1035
-    if not data.get("k8s_service_name") and settings.DEPLOYMENT_TYPE == "k8s":
-        try:
-            create_k8s_service_name(data["name"])
-        except InvalidRFC1035LabelError as e:
-            raise serializers.ValidationError({"k8s_service_name": [str(e)]})
 
 
 def _validate_awx_token(data: dict) -> models.AwxToken:

--- a/src/aap_eda/core/utils/k8s_service_name.py
+++ b/src/aap_eda/core/utils/k8s_service_name.py
@@ -13,24 +13,21 @@
 #  limitations under the License.
 
 import re
-
-
-class InvalidRFC1035LabelError(Exception):
-    pass
+import uuid
 
 
 def create_k8s_service_name(activation_name: str) -> str:
     """Attempt to convert the activation name to a 1035 name.
 
-    Convert dot(.) underscore(_) space( ) to - and convert it to lowercase
+    Convert non qualified letters to - and convert it to lowercase
     """
-    name = re.sub(r"[._\s+]", "-", activation_name.lower())
-    if not is_rfc_1035_compliant(name):
-        raise InvalidRFC1035LabelError(
-            "Please provide a name, that's a valid RFC 1035 name, "
-            "couldn't auto generate a service name"
-        )
+    name = re.sub(r"[^a-z0-9\-]+", "-", activation_name.lower())
+    name = re.sub(r"^[0-9-]+", "", name.rstrip("-"))
+    if len(name) > 63:
+        name = f"{name[0:61]}-{name[-1]}"
 
+    if not name:
+        name = f"service-{uuid.uuid4()}"
     return name
 
 

--- a/tests/integration/api/test_k8s_activation.py
+++ b/tests/integration/api/test_k8s_activation.py
@@ -125,12 +125,6 @@ def use_k8s_setting(settings):
             status.HTTP_201_CREATED,
             None,
         ),
-        (
-            "78_inconvertable_invalid_activation_name",
-            None,
-            status.HTTP_400_BAD_REQUEST,
-            "k8s_service_name",
-        ),
     ],
 )
 def test_create_k8s_activation_with_service_name(


### PR DESCRIPTION
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
Enhance `create_k8s_service_name(activation_nam)` to accept any activation name
<!-- If applicable, provide a link to the issue that is being addressed -->
[AAP-43742](https://issues.redhat.com/browse/AAP-43742)
<!-- What is being changed? -->
For k8s deployment we always prepare a service name in case it is needed for the rulebook. The current implementation of `create_k8s_service_name(activation_nam)` converts some non rfc_1035 compliant letters such as dot and _ into -, but rejects other non-qualified letters. This prevents the users from creating activation with a name containing such letters even if the service is not eventually needed.
The solution is to always create a rfc_1035_compliant service name. Never reject an activation name. Activation name is used only as a reference to create the service name. No special requirements should be imposed.

