### PR TITLE
fix: [AAP-44575] Always use AUTOMATION_ANALYTICS_URL from EDA settings

### DIFF
--- a/src/aap_eda/analytics/utils.py
+++ b/src/aap_eda/analytics/utils.py
@@ -251,10 +251,9 @@ def get_proxy_url() -> str:
 
 
 def get_analytics_url() -> str:
-    return (
-        application_settings.AUTOMATION_ANALYTICS_URL
-        or settings.AUTOMATION_ANALYTICS_URL
-    )
+    # TODO: Temporarily remove checking on the gateway's application_settings
+    # Remeber to add it back when gateway supports analytics
+    return settings.AUTOMATION_ANALYTICS_URL
 
 
 def get_client_id() -> str:

--- a/tests/integration/analytics/test_package.py
+++ b/tests/integration/analytics/test_package.py
@@ -54,9 +54,7 @@ def test_get_ingress_url(package: Package, mock_settings) -> None:
     mock_credentials = MagicMock()
     mock_credentials.return_value.exists.return_value = False
 
-    with patch(
-        "aap_eda.analytics.utils.application_settings", new=mock_settings
-    ), patch(
+    with patch("aap_eda.analytics.utils.settings", new=mock_settings), patch(
         "aap_eda.analytics.utils._get_analytics_credentials",
         return_value=mock_credentials,
     ):


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-44575

Ignore AUTOMATION_ANALYTICS_URL from the application settings set by the Gateway.