### PR TITLE
fix: [AAP-43898] update status endpoint response to DAB enum

### DIFF
--- a/src/aap_eda/core/views.py
+++ b/src/aap_eda/core/views.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from ansible_base.lib.constants import STATUS_FAILED, STATUS_GOOD
 from django.db import connection
 from django.db.utils import OperationalError
 from drf_spectacular.utils import OpenApiResponse, extend_schema
@@ -54,9 +55,12 @@ class StatusView(APIView):
     def get(self, request):
         try:
             connection.ensure_connection()
-            return Response({"status": "OK"}, status=status.HTTP_200_OK)
+            return Response({"status": STATUS_GOOD}, status=status.HTTP_200_OK)
         except OperationalError:
             return Response(
-                {"status": "error", "message": "Database connection failed"},
+                {
+                    "status": STATUS_FAILED,
+                    "message": "Database connection failed",
+                },
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )

--- a/tests/integration/core/test_views.py
+++ b/tests/integration/core/test_views.py
@@ -1,4 +1,5 @@
 import pytest
+from ansible_base.lib.constants import STATUS_GOOD
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -20,4 +21,4 @@ def test_status_view():
     client.force_authenticate(user=None)
     response = client.get(f"{api_url_v1}/status/")
     assert response.status_code == status.HTTP_200_OK
-    assert response.data == {"status": "OK"}
+    assert response.data == {"status": STATUS_GOOD}


### PR DESCRIPTION
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
<!-- If applicable, provide a link to the issue that is being addressed -->
Change the response from `/v1/status/` endpoint to use enum provided by DAB.

JIRA: [AAP-43898](https://issues.redhat.com/browse/AAP-43898)
<!-- What is being changed? -->
<!-- Why is this change needed? -->
<!-- How does this change address the issue? -->
<!-- Does this change introduce any new dependencies, blockers or breaking changes? -->
<!-- How it can be tested? -->
