### PR TITLE
fix: change error field from rulebook to source_mappings

### DIFF
--- a/src/aap_eda/api/constants.py
+++ b/src/aap_eda/api/constants.py
@@ -14,4 +14,4 @@
 
 # EDA_SERVER_VAULT_LABEL is reserved for system vault password identifiers
 EDA_SERVER_VAULT_LABEL = "EDA_SERVER"
-SOURCE_MAPPING_ERROR_KEY = "rulebook"
+SOURCE_MAPPING_ERROR_KEY = "source_mappings"


### PR DESCRIPTION
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
The error "Rulebook has changed since the sources were mapped. Please reattach event streams" is caused by validating field source_mappings.
<!-- If applicable, provide a link to the issue that is being addressed -->
[AAP-44583](https://issues.redhat.com/browse/AAP-44583)
<!-- What is being changed? -->
This fix changes the validate error message of the 404 error body from key rulebook to source_mappings. The key must match the actual field in the creation/update body so that the UI can correctly highlight the field for user to fix error.

