### PR TITLE
fix: reschedule analytics when interval changes in credential

### DIFF
--- a/src/aap_eda/analytics/utils.py
+++ b/src/aap_eda/analytics/utils.py
@@ -311,6 +311,13 @@ def get_analytics_interval() -> int:
         return ANALYTICS_GATHER_INTERVAL
 
 
+def get_analytics_interval_if_exist(credential: models.EdaCredential) -> int:
+    if credential.credential_type.kind != get_auth_mode():
+        return 0
+    inputs = inputs_from_store(credential.inputs.get_secret_value())
+    return inputs.get("gather_interval", 0)
+
+
 def _validate_credential() -> None:
     if _get_analytics_credentials().exists():
         return


### PR DESCRIPTION
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
When the gather interval in the analytics credential changes, before the fix eda-server will wait until the scheduled analytics based on the old interval is executed, and then schedule the next job with the new interval. The fix immediately cancels the scheduled job and reschedules the next job to run at the new interval
<!-- If applicable, provide a link to the issue that is being addressed -->
[AAP-44570](https://issues.redhat.com/browse/AAP-44570)
