### PR TITLE
refactor: rename dispatch to queue_dispatch

### DIFF
--- a/src/aap_eda/tasks/orchestrator.py
+++ b/src/aap_eda/tasks/orchestrator.py
@@ -180,7 +180,7 @@ def _run_request(
     return True
 
 
-def dispatch(
+def queue_dispatch(
     process_parent_type: ProcessParentType,
     process_parent_id: int,
     request_type: Optional[ActivationRequest],
@@ -534,7 +534,7 @@ def monitor_rulebook_processes_no_lock() -> None:
     """
     # run pending user requests
     for request in requests_queue.list_requests():
-        dispatch(
+        queue_dispatch(
             request.process_parent_type,
             request.process_parent_id,
             request.request,
@@ -552,7 +552,7 @@ def monitor_rulebook_processes_no_lock() -> None:
         process_parent_type = str(process.parent_type)
         process_parent_id = process.activation_id
 
-        dispatch(
+        queue_dispatch(
             process_parent_type,
             process_parent_id,
             None,

--- a/tests/integration/tasks/test_orchestrator.py
+++ b/tests/integration/tasks/test_orchestrator.py
@@ -333,7 +333,7 @@ def test_dispatch_existing_rq_jobs(
     )
     activation.status = ActivationStatus.STOPPED
     activation.save(update_fields=["status"])
-    orchestrator.dispatch(
+    orchestrator.queue_dispatch(
         ProcessParentType.ACTIVATION, activation.id, ActivationRequest.START
     )
     enqueue_mock.assert_not_called()


### PR DESCRIPTION
Minor refactor around the function `dispatch` this is to avoid confusion with dispatcherd. 