### PR TITLE
refactor: get feature flags from features module

### DIFF
--- a/src/aap_eda/analytics/collector.py
+++ b/src/aap_eda/analytics/collector.py
@@ -16,13 +16,14 @@ import logging
 from datetime import datetime
 from typing import Optional
 
+from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import connection
-from flags.state import flag_enabled
 from insights_analytics_collector import Collector
 
 from aap_eda.analytics import analytics_collectors, package, utils
 from aap_eda.conf.settings import application_settings
+from aap_eda.settings import features
 
 
 class AnalyticsCollector(Collector):
@@ -35,10 +36,7 @@ class AnalyticsCollector(Collector):
         return package.Package
 
     def _is_shipping_configured(self) -> bool:
-        if (
-            not flag_enabled("FEATURE_EDA_ANALYTICS_ENABLED")
-            or not utils.get_insights_tracking_state()
-        ):
+        if not features.ANALYTICS or not utils.get_insights_tracking_state():
             self.logger.warning(
                 "Insights for Event Driven Ansible is not enabled."
             )
@@ -91,8 +89,8 @@ class AnalyticsCollector(Collector):
 def gather(collection_type="scheduled", since=None, until=None, logger=None):
     if not logger:
         logger = logging.getLogger("aap_eda.analytics")
-    if not flag_enabled("FEATURE_EDA_ANALYTICS_ENABLED"):
-        logger.info("FEATURE_EDA_ANALYTICS_ENABLED is set to False.")
+    if not features.ANALYTICS:
+        logger.info(f"{settings.ANALYTICS_FEATURE_FLAG_NAME} is set to False.")
         return
     collector = AnalyticsCollector(
         collector_module=analytics_collectors,

--- a/src/aap_eda/core/management/commands/create_initial_data.py
+++ b/src/aap_eda/core/management/commands/create_initial_data.py
@@ -23,13 +23,13 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.management import BaseCommand
 from django.db import transaction
 from django.db.models import Q
-from flags.state import flag_enabled
 
 from aap_eda.conf import settings_registry
 from aap_eda.core import enums, models
 from aap_eda.core.models.utils import get_default_organization
 from aap_eda.core.tasking import enable_redis_prefix
 from aap_eda.core.utils.credentials import inputs_to_store
+from aap_eda.settings import features
 
 NEW_HELP_TEXT = (
     "Red Hat Ansible Automation Platform base URL to authenticate with.",
@@ -1255,7 +1255,7 @@ def populate_credential_types(
     for credential_type_data in credential_types:
         # Analytics credential types are only available when it's enabled
         if (
-            not flag_enabled("FEATURE_EDA_ANALYTICS_ENABLED")
+            not features.ANALYTICS
             and credential_type_data.get("name")
             in enums.SINGLETON_CREDENTIAL_TYPES
         ):

--- a/src/aap_eda/core/management/commands/gather_analytics.py
+++ b/src/aap_eda/core/management/commands/gather_analytics.py
@@ -16,10 +16,11 @@ import logging
 from datetime import timezone
 
 from dateutil import parser
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandParser
-from flags.state import flag_enabled
 
 from aap_eda.analytics import collector
+from aap_eda.settings import features
 
 
 class Command(BaseCommand):
@@ -71,8 +72,10 @@ class Command(BaseCommand):
         opt_since = options.get("since")
         opt_until = options.get("until")
 
-        if not flag_enabled("FEATURE_EDA_ANALYTICS_ENABLED"):
-            self.logger.error("FEATURE_EDA_ANALYTICS_ENABLED is set to False.")
+        if not features.ANALYTICS:
+            self.logger.error(
+                f"{settings.ANALYTICS_FEATURE_FLAG_NAME} is set to False."
+            )
             return
 
         since = parser.parse(opt_since) if opt_since else None

--- a/src/aap_eda/core/management/commands/rqworker.py
+++ b/src/aap_eda/core/management/commands/rqworker.py
@@ -17,7 +17,8 @@
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandParser
 from django_rq.management.commands import rqworker
-from flags.state import flag_enabled
+
+from aap_eda.settings import features
 
 
 class Command(BaseCommand):
@@ -33,7 +34,7 @@ class Command(BaseCommand):
         return rqworker.Command.add_arguments(self, parser)
 
     def handle(self, *args, **options) -> None:
-        if flag_enabled(settings.DISPATCHERD_FEATURE_FLAG_NAME):
+        if features.DISPATCHERD:
             self.stderr.write(
                 self.style.ERROR(
                     "DISPATCHERD feature not implemented yet. "

--- a/src/aap_eda/core/management/commands/scheduler.py
+++ b/src/aap_eda/core/management/commands/scheduler.py
@@ -77,9 +77,9 @@ import django_rq
 import rq_scheduler
 from django.conf import settings
 from django_rq.management.commands import rqscheduler
-from flags.state import flag_enabled
 
 from aap_eda.core import tasking
+from aap_eda.settings import features
 from aap_eda.utils.logging import startup_logging
 
 logger = logging.getLogger(__name__)
@@ -166,7 +166,7 @@ class Command(rqscheduler.Command):
     help = "Runs RQ scheduler with configured jobs."
 
     def handle(self, *args, **options) -> None:
-        if flag_enabled(settings.DISPATCHERD_FEATURE_FLAG_NAME):
+        if features.DISPATCHERD:
             self.stderr.write(
                 self.style.ERROR(
                     "This command is not supported when "

--- a/src/aap_eda/settings/core.py
+++ b/src/aap_eda/settings/core.py
@@ -17,9 +17,10 @@
 # Defines feature flags, and their conditions.
 # See https://cfpb.github.io/django-flags/
 DISPATCHERD_FEATURE_FLAG_NAME = "FEATURE_DISPATCHERD_ENABLED"
+ANALYTICS_FEATURE_FLAG_NAME = "FEATURE_EDA_ANALYTICS_ENABLED"
 
 FLAGS = {
-    "FEATURE_EDA_ANALYTICS_ENABLED": [
+    ANALYTICS_FEATURE_FLAG_NAME: [
         {
             "condition": "boolean",
             "value": False,

--- a/src/aap_eda/settings/features.py
+++ b/src/aap_eda/settings/features.py
@@ -1,0 +1,46 @@
+#  Copyright 2025 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from functools import cache
+from typing import Any, Dict
+
+from django.conf import settings
+from flags.state import flag_enabled
+
+# Type hints for module attributes
+DISPATCHERD: bool
+ANALYTICS: bool
+
+# Mapping of feature names to their corresponding setting names
+_FEATURE_FLAGS: Dict[str, str] = {
+    "DISPATCHERD": "DISPATCHERD_FEATURE_FLAG_NAME",
+    "ANALYTICS": "ANALYTICS_FEATURE_FLAG_NAME",
+}
+
+
+@cache
+def _get_feature(name: str) -> bool:
+    """Get the current value of a feature flag."""
+    return flag_enabled(name)
+
+
+def __getattr__(name: str) -> Any:
+    """Dynamically provide access to feature flags as module attributes."""
+    try:
+        setting_name = _FEATURE_FLAGS[name]
+        return _get_feature(getattr(settings, setting_name))
+    except KeyError:
+        raise AttributeError(
+            f"module {__name__} has no attribute {name}"
+        ) from None

--- a/src/aap_eda/tasks/analytics.py
+++ b/src/aap_eda/tasks/analytics.py
@@ -16,10 +16,10 @@ import logging
 
 import django_rq
 from ansible_base.lib.utils.db import advisory_lock
-from flags.state import flag_enabled
 
 from aap_eda.analytics import collector, utils
 from aap_eda.core import tasking
+from aap_eda.settings import features
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ job = tasking.redis_connect_retry()(django_rq.job)
 def schedule_gather_analytics(
     queue_name: str = ANALYTICS_TASKS_QUEUE, cancel: bool = False
 ) -> None:
-    if not flag_enabled("FEATURE_EDA_ANALYTICS_ENABLED"):
+    if not features.ANALYTICS:
         return
     interval = utils.get_analytics_interval()
     logger.info(f"Schedule analytics to run in {interval} seconds")

--- a/tests/integration/api/test_feature_flags.py
+++ b/tests/integration/api/test_feature_flags.py
@@ -15,7 +15,7 @@ def test_feature_flags_list_endpoint(admin_client):
     # Validates expected default feature flags
     # Modify each time a flag is added to default settings
     assert len(response.data) == 2
-    assert response.data["FEATURE_EDA_ANALYTICS_ENABLED"] is False
+    assert response.data[settings.ANALYTICS_FEATURE_FLAG_NAME] is False
     assert response.data[settings.DISPATCHERD_FEATURE_FLAG_NAME] is False
 
 

--- a/tests/integration/tasks/test_analytics.py
+++ b/tests/integration/tasks/test_analytics.py
@@ -56,8 +56,7 @@ def test_schedule_gather_analytics_success():
     ) as mock_enqueue, mock.patch(
         "aap_eda.tasks.analytics.logger.info"
     ) as mock_logger, mock.patch(
-        "aap_eda.tasks.analytics.flag_enabled",
-        return_value=True,
+        "aap_eda.tasks.analytics.features.ANALYTICS", True
     ):
         mock_interval.return_value = test_interval
 
@@ -82,8 +81,7 @@ def test_schedule_gather_analytics_with_default_queue():
     ) as mock_interval, mock.patch(
         "aap_eda.tasks.analytics.tasking.enqueue_delay"
     ) as mock_enqueue, mock.patch(
-        "aap_eda.tasks.analytics.flag_enabled",
-        return_value=True,
+        "aap_eda.tasks.analytics.features.ANALYTICS", True
     ):
         mock_interval.return_value = 300
         analytics.schedule_gather_analytics()
@@ -104,8 +102,7 @@ def test_schedule_gather_analytics_error_handling():
     ), mock.patch(
         "aap_eda.tasks.analytics.tasking.enqueue_delay"
     ) as mock_enqueue, mock.patch(
-        "aap_eda.tasks.analytics.flag_enabled",
-        return_value=True,
+        "aap_eda.tasks.analytics.features.ANALYTICS", True
     ):
         mock_enqueue.side_effect = RuntimeError("Queue connection failed")
 
@@ -124,8 +121,7 @@ def test_reschedule_gather_analytics():
     ) as mock_enqueue, mock.patch(
         "aap_eda.tasks.analytics.tasking.queue_cancel_job"
     ) as mock_cancel_job, mock.patch(
-        "aap_eda.tasks.analytics.flag_enabled",
-        return_value=True,
+        "aap_eda.tasks.analytics.features.ANALYTICS", True
     ):
         mock_interval.return_value = 300
         analytics.reschedule_gather_analytics()

--- a/tests/unit/commands/test_rq_cmd_wrapper.py
+++ b/tests/unit/commands/test_rq_cmd_wrapper.py
@@ -15,20 +15,14 @@
 from unittest import mock
 
 import pytest
-from django.conf import settings
 from django.core.management import call_command
-from django.test import override_settings
 from django_rq.management.commands import rqscheduler, rqworker
 
 
-@override_settings(
-    FLAGS={
-        settings.DISPATCHERD_FEATURE_FLAG_NAME: [
-            {"condition": "boolean", "value": True},
-        ],
-    }
-)
 @pytest.mark.django_db
+@mock.patch(
+    "aap_eda.core.management.commands.rqworker.features.DISPATCHERD", True
+)
 def test_rqworker_command_feature_flag_enabled(capsys):
     with pytest.raises(SystemExit) as exc_info:
         call_command(
@@ -40,14 +34,10 @@ def test_rqworker_command_feature_flag_enabled(capsys):
     assert "DISPATCHERD feature not implemented yet" in captured.err
 
 
-@override_settings(
-    FLAGS={
-        settings.DISPATCHERD_FEATURE_FLAG_NAME: [
-            {"condition": "boolean", "value": False},
-        ],
-    }
-)
 @pytest.mark.django_db
+@mock.patch(
+    "aap_eda.core.management.commands.rqworker.features.DISPATCHERD", False
+)
 @mock.patch.object(rqworker.Command, "handle", return_value=None)
 def test_rqworker_command_feature_flag_disabled(
     mock_rqworker_handle,
@@ -60,14 +50,10 @@ def test_rqworker_command_feature_flag_disabled(
     mock_rqworker_handle.assert_called_once()
 
 
-@override_settings(
-    FLAGS={
-        settings.DISPATCHERD_FEATURE_FLAG_NAME: [
-            {"condition": "boolean", "value": False},
-        ],
-    }
-)
 @pytest.mark.django_db
+@mock.patch(
+    "aap_eda.core.management.commands.scheduler.features.DISPATCHERD", False
+)
 @mock.patch.object(rqscheduler.Command, "handle", return_value=None)
 def test_rqscheduler_command_feature_flag_disabled(
     mock_rqscheduler_handle,
@@ -77,14 +63,10 @@ def test_rqscheduler_command_feature_flag_disabled(
     mock_rqscheduler_handle.assert_called_once()
 
 
-@override_settings(
-    FLAGS={
-        settings.DISPATCHERD_FEATURE_FLAG_NAME: [
-            {"condition": "boolean", "value": True},
-        ],
-    }
-)
 @pytest.mark.django_db
+@mock.patch(
+    "aap_eda.core.management.commands.scheduler.features.DISPATCHERD", True
+)
 @mock.patch.object(rqscheduler.Command, "handle", return_value=None)
 def test_rqscheduler_command_feature_flag_enabled(
     mock_rqscheduler_handle,

--- a/tests/unit/test_features.py
+++ b/tests/unit/test_features.py
@@ -1,0 +1,89 @@
+#  Copyright 2025 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Unit tests for feature flags functionality."""
+
+import pytest
+
+from aap_eda.settings import features
+from aap_eda.settings.features import _get_feature
+
+
+@pytest.fixture(autouse=True)
+def clear_feature_cache():
+    """Clear the feature flag cache before each test."""
+    _get_feature.cache_clear()
+
+
+@pytest.mark.django_db
+def test_get_feature_flag(settings):
+    """Test getting feature flag values."""
+    settings.FLAGS = {
+        settings.DISPATCHERD_FEATURE_FLAG_NAME: [
+            {"condition": "boolean", "value": True}
+        ],
+        settings.ANALYTICS_FEATURE_FLAG_NAME: [
+            {"condition": "boolean", "value": False}
+        ],
+    }
+
+    assert features.DISPATCHERD is True
+    assert features.ANALYTICS is False
+
+
+@pytest.mark.django_db
+def test_feature_flag_caching(settings):
+    """Test that feature flag values are properly cached."""
+    settings.FLAGS = {
+        settings.DISPATCHERD_FEATURE_FLAG_NAME: [
+            {"condition": "boolean", "value": True}
+        ]
+    }
+
+    # First access - should cache the value
+    assert features.DISPATCHERD is True
+
+    # Change the underlying flag value
+    settings.FLAGS[settings.DISPATCHERD_FEATURE_FLAG_NAME][0]["value"] = False
+
+    # Should still get the cached value
+    assert features.DISPATCHERD is True
+
+
+@pytest.mark.django_db
+def test_cache_invalidation(settings):
+    """Test that cache invalidation works as expected."""
+    settings.FLAGS = {
+        settings.DISPATCHERD_FEATURE_FLAG_NAME: [
+            {"condition": "boolean", "value": True}
+        ]
+    }
+
+    # Populate cache
+    assert features.DISPATCHERD is True
+
+    # Change the flag value and clear cache
+    settings.FLAGS[settings.DISPATCHERD_FEATURE_FLAG_NAME][0]["value"] = False
+    _get_feature.cache_clear()
+
+    # Should get the new value after cache clear
+    assert features.DISPATCHERD is False
+
+
+@pytest.mark.django_db
+def test_invalid_attribute():
+    """Test accessing non-existent feature flag raises AttributeError."""
+    with pytest.raises(AttributeError) as excinfo:
+        _ = features.NON_EXISTENT_FEATURE
+    assert "has no attribute NON_EXISTENT_FEATURE" in str(excinfo.value)


### PR DESCRIPTION
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
Get whether a feature flag is on or off as a constant from the new features module.
It improves the code readability and slightly the performance as the flags are now cached.

This work is to prepare the merging of the dispatcherd feature which is guarded by a flag.
