### PR TITLE
ci: add param for dispatcherd flag in e2e-dispatch

### DIFF
--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -11,6 +11,10 @@ on:
         description: 'filter for pytest to be used after "-k" flag, default is empty'
         required: false
         default: ''
+      feature_dispatcherd_enabled:
+        description: 'enable feature dispatcherd, default is false'
+        required: false
+        default: 'False'
   pull_request_target:
     types:
       - labeled
@@ -52,6 +56,7 @@ jobs:
         env:
           DJANGO_SETTINGS_MODULE: aap_eda.settings.default
           EDA_DEBUG: "false"
+          EDA_FEATURE_DISPATCHERD_ENABLED: ${{ github.event.inputs.feature_dispatcherd_enabled }}
         run: |
           docker compose -p eda -f tools/docker/docker-compose-dev.yaml build
           docker compose -p eda -f tools/docker/docker-compose-dev.yaml up -d
@@ -176,6 +181,7 @@ jobs:
           # multinode-upstream tests require a longer timeout
           # to allow for the time it takes to start the workers inside the tests
           EDAQA_DEFAULT_TIMEOUT: 120
+          EDA_FEATURE_DISPATCHERD_ENABLED: ${{ github.event.inputs.feature_dispatcherd_enabled }}
         run: |
           pytest -vv -s eda_qa/tests/whitebox/upstream --junit-xml=eda-qa-e2e-multinode-test-results.xml --reruns ${{ env.PYTEST_RETRIES }}
 


### PR DESCRIPTION
Add a new param to set the dispatcherd feature flag in our e2e-dispatch workflow. 
This workflow is always executed from main. This allows us to run on demand the test suite with the feature flag enabled. Once the feature flag is implemented and merged in main, we will have to update this workflow to add a matrix strategy and run the test suite by default with the flag enabled. For now, it is intended to work only for on-demand runs. 
