### PR TITLE
chore: add helper to sanitize pg identifiers

### DIFF
--- a/src/aap_eda/core/models/event_stream.py
+++ b/src/aap_eda/core/models/event_stream.py
@@ -16,6 +16,8 @@ import uuid
 
 from django.db import models
 
+from aap_eda.utils import sanitize_postgres_identifier
+
 from .base import BaseOrgModel, PrimordialModel, UniqueNamedModel
 
 __all__ = "EventStream"
@@ -92,9 +94,7 @@ class EventStream(BaseOrgModel, UniqueNamedModel, PrimordialModel):
 
     def _get_channel_name(self) -> str:
         """Generate the channel name based on the UUID and prefix."""
-        return (
-            f"{EDA_EVENT_STREAM_CHANNEL_PREFIX}"
-            f"{str(self.uuid).replace('-','_')}"
-        )
+        channel_name = f"{EDA_EVENT_STREAM_CHANNEL_PREFIX}{str(self.uuid)}"
+        return sanitize_postgres_identifier(channel_name)
 
     channel_name = property(_get_channel_name)

--- a/src/aap_eda/utils/__init__.py
+++ b/src/aap_eda/utils/__init__.py
@@ -47,18 +47,26 @@ def sanitize_postgres_identifier(identifier: str) -> str:
     if not identifier:
         raise ValueError("Identifier cannot be empty.")
 
-    # Replace invalid characters with underscores
-    sanitized = re.sub(r"\W", "_", identifier)
+    if len(identifier) > max_identifier_length:
+        raise ValueError(
+            f"Identifier exceeds {max_identifier_length} characters."
+        )
+
+    sanitized = identifier
 
     # Ensure it starts with a valid character
-    if not re.match(r"[A-Za-z_]", sanitized[0]):
-        sanitized = f"_{sanitized}"
+    if not re.match(r"[A-Za-z_]", identifier[0]):
+        if len(identifier) == max_identifier_length:
+            raise ValueError(
+                f"Identifier has invalid first character and "
+                f"{max_identifier_length} characters. "
+                "It can not be sanitized to a valid "
+                "PostgreSQL identifier below "
+                f"{max_identifier_length} characters."
+            )
+        sanitized = f"_{identifier}"
 
-    # Ensure length
-    if len(sanitized) > max_identifier_length:
-        raise ValueError(
-            f"Sanitized channel name exceeds {max_identifier_length} "
-            "characters."
-        )
+    # Replace invalid characters with underscores
+    sanitized = re.sub(r"\W", "_", sanitized)
 
     return sanitized

--- a/src/aap_eda/utils/__init__.py
+++ b/src/aap_eda/utils/__init__.py
@@ -13,6 +13,8 @@
 #  limitations under the License.
 import importlib.metadata
 import logging
+import re
+from functools import cache
 
 logger = logging.getLogger(__name__)
 
@@ -32,3 +34,31 @@ def get_package_version(package_name: str) -> str:
             package_name,
         )
         return "unknown"
+
+
+@cache
+def sanitize_postgres_identifier(identifier: str) -> str:
+    """
+    Sanitize an input string to conform to PostgreSQL identifier rules.
+
+    Initially intended to be used for pg_notify channel names.
+    """
+    max_identifier_length = 63
+    if not identifier:
+        raise ValueError("Identifier cannot be empty.")
+
+    # Replace invalid characters with underscores
+    sanitized = re.sub(r"\W", "_", identifier)
+
+    # Ensure it starts with a valid character
+    if not re.match(r"[A-Za-z_]", sanitized[0]):
+        sanitized = f"_{sanitized}"
+
+    # Ensure length
+    if len(sanitized) > max_identifier_length:
+        raise ValueError(
+            f"Sanitized channel name exceeds {max_identifier_length} "
+            "characters."
+        )
+
+    return sanitized

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -188,8 +188,10 @@ def test_generate_query_params(serializer, expected_params):
         ("some space", "some_space"),
         ("123name", "_123name"),
         ("9abc", "_9abc"),
-        ("@@@", "___"),
+        ("@@@", "____"),
         ("123", "_123"),
+        ("a" * 63, "a" * 63),
+        (("1" + "a" * 61), ("_1" + "a" * 61)),
     ],
 )
 def test_sanitize_postgres_identifier_valid_cases(input_str, expected_output):
@@ -204,4 +206,10 @@ def test_empty_identifier_raises():
 def test_identifier_exceeding_length_limit_raises():
     too_long = "a" * 64
     with pytest.raises(ValueError, match="exceeds 63 characters"):
+        sanitize_postgres_identifier(too_long)
+
+
+def test_identifier_with_invalid_first_character_raises():
+    too_long = "1" + "a" * 62
+    with pytest.raises(ValueError, match="invalid first character"):
         sanitize_postgres_identifier(too_long)


### PR DESCRIPTION
For dispatcherd we need to sanitize the channel name as we already do for event streams. There is no need to fill the code with `.replace()` calls. 
Instead create a helper that can sanitize the name in a more reusable and reliable way. 