### PR TITLE
fix: Check queue name of worker before applying missing policy

### DIFF
--- a/src/aap_eda/services/activation/activation_manager.py
+++ b/src/aap_eda/services/activation/activation_manager.py
@@ -906,7 +906,17 @@ class ActivationManager(StatusManager):
         # Activations in running status must have a container
         # This case prevents cases when the container is externally deleted
         if container_status is None:
-            self._missing_container_policy()
+            if self.latest_instance.queue_name != self._get_queue_name():
+                msg = (
+                    f"Monitor operation: activation id: {self.db_instance.id} "
+                    "Activation is not running on this worker. "
+                    f"Instance queue {self.latest_instance.queue_name} "
+                    f"Node queue name {self._get_queue_name()}"
+                    "Nothing to do."
+                )
+                LOGGER.info(msg)
+            else:
+                self._missing_container_policy()
             return
 
         LOGGER.info(


### PR DESCRIPTION
Trying to fix a race condition when the monitor triggers a missing policy if the container cannot be found

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
<!-- If applicable, provide a link to the issue that is being addressed -->

<!-- What is being changed? -->
Checking if the queue name in the instance matches the nodes queue name
<!-- Why is this change needed? -->
To avoid a race condition that ends up terminating the running container
<!-- How does this change address the issue? -->
Intermittent test failure
<!-- Does this change introduce any new dependencies, blockers or breaking changes? -->
No
<!-- How it can be tested? -->
Running the eda-qa test suite.

https://issues.redhat.com/browse/AAP-45421