### PR TITLE
chore: define pytest test paths

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+testpaths = tests/
 asyncio_mode = auto
 env =
     EDA_MODE=development


### PR DESCRIPTION
Define which is the expected test paths for pytest. If you configure your working project to work with local versions of libraries, like ansible_base or dispatcherd, by default pytest will lookup tests also from those projects and potentially ending up in errors. With this setting we explicitly set where are the tests that pytest will run for this project. 
