### PR TITLE
test: fix job uniqueness test

### DIFF
--- a/tests/integration/test_advisory_lock.py
+++ b/tests/integration/test_advisory_lock.py
@@ -25,18 +25,6 @@ from tests.integration.utils import ThreadSafeList
         },
         {
             "module_path": "aap_eda.tasks.project",
-            "fn_mock": "_import_project",
-            "fn_call": "import_project",
-            "fn_args": [1],
-        },
-        {
-            "module_path": "aap_eda.tasks.project",
-            "fn_mock": "_sync_project",
-            "fn_call": "sync_project",
-            "fn_args": [1],
-        },
-        {
-            "module_path": "aap_eda.tasks.project",
             "fn_mock": "_monitor_project_tasks",
             "fn_call": "monitor_project_tasks",
             "fn_args": [],
@@ -45,9 +33,7 @@ from tests.integration.utils import ThreadSafeList
     ids=[
         "gather_analytics",
         "monitor_rulebook_processes",
-        "import_project",
-        "sync_project",
-        "monitor_project_tasks",
+        "monitor_project_tasks",  # only scheduled in RQ
     ],
 )
 @pytest.mark.django_db
@@ -55,8 +41,8 @@ def test_job_uniqueness(module_data):
     call_log = []
     lock = Lock()
 
-    def gather_analytics_wrapper_call(shared_list):
-        """Patch _gather_analytics in a thread-safe way inside each thread."""
+    def _wrapper_call(shared_list):
+        """Patch fn mock in a thread-safe way inside each thread."""
         import importlib
 
         module = importlib.import_module(module_data["module_path"])
@@ -72,10 +58,91 @@ def test_job_uniqueness(module_data):
                 shared_list.append("called")
 
             fn_mock.side_effect = record_call
-            getattr(module, module_data["fn_call"])(*module_data["fn_args"])
+            try:
+                getattr(module, module_data["fn_call"])(
+                    *module_data["fn_args"],
+                )
+            except Exception as e:
+                pytest.fail(
+                    f"Exception raised in {module_data['fn_call']}: {e}"
+                )
 
     def thread_safe_call():
-        gather_analytics_wrapper_call(ThreadSafeList(call_log, lock))
+        _wrapper_call(ThreadSafeList(call_log, lock))
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(thread_safe_call),
+            executor.submit(thread_safe_call),
+        ]
+        wait(futures, timeout=3)
+
+    assert len(call_log) == 1
+
+
+@pytest.mark.parametrize(
+    "module_data",
+    [
+        {
+            "module_path": "aap_eda.tasks.project",
+            "fn_mock_dispatcherd": "import_project_dispatcherd",
+            "fn_mock_rq": "import_project_rq",
+            "fn_call": "import_project",
+            "fn_args": [1],
+        },
+        {
+            "module_path": "aap_eda.tasks.project",
+            "fn_mock_dispatcherd": "sync_project_dispatcherd",
+            "fn_mock_rq": "sync_project_rq",
+            "fn_call": "sync_project",
+            "fn_args": [1],
+        },
+    ],
+    ids=[
+        "import_project",
+        "sync_project",
+    ],
+)
+@pytest.mark.django_db
+def test_project_job_uniqueness(module_data):
+    call_log = []
+    lock = Lock()
+
+    def _wrapper_call(shared_list):
+        """Patch fn_mock in a thread-safe way inside each thread."""
+        import importlib
+        from aap_eda.settings import features
+
+        module = importlib.import_module(module_data["module_path"])
+
+        importlib.reload(module)
+
+        mock_fn_target = (
+            f"{module_data['fn_mock_dispatcherd']}"
+            if features.DISPATCHERD
+            else f"{module_data['fn_mock_rq']}"
+        )
+
+        mock_path = f"{module_data['module_path']}.{mock_fn_target}"
+
+        with mock.patch(mock_path) as fn_mock:
+
+            def record_call(void=None):
+                time.sleep(1)
+                shared_list.append("called")
+
+            fn_mock.side_effect = record_call
+            try:
+                getattr(module, module_data["fn_call"])(
+                    *module_data["fn_args"],
+                )
+            except Exception as e:
+                pytest.fail(
+                    f"Exception raised in {module_data['fn_call']}: {e}"
+                )
+
+    def thread_safe_call():
+        _wrapper_call(ThreadSafeList(call_log, lock))
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         futures = [


### PR DESCRIPTION
Update job uniqueness tests to mock proxy functions. 
Also moves import/sync project tasks from the job decorator to the direct calling, this for consistency and convenience at testing.
(projects jobs continue working as expected, manually verified)