### PR TITLE
chore: extend eda_init playbook tool

### DIFF
--- a/tools/ansible/eda_init.yml
+++ b/tools/ansible/eda_init.yml
@@ -13,6 +13,8 @@
     controller_password: testpass
     organization_name: Default
     validate_certs: no
+    create_activations: False
+    number_of_activations: 1
   module_defaults:
     group/ansible.eda.eda:
       controller_host: "{{ controller_host }}"
@@ -59,5 +61,15 @@
           debug:
             msg: "Basic Event Stream URL: {{ event_stream_data.event_streams[0].url }}"
 
-
+    - name: Create activations async
+      when: create_activations
+      loop: "{{ range(1, number_of_activations + 1) | list }}"
+      async: 10
+      poll: 0
+      ansible.eda.rulebook_activation:
+        organization_name: "{{ organization_name }}"
+        decision_environment_name: "Upstream decision environment"
+        project_name: "Eda sample project"
+        rulebook_name: range_long_running.yml
+        name: "Long running test activation {{ item }}"
 


### PR DESCRIPTION
Add to eda_init.yml playbook tool the capability to also create sample activations, disabled by default. Useful for testing and demos.
