### PR TITLE
AAP-41454 - [API] Make project scm_url editable in the patch API

### DIFF
--- a/src/aap_eda/api/serializers/project.py
+++ b/src/aap_eda/api/serializers/project.py
@@ -190,6 +190,12 @@ class ProjectUpdateRequestSerializer(serializers.ModelSerializer):
         allow_null=True,
         help_text="Proxy server for http or https connection",
     )
+    url = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        help_text="Source control repository URL.",
+    )
 
     class Meta:
         model = models.Project
@@ -203,6 +209,7 @@ class ProjectUpdateRequestSerializer(serializers.ModelSerializer):
             "scm_refspec",
             "verify_ssl",
             "proxy",
+            "url",
         ]
 
     def validate(self, data):

--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -211,6 +211,7 @@ class ProjectViewSet(
 
         update_fields = []
         old_data = model_to_dict(project)
+
         for key, value in serializer.validated_data.items():
             setattr(project, key, value)
             update_fields.append(key)

--- a/tests/integration/api/test_project.py
+++ b/tests/integration/api/test_project.py
@@ -791,6 +791,27 @@ def test_partial_update_project_bad_proxy(
 
 
 @pytest.mark.django_db
+def test_partial_update_project_url(
+    new_project: models.Project,
+    admin_client: APIClient,
+):
+    original_url = new_project.url
+    new_url = "https://git.example.com/foo-bar"
+
+    response = admin_client.patch(
+        f"{api_url_v1}/projects/{new_project.id}/",
+        data={"url": new_url},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["url"] == new_url
+
+    new_project.refresh_from_db()
+    assert new_project.url == new_url
+    assert new_project.url != original_url
+
+
+@pytest.mark.django_db
 def test_delete_project(
     new_project: models.Project,
     admin_client: APIClient,


### PR DESCRIPTION
The URL attribute in the project is allowed to be set in the body to patch a project.

ATF tests are added to change the URL of an existing project 

https://issues.redhat.com/browse/AAP-41454