### PR TITLE
fix: [AAP-46553] modify the project clone playbook for ansible-core 2.19

### DIFF
--- a/src/aap_eda/data/playbooks/project_clone.yml
+++ b/src/aap_eda/data/playbooks/project_clone.yml
@@ -16,11 +16,11 @@
   tasks:
     - name: Clone or pull a project using git
       block:
-        - name: Clone or pull a project using gitt
+        - name: Clone or pull a project using git
           ansible.builtin.git:
             dest: "{{ project_path | quote }}"
             repo: "{{ scm_url }}"
-            version: "{{ scm_branch | default(omit) | quote }}"
+            version: "{{ omit if scm_branch is undefined else scm_branch|quote  }}"
             refspec: "{{ scm_refspec | default(omit) }}"
             key_file: "{{ key_file | default(omit) }}"
             accept_hostkey: true


### PR DESCRIPTION
`omit` should always be the end state, and not used in the middle. 

https://issues.redhat.com/browse/AAP-46553

e.g
```
version: "{{ scm_branch | default(omit) | quote }}"
```
gets interpreted as 
```
"cmd": "/usr/bin/git checkout --force '<<Omit>>'",
```