### PR TITLE
fix: [AAP-46785] set log_tracking_id when copying activations

### DIFF
--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -573,6 +573,7 @@ class ActivationCopySerializer(serializers.ModelSerializer):
             "rulebook_rulesets": activation.rulebook_rulesets,
             "git_hash": activation.rulebook.project.git_hash,
             "project": activation.rulebook.project,
+            "log_tracking_id": str(uuid.uuid4()),
         }
         if activation.eda_system_vault_credential:
             inputs = yaml.safe_load(

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -1260,6 +1260,7 @@ def test_copy_activation(
     activation = models.Activation.objects.filter(id=data["id"]).first()
     assert activation.name == "another_name"
     assert activation.is_enabled is False
+    assert activation.log_tracking_id is not None
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
The log_tracking_id is missing in the copied activation.
https://issues.redhat.com/browse/AAP-46785

![image](https://github.com/user-attachments/assets/4b3495a1-065e-4fe7-874c-88a59d5259fb)


