### PR TITLE
fix: Run noop loop in scheduler under dispatcherd flag

### DIFF
--- a/src/aap_eda/core/exceptions.py
+++ b/src/aap_eda/core/exceptions.py
@@ -43,3 +43,7 @@ class DuplicateEnvKeyError(Exception):
 
 class InvalidEnvKeyError(Exception):
     pass
+
+
+class GracefulExit(Exception):
+    pass


### PR DESCRIPTION
This PR changes the approach to handle the dispatcherd flag in the scheduler. Instead or returning an error and creating noise for users, that also need to modify their deployments to not deploy the scheduler which would be restarting all the time in default deployments,  it applies a less disruptive approach by just warning about it and running a noop loop. 
