### PR TITLE
test: fix flaky tests caused by multithreaded tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,10 +99,26 @@ jobs:
       - name: Check migrations are up to date
         run: poetry run /usr/bin/env aap-eda-manage makemigrations --dry-run --check
 
-      - name: Run tests
+      - name: Run default tests
         run: |
-          poetry run python -m pytest -vv --cov=./ --cov-report=xml --junit-xml=eda-server-test-results.xml
+          poetry run python -m pytest -vv \
+            --cov=./ \
+            --cov-report=xml \
+            --junit-xml=eda-server-default.xml
           echo "GIT_SHA=$(git rev-parse "$GITHUB_SHA")" >> "$GITHUB_ENV"
+
+      - name: Run multithreaded tests
+        run: |
+          poetry run python -m pytest -vv \
+            --cov=./ \
+            --cov-append \
+            --junit-xml=eda-server-multithreaded.xml \
+            -m "multithreaded"
+
+      - name: Merge test results
+        run: |
+          pip install junitparser
+          junitparser merge eda-server-default.xml eda-server-multithreaded.xml eda-server-test-results.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -79,6 +79,7 @@ tasks:
           $ task test -- tests/integration/api/test_activation.py::test_retrieve_activation
     cmds:
       - "{{.PYTEST_CMD}} {{.CLI_ARGS}}"
+      - "{{.PYTEST_CMD}} -m multithreaded {{.CLI_ARGS}}"
 
   lint:
     desc: "Run all linters."

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,6 @@ env =
     EDA_MODE=development
 DJANGO_SETTINGS_MODULE = aap_eda.settings.default
 log_file_level = INFO
+markers =
+    multithreaded # mark multithreaded tests, these tests must be run in a separate process
+    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,21 @@ from aap_eda.settings import redis as redis_settings
 
 
 #################################################################
+# run tests setup
+#################################################################
+def pytest_runtest_setup(item):
+    marker_expr = item.config.getoption("-m")
+
+    if "multithreaded" in item.keywords and (
+        not marker_expr or "multithreaded" not in marker_expr
+    ):
+        pytest.skip(
+            "Skipped multithreaded test "
+            "(not explicitly selected via `-m multithreaded`)"
+        )
+
+
+#################################################################
 # Log capture factory
 #################################################################
 @pytest.fixture

--- a/tests/integration/test_advisory_lock.py
+++ b/tests/integration/test_advisory_lock.py
@@ -37,6 +37,7 @@ from tests.integration.utils import ThreadSafeList
     ],
 )
 @pytest.mark.django_db
+@pytest.mark.multithreaded
 def test_job_uniqueness(module_data):
     call_log = []
     lock = Lock()


### PR DESCRIPTION
We have sporadic unexpected failures in tests. I think this is caused by `test_job_uniqueness` which uses multithreading and seems to interfere intermittently with other mocks. Since I could not found a way to avoid it or a better way to do this test (which I think right now is clean and reliable except for the mock interference) I think the best way is to just keep them separately, which is a good and common pattern in general. 

It marks the test with a new marker "multithreaded" which is never executed by default. Then CI stuff is updated to execute both, default and multithreaded, separately. 

Depends on https://github.com/ansible/eda-server/pull/1333 