### PR TITLE
ci: make CI github workflow reusable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,14 +1,13 @@
+# Reusable GitHub Actions workflow for CI
+# intended to be called by other workflows
+
 name: CI
 
 env:
   POETRY_NO_INTERACTION: 1
 
 on:
-  push:
-    branches: [ 'main' ]
-  pull_request:
-  merge_group:
-    branches: [ 'main' ]
+  workflow_call:
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -1,0 +1,12 @@
+name: Run CI
+
+on:
+  push:
+    branches: [ 'main' ]
+  pull_request:
+  merge_group:
+    branches: [ 'main' ]
+
+jobs:
+  run-ci:
+    uses: ./.github/workflows/ci.yaml


### PR DESCRIPTION
Convert the CI workflow in reusable workflow, called by run CI workflow with the existing logic. This allows to other forks and mirrors to reuse the CI pipeline with a different trigger configuration. 

This change needs too to modify the status checks required in the repo configuration after merge, It can not be done before because they don't exist yet. In this PR you can see the new ones executed.
