### PR TITLE
Move to Runtime Platform Flags

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -660,14 +660,14 @@ files = [
 
 [[package]]
 name = "django"
-version = "4.2.16"
+version = "4.2.22"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "Django-4.2.16-py3-none-any.whl", hash = "sha256:1ddc333a16fc139fd253035a1606bb24261951bbc3a6ca256717fa06cc41a898"},
-    {file = "Django-4.2.16.tar.gz", hash = "sha256:6f1616c2786c408ce86ab7e10f792b8f15742f7b7b7460243929cb371e7f1dad"},
+    {file = "django-4.2.22-py3-none-any.whl", hash = "sha256:0a32773b5b7f4e774a155ee253ab24a841fed7e9e9061db08bf2ce9711da404d"},
+    {file = "django-4.2.22.tar.gz", hash = "sha256:e726764b094407c313adba5e2e866ab88f00436cad85c540a5bf76dc0a912c9e"},
 ]
 
 [package.dependencies]
@@ -681,7 +681,7 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-ansible-base"
-version = "2025.5.8"
+version = "25.6.17.0.dev663+gd8be258"
 description = "A Django app used by ansible services"
 optional = false
 python-versions = ">=3.9"
@@ -693,7 +693,7 @@ develop = false
 asgiref = {version = "*", optional = true, markers = "extra == \"resource-registry\""}
 channels = {version = "*", optional = true, markers = "extra == \"channel-auth\""}
 cryptography = "*"
-Django = ">=4.2.16,<4.3.0"
+Django = ">=4.2.21,<4.3.0"
 django-crum = "*"
 django-flags = {version = "*", optional = true, markers = "extra == \"feature-flags\""}
 django-redis = {version = "*", optional = true, markers = "extra == \"redis-client\""}
@@ -707,9 +707,9 @@ sqlparse = ">=0.5.2"
 urllib3 = {version = "*", optional = true, markers = "extra == \"resource-registry\""}
 
 [package.extras]
-all = ["asgiref", "channels", "cryptography", "django-auth-ldap", "django-flags", "django-oauth-toolkit (<2.4.0)", "django-redis", "drf-spectacular", "pyjwt", "pyjwt", "pyrad", "pytest", "pytest-django", "python-ldap", "python3-saml", "redis", "requests", "requests", "social-auth-app-django (==5.4.1)", "social-auth-core (<=4.5.4)", "tabulate", "tacacs_plus", "urllib3", "xmlsec (==1.3.13)"]
+all = ["asgiref", "channels", "cryptography", "django-auth-ldap", "django-flags", "django-oauth-toolkit (<2.4.0)", "django-redis", "drf-spectacular", "ldap-filter", "pyjwt", "pyjwt", "pyrad", "pytest", "pytest-django", "python-ldap", "python3-saml", "redis", "requests", "requests", "social-auth-app-django (==5.4.1)", "social-auth-core (<=4.5.4)", "tabulate", "tacacs_plus", "urllib3", "xmlsec (==1.3.13)"]
 api-documentation = ["drf-spectacular"]
-authentication = ["django-auth-ldap", "pyrad", "python-ldap", "python3-saml", "social-auth-app-django (==5.4.1)", "social-auth-core (<=4.5.4)", "tabulate", "tacacs_plus", "xmlsec (==1.3.13)"]
+authentication = ["django-auth-ldap", "ldap-filter", "pyrad", "python-ldap", "python3-saml", "social-auth-app-django (==5.4.1)", "social-auth-core (<=4.5.4)", "tabulate", "tacacs_plus", "xmlsec (==1.3.13)"]
 channel-auth = ["channels"]
 feature-flags = ["django-flags"]
 jwt-consumer = ["pyjwt", "requests"]
@@ -720,9 +720,9 @@ testing = ["cryptography", "pytest", "pytest-django"]
 
 [package.source]
 type = "git"
-url = "https://github.com/ansible/django-ansible-base.git"
-reference = "2025.5.8"
-resolved_reference = "a46ebe5efa8eea15d5943301d866f204e82f6af4"
+url = "https://github.com/zkayyali812/django-ansible-base.git"
+reference = "phase2/feature-flags/poc"
+resolved_reference = "d8be25892d8239210d18a0be0df492cfa01325d6"
 
 [[package]]
 name = "django-crum"
@@ -3024,4 +3024,4 @@ dev = ["psycopg-binary"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "407ebe011c6024e245c6f1a50fda29dcdcca9b8429e3e007e74eaac7d5135b68"
+content-hash = "70130491087003a7131da493297e07bfdf1bb7cfa759cd45719fba6fde4ab6ff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ cryptography = ">=42,<43"
 kubernetes = "26.1.*"
 podman = "5.4.*"
 rq-scheduler = "^0.10"
-django-ansible-base = { git = "https://github.com/ansible/django-ansible-base.git", tag = "2025.5.8", extras = [
+django-ansible-base = { git = "https://github.com/zkayyali812/django-ansible-base.git", branch = "phase2/feature-flags/poc", extras = [
     "channel-auth",
     "rbac",
     "redis-client",

--- a/src/aap_eda/api/resource_api.py
+++ b/src/aap_eda/api/resource_api.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+from ansible_base.feature_flags.models import AAPFlag
 from ansible_base.resource_registry.registry import (
     ParentResource,
     ResourceConfig,
@@ -19,6 +19,7 @@ from ansible_base.resource_registry.registry import (
     SharedResource,
 )
 from ansible_base.resource_registry.shared_types import (
+    FeatureFlagType,
     OrganizationType,
     TeamType,
     UserType,
@@ -50,6 +51,12 @@ RESOURCE_LIST = (
         models.Organization,
         shared_resource=SharedResource(
             serializer=OrganizationType, is_provider=False
+        ),
+    ),
+    ResourceConfig(
+        AAPFlag,
+        shared_resource=SharedResource(
+            serializer=FeatureFlagType, is_provider=False
         ),
     ),
 )

--- a/src/aap_eda/settings/core.py
+++ b/src/aap_eda/settings/core.py
@@ -19,24 +19,9 @@
 DISPATCHERD_FEATURE_FLAG_NAME = "FEATURE_DISPATCHERD_ENABLED"
 ANALYTICS_FEATURE_FLAG_NAME = "FEATURE_EDA_ANALYTICS_ENABLED"
 
-FLAGS = {
-    ANALYTICS_FEATURE_FLAG_NAME: [
-        {
-            "condition": "boolean",
-            "value": False,
-        },
-    ],
-    DISPATCHERD_FEATURE_FLAG_NAME: [
-        {
-            "condition": "boolean",
-            "value": False,
-        },
-    ],
-}
 
 INSTALLED_APPS = [
     "daphne",
-    "flags",
     # Django apps
     "django.contrib.auth",
     "django.contrib.contenttypes",

--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -19,7 +19,6 @@ from ansible_base.lib.dynamic_config import (
     load_dab_settings,
     load_envvars,
     load_standard_settings_files,
-    toggle_feature_flags,
 )
 
 from .post_load import post_loading
@@ -51,14 +50,5 @@ load_envvars(DYNACONF)  # load envvars prefixed with EDA_
 DYNACONF.load_file("core.py")  # load internal non-overwritable settings
 post_loading(DYNACONF)
 load_dab_settings(DYNACONF)
-
-# toggle feature flags, considering flags coming from
-# /etc/ansible-automation-platform/*.yaml
-# and envvars like `EDA_FEATURE_FOO_ENABLED=true
-DYNACONF.update(
-    toggle_feature_flags(DYNACONF),
-    loader_identifier="settings:toggle_feature_flags",
-    merge=True,
-)
 
 export(__name__, DYNACONF)  # export back to django.conf.settings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,9 @@
 import logging
 
 import pytest
+from ansible_base.feature_flags.utils import (
+    create_initial_data as seed_feature_flags,
+)
 from django.conf import settings
 
 from aap_eda.core import enums, models
@@ -89,6 +92,11 @@ def aap_credential_type(preseed_credential_types):
     return models.CredentialType.objects.get(
         name=enums.DefaultCredentialType.AAP
     )
+
+
+@pytest.fixture
+def preseed_feature_flags():
+    seed_feature_flags()
 
 
 #################################################################

--- a/tests/integration/api/test_root.py
+++ b/tests/integration/api/test_root.py
@@ -83,6 +83,9 @@ from tests.integration.constants import api_url_v1
                 "/organizations/",
                 "/teams/",
                 "/event-streams/",
+                "feature_flags/states/",
+                # To be removed after all components
+                # have migrated away from this endpoint
                 "/feature_flags_state/",
             ],
             False,


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/AAP-45879

This PR moves the EDA  feature flag source from Settings based feature flags, to platform database level feature flags.
This also makes gateway the provider of this data for the platform.

This is required to enable platform level feature flags.

Gateway is the provider of the feature flag value updates, and is resource synced to EDA/other components.

It can be validated and tested simply with AAP Dev, and requires the following DAB PR to be merged in beforehand - 
https://github.com/ansible/django-ansible-base/pull/736
Once the DAB PR is merged, I will update this PR to point back to the upstream `devel` branch of DAB


To test -
1. Clone AAP-Dev
2. make configure-sources
3. Select DAB, GW, and EDA for sources
4. make aap
5. Attempt to hit <GATEWAY_API>/feature_flags/X api endpoint and patch a flags value.
6. If Gateway Setting **RUNTIME_FEATURE_FLAGS** == True, the update succeeds and flag value is resource synced to EDA
7. If Gateway Setting **RUNTIME_FEATURE_FLAGS** == False, the update fails with error explaining why.