### PR TITLE
fix: ensure rulebook_queue_name is not sanitized outside dispatcherd flag

### DIFF
--- a/src/aap_eda/settings/post_load.py
+++ b/src/aap_eda/settings/post_load.py
@@ -530,22 +530,6 @@ def post_loading(loaded_settings: Dynaconf):
         },
     }
 
-    settings.DISPATCHERD_ACTIVATION_WORKER_SETTINGS = {
-        **settings.DISPATCHERD_DEFAULT_SETTINGS,
-        "brokers": {
-            "pg_notify": {
-                **settings.DISPATCHERD_DEFAULT_SETTINGS["brokers"][
-                    "pg_notify"
-                ],
-                "channels": [
-                    utils.sanitize_postgres_identifier(
-                        settings.RULEBOOK_QUEUE_NAME,
-                    )
-                ],
-            },
-        },
-    }
-
     data = {
         key: settings[key]
         for key in settings


### PR DESCRIPTION
We have found a bug where the installers set a rulebook queue_name longer than 63 chars, a limit imposed for pg_notify (dispatcherd feature flag). This was set at the initialization of settings, where we can not check yet the status of the flag. 
This PR ensure the queue name is not sanitized for pg_notify when the feature flag is not enabled. 
