### PR TITLE
WIP - enhancement: parallelize queue_dispatching in monitor loop

### DIFF
--- a/src/aap_eda/tasks/orchestrator.py
+++ b/src/aap_eda/tasks/orchestrator.py
@@ -186,6 +186,28 @@ def _run_request(
 def queue_dispatch(
     process_parent_type: ProcessParentType,
     process_parent_id: int,
+    request_type: Optional[ActivationRequest] = None,
+    request_id: str = "",
+) -> None:  # pragma: no cover
+    job_id = _manage_process_job_id(process_parent_type, process_parent_id)
+    with advisory_lock(job_id, wait=False) as acquired:
+        if not acquired:
+            LOGGER.debug(
+                f"queue_dispatch({job_id}) already being ran, "
+                f"not dispatching request {request_type}",
+            )
+            return
+        queue_dispatch_no_lock(
+            process_parent_type,
+            process_parent_id,
+            request_type,
+            request_id,
+        )
+
+
+def queue_dispatch_no_lock(
+    process_parent_type: ProcessParentType,
+    process_parent_id: int,
     request_type: Optional[ActivationRequest],
     request_id: str = "",
 ):
@@ -216,14 +238,6 @@ def queue_dispatch(
 
     assign_request_id(request_id)
     assign_log_tracking_id(process_parent.log_tracking_id)
-
-    with advisory_lock(job_id, wait=False) as acquired:
-        if not acquired:
-            LOGGER.debug(
-                f"_manage({job_id}) already being ran, "
-                f"not dispatching request {request_type}",
-            )
-            return
 
     LOGGER.info(
         f"Dispatching request {request_type} for {process_parent_type} "
@@ -555,12 +569,16 @@ def monitor_rulebook_processes_no_lock() -> None:
     """
     # run pending user requests
     for request in requests_queue.list_requests():
-        queue_dispatch(
+        tasking.unique_enqueue(
+            "default",
+            "queue_dispatch_" + str(request.process_parent_id),
+            queue_dispatch,
             request.process_parent_type,
             request.process_parent_id,
             request.request,
             request.request_id,
-        )
+    )
+
 
     # monitor running instances
     for process in models.RulebookProcess.objects.filter(
@@ -570,15 +588,15 @@ def monitor_rulebook_processes_no_lock() -> None:
             ActivationStatus.WORKERS_OFFLINE,
         ]
     ):
-        process_parent_type = str(process.parent_type)
-        process_parent_id = process.activation_id
-
-        queue_dispatch(
-            process_parent_type,
-            process_parent_id,
+        tasking.unique_enqueue(
+            "default",
+            "queue_dispatch_" + str(process.activation_id),
+            queue_dispatch,
+            str(process.parent_type),
+            process.activation_id,
             None,
             str(uuid.uuid4()),
-        )
+    )
 
 
 def monitor_rulebook_processes() -> None:


### PR DESCRIPTION
Try to solve the issue of the bottleneck that supposes the superlinear complexity of the current sequential and no scalable monitor_rulebook loop. 
Each user request a monitor needs to be queue dispatched before being processed by the manager. I make follow the same approach as the rest of tasks by implementing a "lock" and "no_lock" versions of `queue_dispatch` and scheduled per every user and monitor request in the monitor for the default worker. In this way we can parallelize the queue_dispatcher while preserving the consistency, leaving the current monitor loop as a lightweight iterator that schedules all the subsequent tasks.

Seems to be working fine, but now I have need to address the issue that max_running_activations is checked in the manager. This was a known and minor issue, where we could have a race condition when enforcing the limit and running more activations than the allowed ones if new activations were processed at the same time by multiple workers. 
Now that the parallelization is broader this problem becomes more problematic and serious, so I need to rewrite completely that logic to ensure that we don't process more new activations than the limit prior to assign them a queue. 
