### PR TITLE
chore(dispatcherd): parameterize and increase queue healthcheck timeout

### DIFF
--- a/src/aap_eda/settings/core.py
+++ b/src/aap_eda/settings/core.py
@@ -152,7 +152,7 @@ DEFAULT_REDIS_DB = 0
 # ---------------------------------------------------------
 # DISPATCHERD SETTINGS
 # ---------------------------------------------------------
-
+DISPATCHERD_QUEUE_HEALTHCHECK_TIMEOUT = 3
 DISPATCHERD_DEFAULT_CHANNEL = "default"
 
 DISPATCHERD_STARTUP_TASKS = {

--- a/src/aap_eda/tasks/orchestrator.py
+++ b/src/aap_eda/tasks/orchestrator.py
@@ -471,7 +471,9 @@ def check_rulebook_queue_health_dispatcherd(queue_name: str) -> bool:
     ctl = get_control_from_settings(
         default_publish_channel=utils.sanitize_postgres_identifier(queue_name)
     )
-    alive = ctl.control_with_reply("alive")
+    alive = ctl.control_with_reply(
+        "alive", timeout=settings.DISPATCHERD_QUEUE_HEALTHCHECK_TIMEOUT
+    )
     if not alive:
         LOGGER.warning(
             f"Worker queue {queue_name} was found to not be healthy"


### PR DESCRIPTION
In some scenarios with high concurrent workload I have observed intermittent healthcheck failures. This PR's increases the default timeout with a more safe value (default is 1)  and exposes it as setting. Depending on the setup this value might need to be adjusted but scaling up workers or adjusting subprocesses per worker should be the right approach in the most of the cases. 