### PR TITLE
feat: reject requests to modify is_superuser field on shared user obj…

### DIFF
--- a/src/aap_eda/api/serializers/mixins.py
+++ b/src/aap_eda/api/serializers/mixins.py
@@ -15,22 +15,23 @@
 from django.conf import settings
 
 from aap_eda.api import exceptions as api_exc
-from aap_eda.core import models
 
 
 class SharedResourceSerializerMixin:
+    """Serializer mixin which controls the access to shared resources."""
+
     def validate_shared_resource(self, data=None):
+        """
+        Validate access to shared resources.
+
+        Here we reject all requests to modify a shared resource if
+        ALLOW_LOCAL_RESOURCE_MANAGEMENT is False.
+
+        Call this method from within super().validate().
+        """
         if not settings.ALLOW_LOCAL_RESOURCE_MANAGEMENT:
             view = self.context.get("view")
             action = view.action.capitalize() if view else "Action"
-
-            # exception where we should allow updating is_superuser field
-            if action == "Partial_update" and isinstance(
-                view.get_object(), models.User
-            ):
-                if data and "is_superuser" in data:
-                    return {"is_superuser": data["is_superuser"]}
-
             raise api_exc.Forbidden(
                 f"{action} should be done through the platform ingress"
             )


### PR DESCRIPTION
…ects

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
<!-- If applicable, provide a link to the issue that is being addressed -->
Requests to modifiy the `User.is_superuser` field are rejected with status 403 FORBIDDEN.
https://issues.redhat.com/browse/AAP-49098

<!-- What is being changed? -->
The `User.is_superuser` field can no longer be modified via the eda API.

<!-- Why is this change needed? -->
After a platform upgrade to version 2.6, it is no longer allowed to change the `User.is_superuser` status via the eda component.

<!-- How does this change address the issue? -->
This change removes the special handling for the `User.is_superuser` field in the user serializer class (more precise: in the serializer mixin which manages the access to shared resources) which allowed for modifying this field even if `settings.ALLOW_LOCAL_RESOURCE_MANAGEMENT` is False.

<!-- Does this change introduce any new dependencies, blockers or breaking changes? -->
Tests which assume that `User.is_superuser` can be patched via the eda API would break after this change.

<!-- How it can be tested? -->
1. Create a non-admin user via gateway
2. Find the new user's id via GET /api/eda/v1/users/ (-> <user-id>)
3. Try to change the new user's type to admin via PATCH /api/eda/v1/users/<user-id>/ with payload={"is_superuser": true}
4. Assert the response to be status 403 FORBIDDEN.