### PR TITLE
fix: add view_organization permission to organization-level admin rules

### DIFF
--- a/src/aap_eda/core/management/commands/create_initial_data.py
+++ b/src/aap_eda/core/management/commands/create_initial_data.py
@@ -2340,6 +2340,19 @@ class Command(BaseCommand):
                         content_type=ct, codename__startswith="add_"
                     )
                 )
+                # Add organization view permission for organization-level admin roles,  # noqa: E501
+                org_ct = self.content_type_model.objects.get(
+                    model="organization"
+                )
+                org_view_permission = DABPermission.objects.filter(
+                    content_type=org_ct, codename="view_organization"
+                ).first()
+                if (
+                    org_view_permission
+                    and org_view_permission not in permissions
+                ):
+                    permissions.append(org_view_permission)
+
                 org_role.permissions.set(permissions)
                 if org_role_created:
                     self.stdout.write(

--- a/tests/integration/core/test_create_initial_data.py
+++ b/tests/integration/core/test_create_initial_data.py
@@ -98,3 +98,16 @@ def test_remove_extra_permission():
     assert perm in auditor_role.permissions.all()
     Command().handle()
     assert perm not in auditor_role.permissions.all()
+
+
+@pytest.mark.django_db
+def test_org_level_admins_have_view_org_permission():
+    assert RoleDefinition.objects.count() == 0
+    Command().handle()
+    org_admin_role = RoleDefinition.objects.get(
+        name="EDA Organization Project Admin"
+    )
+    assert any(
+        perm.codename == "view_organization"
+        for perm in org_admin_role.permissions.all()
+    )


### PR DESCRIPTION
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
A user belongs to a team with organization-level admin role cannot see the organization from the list organizations api endpoint. Comparing the Organzation Project Admin in Controller, it has `view_organization`
<img width="1075" height="410" alt="Screenshot 2025-07-30 at 4 00 12 PM" src="https://github.com/user-attachments/assets/beeea8f9-da3a-45db-8aa4-6f164effa51f" />
The `view_organization` permission is missing for EDA organization Project Admin in EDA 
<img width="1104" height="413" alt="Screenshot 2025-07-30 at 4 01 06 PM" src="https://github.com/user-attachments/assets/230d4909-b9e7-4807-937c-a2578044c9ac" />
 
<!-- If applicable, provide a link to the issue that is being addressed -->
https://issues.redhat.com/browse/AAP-48587
<!-- What is being changed? -->
This PR adds `view_organization` permission to any organization-level admin role
<img width="1139" height="357" alt="Screenshot 2025-07-30 at 4 32 44 PM" src="https://github.com/user-attachments/assets/1fcae192-4b38-43c7-899e-dc3ce2308605" />

<!-- Why is this change needed? -->
<!-- How does this change address the issue? -->
<!-- Does this change introduce any new dependencies, blockers or breaking changes? -->
<!-- How it can be tested? -->
The fix has been tested with aap-dev deployment. An ATF test should be added for automation after the fix is merged.
