### PR TITLE
fix: correct type for MQ_TLS setting - AAP-50811

### DIFF
--- a/src/aap_eda/settings/defaults.py
+++ b/src/aap_eda/settings/defaults.py
@@ -158,7 +158,7 @@ MQ_USER_PASSWORD: Optional[str] = None
 MQ_CLIENT_CACERT_PATH: Optional[str] = None
 MQ_CLIENT_CERT_PATH: Optional[str] = None
 MQ_CLIENT_KEY_PATH: Optional[str] = None
-MQ_TLS: Optional[str] = None
+MQ_TLS: Optional[bool] = None
 MQ_DB: int = core.DEFAULT_REDIS_DB
 
 # The HA cluster hosts is a string of <host>:<port>[,<host>:port>]+


### PR DESCRIPTION
MQ_TLS has a incorrect type, failing with `django.core.exceptions.ImproperlyConfigured: MQ_TLS setting must be a Optional`
Jira: https://issues.redhat.com/browse/AAP-50811