### PR TITLE
fix: moving project out of stuck pending or running state

### DIFF
--- a/src/aap_eda/core/management/commands/fix_project_state.py
+++ b/src/aap_eda/core/management/commands/fix_project_state.py
@@ -1,0 +1,80 @@
+#  Copyright 2025 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from django.core.management import BaseCommand, CommandError
+from django.db import transaction
+
+from aap_eda.core import models
+
+
+class Command(BaseCommand):
+    help = "Fix project import state and error message in the database."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-n", "--name", required=True, help="Name of the project to update"
+        )
+        parser.add_argument(
+            "-s",
+            "--state",
+            required=True,
+            choices=["failed", "completed"],
+            help="New import state for the project",
+        )
+        parser.add_argument(
+            "-e",
+            "--error",
+            required=False,
+            help="Import error message (optional)",
+        )
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        project_name = options["name"]
+        import_state = options["state"]
+        import_error = options.get("error")
+
+        try:
+            project = models.Project.objects.get(name=project_name)
+        except models.Project.DoesNotExist:
+            raise CommandError(f"Project '{project_name}' does not exist.")
+
+        # Store old values for logging
+        old_state = project.import_state
+        old_error = project.import_error
+
+        # Update the project
+        project.import_state = import_state
+        if import_error is not None:
+            project.import_error = import_error
+        elif import_state == "completed":
+            # Clear import_error when state is completed and no error is
+            # explicitly provided
+            project.import_error = None
+        project.save(
+            update_fields=["import_state", "import_error", "modified_at"]
+        )
+
+        # Log the changes
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Successfully updated project '{project_name}'"
+            )
+        )
+        self.stdout.write(f"  Import state: {old_state} -> {import_state}")
+        if import_error is not None:
+            self.stdout.write(f"  Import error: {old_error} -> {import_error}")
+        elif import_state == "completed" and old_error is not None:
+            self.stdout.write(f"  Import error: {old_error} -> (cleared)")
+        elif old_error is not None:
+            self.stdout.write(f"  Import error: {old_error} -> (unchanged)")

--- a/tests/integration/tasks/test_projects.py
+++ b/tests/integration/tasks/test_projects.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import uuid
 from unittest import mock
 
 import pytest
@@ -37,9 +38,8 @@ def test_monitor_project_tasks_import(
     Test that monitor_project_tasks recreate the task
     when import project task is stuck.
     """
-    job_id = "b93ae0b6-53fe-11ee-a5c4-482ae389cd08"
-    job = mock.Mock(id=job_id)
-    import_task_mock.delay.return_value = job
+    job_id = str(uuid.uuid4())
+    import_task_mock.return_value = job_id
 
     project = models.Project.objects.create(
         name="test_monitor_project_tasks",
@@ -69,9 +69,8 @@ def test_monitor_project_tasks_sync(
     Test that monitor_project_tasks recreate the task
     when sync project task is stuck.
     """
-    job_id = "b93ae0b6-53fe-11ee-a5c4-482ae389cd08"
-    job = mock.Mock(id=job_id)
-    sync_task_mock.delay.return_value = job
+    job_id = str(uuid.uuid4())
+    sync_task_mock.return_value = job_id
 
     project = models.Project.objects.create(
         name="test_monitor_project_tasks",
@@ -102,10 +101,9 @@ def test_monitor_project_tasks_with_job(
     Test that monitor_project_tasks does not recreate the task
     when sync project task is not stuck
     """
-    job_id = "b93ae0b6-53fe-11ee-a5c4-482ae389cd08"
-    job = mock.Mock(id=job_id)
-    sync_task_mock.delay.return_value = job
-    expected_job_id = "13affe8a-5401-11ee-8f1c-482ae389cd08"
+    job_id = str(uuid.uuid4())
+    sync_task_mock.return_value = job_id
+    expected_job_id = str(uuid.uuid4())
 
     project = models.Project.objects.create(
         name="test_monitor_project_tasks",
@@ -124,3 +122,232 @@ def test_monitor_project_tasks_with_job(
     worker.work(burst=True)
     project.refresh_from_db()
     assert str(project.import_task_id) == expected_job_id
+
+
+@pytest.mark.django_db
+def test_monitor_project_tasks_running_state_missing_job(
+    default_organization: models.Organization,
+    default_queue: Queue,
+):
+    """Test monitor_project_tasks handles RUNNING projects with missing jobs.
+
+    Test that projects in RUNNING state without corresponding jobs
+    are marked as FAILED with appropriate error message.
+    """
+    project = models.Project.objects.create(
+        name="test_running_missing_job",
+        url="https://git.example.com/acme/project-running",
+        import_state=models.Project.ImportState.RUNNING,
+        import_task_id=uuid.uuid4(),
+        organization=default_organization,
+    )
+
+    default_queue.enqueue(monitor_project_tasks, default_queue.name)
+
+    worker = DefaultWorker(
+        [default_queue], connection=default_queue.connection
+    )
+    worker.work(burst=True)
+
+    project.refresh_from_db()
+    assert project.import_state == models.Project.ImportState.FAILED
+    assert project.import_task_id is None
+    assert (
+        project.import_error
+        == "Project was in running state but is no longer running"
+    )
+
+
+@pytest.mark.django_db
+def test_monitor_project_tasks_ignores_completed_and_failed_projects(
+    default_organization: models.Organization,
+    default_queue: Queue,
+):
+    """Test monitor_project_tasks ignores projects in COMPLETED and FAILED
+    states.
+
+    Test that projects in terminal states (COMPLETED, FAILED) are not
+    processed even if they have missing jobs.
+    """
+    # Create projects in terminal states
+    completed_project = models.Project.objects.create(
+        name="test_completed",
+        url="https://git.example.com/acme/project-completed",
+        import_state=models.Project.ImportState.COMPLETED,
+        import_task_id=uuid.uuid4(),
+        organization=default_organization,
+    )
+
+    failed_project = models.Project.objects.create(
+        name="test_failed",
+        url="https://git.example.com/acme/project-failed",
+        import_state=models.Project.ImportState.FAILED,
+        import_task_id=uuid.uuid4(),
+        organization=default_organization,
+    )
+
+    default_queue.enqueue(monitor_project_tasks, default_queue.name)
+
+    worker = DefaultWorker(
+        [default_queue], connection=default_queue.connection
+    )
+    worker.work(burst=True)
+
+    # Refresh and verify states haven't changed
+    completed_project.refresh_from_db()
+    failed_project.refresh_from_db()
+
+    assert (
+        completed_project.import_state == models.Project.ImportState.COMPLETED
+    )
+    assert failed_project.import_state == models.Project.ImportState.FAILED
+
+
+def failing_job():
+    """A job that always fails."""
+    raise Exception("This job always fails")
+
+
+@pytest.mark.django_db
+def test_monitor_project_tasks_running_state_failed_job(
+    default_organization: models.Organization,
+    default_queue: Queue,
+):
+    """Test monitor_project_tasks handles running projects with failed jobs.
+
+    Test that projects in RUNNING state with failed jobs are marked as FAILED.
+    """
+    # Create a running project
+    project = models.Project.objects.create(
+        name="test_running_failed_job",
+        url="https://git.example.com/acme/running-failed-job",
+        import_state=models.Project.ImportState.RUNNING,
+        import_task_id=uuid.uuid4(),
+        organization=default_organization,
+    )
+
+    # Create a job that will actually fail when executed
+    failed_job_id = str(project.import_task_id)
+    default_queue.enqueue(failing_job, job_id=failed_job_id)
+
+    # Run the failing job first
+    worker = DefaultWorker(
+        [default_queue], connection=default_queue.connection
+    )
+    worker.work(burst=True)
+
+    # Now enqueue monitor_project_tasks to check the failed job
+    default_queue.enqueue(monitor_project_tasks, default_queue.name)
+    worker.work(burst=True)
+
+    # Verify project was marked as failed
+    project.refresh_from_db()
+    assert project.import_task_id is None
+    assert project.import_state == models.Project.ImportState.FAILED
+    assert (
+        project.import_error
+        == "Project was in running state but is no longer running"
+    )
+
+
+@pytest.mark.django_db
+@mock.patch("aap_eda.tasks.project.sync_project")
+@mock.patch("aap_eda.tasks.project.import_project")
+@mock.patch("aap_eda.tasks.project.logger")
+def test_monitor_project_tasks_logging(
+    logger_mock: mock.Mock,
+    import_mock: mock.Mock,
+    sync_mock: mock.Mock,
+    default_organization: models.Organization,
+    default_queue: Queue,
+):
+    """Test monitor_project_tasks produces expected log messages.
+
+    Test that appropriate log messages are generated for different scenarios.
+    """
+    import_job_id = str(uuid.uuid4())
+    sync_job_id = str(uuid.uuid4())
+    import_mock.return_value = import_job_id
+    sync_mock.return_value = sync_job_id
+
+    # Create projects for different scenarios
+    # Pending project without git_hash - should call import_project
+    pending_import_project = models.Project.objects.create(
+        name="pending_import_logs",
+        url="https://git.example.com/acme/pending-import-logs",
+        import_state=models.Project.ImportState.PENDING,
+        import_task_id=uuid.uuid4(),
+        git_hash="",
+        organization=default_organization,
+    )
+
+    # Pending project with git_hash - should call sync_project
+    pending_sync_project = models.Project.objects.create(
+        name="pending_sync_logs",
+        url="https://git.example.com/acme/pending-sync-logs",
+        import_state=models.Project.ImportState.PENDING,
+        import_task_id=uuid.uuid4(),
+        git_hash="abc123def456",
+        organization=default_organization,
+    )
+
+    # Running project - should be marked as failed
+    running_project = models.Project.objects.create(
+        name="running_for_logs",
+        url="https://git.example.com/acme/running-logs",
+        import_state=models.Project.ImportState.RUNNING,
+        import_task_id=uuid.uuid4(),
+        organization=default_organization,
+    )
+
+    # Call the internal function directly to ensure mocking works
+    from aap_eda.tasks.project import _monitor_project_tasks
+
+    _monitor_project_tasks(default_queue.name)
+
+    # Verify projects were processed
+    pending_import_project.refresh_from_db()
+    pending_sync_project.refresh_from_db()
+    running_project.refresh_from_db()
+
+    # Pending import project should get new import task ID
+    assert str(pending_import_project.import_task_id) == import_job_id
+    assert (
+        pending_import_project.import_state
+        == models.Project.ImportState.PENDING
+    )
+
+    # Pending sync project should get new sync task ID
+    assert str(pending_sync_project.import_task_id) == sync_job_id
+    assert (
+        pending_sync_project.import_state == models.Project.ImportState.PENDING
+    )
+
+    # Running project should be marked as failed
+    assert running_project.import_task_id is None
+    assert running_project.import_state == models.Project.ImportState.FAILED
+    assert (
+        running_project.import_error
+        == "Project was in running state but is no longer running"
+    )
+
+    # Verify expected log messages were produced
+    expected_calls = [
+        mock.call("Task started: Monitor project tasks"),
+        mock.call(
+            f"monitor_project_tasks: Project {pending_import_project.name} is "
+            "missing a job in the queue. Adding it back."
+        ),
+        mock.call(
+            f"monitor_project_tasks: Project {pending_sync_project.name} is "
+            "missing a job in the queue. Adding it back."
+        ),
+        mock.call(
+            f"monitor_project_tasks: Project {running_project.name} was in "
+            "running state but is no longer running. Marking as failed."
+        ),
+        mock.call("Task complete: Monitor project tasks"),
+    ]
+
+    # Assert that all expected log calls were made
+    logger_mock.info.assert_has_calls(expected_calls, any_order=False)

--- a/tests/unit/commands/test_fix_project_state.py
+++ b/tests/unit/commands/test_fix_project_state.py
@@ -1,0 +1,262 @@
+#  Copyright 2025 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from io import StringIO
+
+import pytest
+from django.core.management import base, call_command
+
+from aap_eda.core import models
+
+
+@pytest.mark.django_db
+def test_fix_project_state_successful(default_organization):
+    """Test successfully updating project state."""
+    # Create a test project
+    project = models.Project.objects.create(
+        name="test-project",
+        description="Test Project",
+        url="https://git.example.com/test/project",
+        git_hash="abc123",
+        organization=default_organization,
+        import_state=models.Project.ImportState.PENDING,
+        import_error="Old error message",
+    )
+
+    out = StringIO()
+    call_command(
+        "fix_project_state",
+        "--name",
+        "test-project",
+        "--state",
+        "completed",
+        "--error",
+        "New error message",
+        stdout=out,
+    )
+
+    project.refresh_from_db()
+    output = out.getvalue()
+
+    assert project.import_state == models.Project.ImportState.COMPLETED
+    assert project.import_error == "New error message"
+    assert "Successfully updated project 'test-project'" in output
+    assert "Import state: pending -> completed" in output
+    assert "Import error: Old error message -> New error message" in output
+
+
+@pytest.mark.django_db
+def test_fix_project_state_without_error(default_organization):
+    """Test updating project state without changing error message."""
+    project = models.Project.objects.create(
+        name="test-project-2",
+        description="Test Project 2",
+        url="https://git.example.com/test/project2",
+        git_hash="def456",
+        organization=default_organization,
+        import_state=models.Project.ImportState.PENDING,
+        import_error="Existing error",
+    )
+
+    out = StringIO()
+    call_command(
+        "fix_project_state",
+        "--name",
+        "test-project-2",
+        "--state",
+        "failed",
+        stdout=out,
+    )
+
+    project.refresh_from_db()
+    output = out.getvalue()
+
+    assert project.import_state == models.Project.ImportState.FAILED
+    assert project.import_error == "Existing error"  # Should remain unchanged
+    assert "Successfully updated project 'test-project-2'" in output
+    assert "Import state: pending -> failed" in output
+    assert "Import error: Existing error -> (unchanged)" in output
+
+
+@pytest.mark.django_db
+def test_fix_project_state_completed_clears_error(default_organization):
+    """Test that setting state to completed without providing error clears
+    existing error."""
+    project = models.Project.objects.create(
+        name="test-project-clear",
+        description="Test Project Clear Error",
+        url="https://git.example.com/test/project-clear",
+        git_hash="ghi789",
+        organization=default_organization,
+        import_state=models.Project.ImportState.FAILED,
+        import_error="Previous import error",
+    )
+
+    out = StringIO()
+    call_command(
+        "fix_project_state",
+        "--name",
+        "test-project-clear",
+        "--state",
+        "completed",
+        stdout=out,
+    )
+
+    project.refresh_from_db()
+    output = out.getvalue()
+
+    assert project.import_state == models.Project.ImportState.COMPLETED
+    assert project.import_error is None  # Should be cleared
+    assert "Successfully updated project 'test-project-clear'" in output
+    assert "Import state: failed -> completed" in output
+    assert "Import error: Previous import error -> (cleared)" in output
+
+
+@pytest.mark.django_db
+def test_fix_project_state_completed_with_explicit_error(default_organization):
+    """Test that setting state to completed with explicit error keeps the
+    provided error."""
+    project = models.Project.objects.create(
+        name="test-project-explicit",
+        description="Test Project Explicit Error",
+        url="https://git.example.com/test/project-explicit",
+        git_hash="jkl012",
+        organization=default_organization,
+        import_state=models.Project.ImportState.FAILED,
+        import_error="Previous import error",
+    )
+
+    out = StringIO()
+    call_command(
+        "fix_project_state",
+        "--name",
+        "test-project-explicit",
+        "--state",
+        "completed",
+        "--error",
+        "Custom completion message",
+        stdout=out,
+    )
+
+    project.refresh_from_db()
+    output = out.getvalue()
+
+    assert project.import_state == models.Project.ImportState.COMPLETED
+    assert (
+        project.import_error == "Custom completion message"
+    )  # Should use provided error
+    assert "Successfully updated project 'test-project-explicit'" in output
+    assert "Import state: failed -> completed" in output
+    assert (
+        "Import error: Previous import error -> Custom completion message"
+        in output
+    )
+
+
+@pytest.mark.django_db
+def test_fix_project_state_failed_preserves_error(default_organization):
+    """Test that setting state to failed without providing error preserves
+    existing error."""
+    project = models.Project.objects.create(
+        name="test-project-preserve",
+        description="Test Project Preserve Error",
+        url="https://git.example.com/test/project-preserve",
+        git_hash="mno345",
+        organization=default_organization,
+        import_state=models.Project.ImportState.RUNNING,
+        import_error="Existing error message",
+    )
+
+    out = StringIO()
+    call_command(
+        "fix_project_state",
+        "--name",
+        "test-project-preserve",
+        "--state",
+        "failed",
+        stdout=out,
+    )
+
+    project.refresh_from_db()
+    output = out.getvalue()
+
+    assert project.import_state == models.Project.ImportState.FAILED
+    assert (
+        project.import_error == "Existing error message"
+    )  # Should remain unchanged
+    assert "Successfully updated project 'test-project-preserve'" in output
+    assert "Import state: running -> failed" in output
+    assert "Import error: Existing error message -> (unchanged)" in output
+
+
+@pytest.mark.django_db
+def test_fix_project_state_nonexistent_project():
+    """Test command with non-existent project."""
+    out = StringIO()
+
+    with pytest.raises(base.CommandError) as exc_info:
+        call_command(
+            "fix_project_state",
+            "--name",
+            "nonexistent-project",
+            "--state",
+            "completed",
+            stdout=out,
+        )
+
+    assert "Project 'nonexistent-project' does not exist." in str(
+        exc_info.value
+    )
+
+
+@pytest.mark.parametrize(
+    "invalid_state", ["invalid-state", "pending", "running"]
+)
+@pytest.mark.django_db
+def test_fix_project_state_invalid_states(invalid_state):
+    """Test command rejects invalid import states."""
+    out = StringIO()
+
+    with pytest.raises(base.CommandError) as exc_info:
+        call_command(
+            "fix_project_state",
+            "--name",
+            "test-project",
+            "--state",
+            invalid_state,
+            stdout=out,
+        )
+
+    error_msg = str(exc_info.value)
+    # Handle both quoted and unquoted error message formats
+    assert (
+        f"invalid choice: '{invalid_state}'" in error_msg
+        or f"invalid choice: {invalid_state}" in error_msg
+    )
+    assert "choose from" in error_msg
+    assert "failed" in error_msg
+    assert "completed" in error_msg
+
+
+@pytest.mark.django_db
+def test_fix_project_state_missing_required_args():
+    """Test command with missing required arguments."""
+    out = StringIO()
+
+    with pytest.raises(base.CommandError) as exc_info:
+        call_command("fix_project_state", stdout=out)
+
+    assert (
+        "the following arguments are required: -n/--name, -s/--state"
+        in str(exc_info.value)
+    )


### PR DESCRIPTION
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
Fix bug in existing monitor_project_tasks for pending state. 
Add new logic to handle running state. 
Add new django command to manually change the import state of a project
<!-- If applicable, provide a link to the issue that is being addressed -->
https://issues.redhat.com/browse/AAP-51139
<!-- What is being changed? -->
Fix the bug in requeueing pending projects that are no longer in the queue.
Detect running projects that are no longer in the queue or already failed but not updated in database.
The django command can be used as a last resort helping the project to move out of a stuck state.
<!-- Why is this change needed? -->
Once a project is stuck in pending or running, it cannot be restarted. This work helps to move such projects out of the situation.
<!-- How does this change address the issue? -->
<!-- Does this change introduce any new dependencies, blockers or breaking changes? -->
<!-- How it can be tested? -->
