### PR TITLE
fix: the test function was broken for eda_credential

### DIFF
--- a/src/aap_eda/api/serializers/credential_type.py
+++ b/src/aap_eda/api/serializers/credential_type.py
@@ -92,7 +92,7 @@ class CredentialTypeTestSerializer(serializers.ModelSerializer):
     )
 
     def validate(self, data):
-        metadata = data.get("metadata")
+        metadata = data.get("metadata", {})
         inputs = data.get("inputs")
 
         validators.check_credential_test_data(self.instance, inputs, metadata)

--- a/src/aap_eda/api/serializers/eda_credential.py
+++ b/src/aap_eda/api/serializers/eda_credential.py
@@ -329,7 +329,7 @@ class EdaCredentialTestSerializer(serializers.ModelSerializer):
     )
 
     def validate(self, attrs):
-        metadata = attrs.get("metadata")
+        metadata = attrs.get("metadata", {})
         inputs = inputs_from_store(self.instance.inputs.get_secret_value())
 
         validators.check_credential_test_data(

--- a/src/aap_eda/core/validators.py
+++ b/src/aap_eda/core/validators.py
@@ -598,9 +598,9 @@ def check_if_refspec_valid(refspec: str) -> str:
 def check_credential_test_data(
     credential_type: models.CredentialType, inputs: dict, metadata: dict
 ):
-    if not inputs or not metadata:
+    if not inputs:
         raise serializers.ValidationError(
-            "In test mode both inputs and metadata have to be provided"
+            "In test mode inputs have to be provided"
         )
 
     errors = validate_inputs(

--- a/tests/integration/api/test_eda_credential.py
+++ b/tests/integration/api/test_eda_credential.py
@@ -1442,27 +1442,80 @@ def test_create_external_credential_type(
 
 
 @pytest.mark.parametrize(
-    ("metadata", "status_code", "raise_exception"),
+    (
+        "credential_type_name",
+        "inputs",
+        "metadata",
+        "status_code",
+        "raise_exception",
+    ),
     [
         (
+            enums.DefaultCredentialType.HASHICORP_LOOKUP,
+            {
+                "url": "https://www.example.com",
+                "api_version": "v2",
+                "token": secrets.token_hex(32),
+            },
             {"secret_path": "secret/foo", "secret_key": "bar"},
             status.HTTP_202_ACCEPTED,
             False,
         ),
         (
+            enums.DefaultCredentialType.HASHICORP_LOOKUP,
+            {
+                "url": "https://www.example.com",
+                "api_version": "v2",
+                "token": secrets.token_hex(32),
+            },
             {"secret_key": "bar"},
             status.HTTP_400_BAD_REQUEST,
             False,
         ),
         (
+            enums.DefaultCredentialType.HASHICORP_LOOKUP,
+            {
+                "url": "https://www.example.com",
+                "api_version": "v2",
+                "token": secrets.token_hex(32),
+            },
+            {},
+            status.HTTP_400_BAD_REQUEST,
+            False,
+        ),
+        (
+            enums.DefaultCredentialType.HASHICORP_LOOKUP,
+            {
+                "url": "https://www.example.com",
+                "api_version": "v2",
+                "token": secrets.token_hex(32),
+            },
             {"secret_path": "secret/foo", "secret_key": "bar"},
             status.HTTP_400_BAD_REQUEST,
             True,
         ),
         (
+            enums.DefaultCredentialType.HASHICORP_LOOKUP,
+            {
+                "url": "https://www.example.com",
+                "api_version": "v2",
+                "token": secrets.token_hex(32),
+            },
             None,
             status.HTTP_400_BAD_REQUEST,
             True,
+        ),
+        (
+            enums.DefaultCredentialType.GITHUB_APP,
+            {
+                "app_or_client_id": "1111111",
+                "github_api_url": "https://api.github.com",
+                "install_id": "11111111",
+                "private_rsa_key": DUMMY_SSH_KEY,
+            },
+            {},
+            status.HTTP_202_ACCEPTED,
+            False,
         ),
     ],
 )
@@ -1471,22 +1524,20 @@ def test_create_external_credential_test(
     admin_client: APIClient,
     default_organization: models.Organization,
     preseed_credential_types,
+    credential_type_name: str,
+    inputs: dict,
     metadata: Optional[dict],
     status_code: int,
     raise_exception: bool,
 ):
-    hashi_type = models.CredentialType.objects.get(
-        name=enums.DefaultCredentialType.HASHICORP_LOOKUP
+    credential_type = models.CredentialType.objects.get(
+        name=credential_type_name
     )
 
     data_in = {
         "name": "eda-credential",
-        "inputs": {
-            "url": "https://www.example.com",
-            "api_version": "v2",
-            "token": secrets.token_hex(32),
-        },
-        "credential_type_id": hashi_type.id,
+        "inputs": inputs,
+        "credential_type_id": credential_type.id,
         "organization_id": default_organization.id,
     }
 


### PR DESCRIPTION
The test function for eda_credential was broken, it needs to support some of the Credential Types that have optional metadata fields like GitHub App Installation Access Token Lookup We need to support empty metadata during the test. If the metadata is empty we have to look at the credentials schema and see if it has mandatory fields and then raise an error. If the fields are optional then we should allow empty metadata

https://issues.redhat.com/browse/AAP-52232