### PR TITLE
AAP-52587: support extended boolean values

### DIFF
--- a/src/aap_eda/settings/defaults.py
+++ b/src/aap_eda/settings/defaults.py
@@ -65,7 +65,7 @@ Redis queue settings:
 *   - Takes precedence over host and port
 * MQ_HOST - Redis queue hostname (default: "127.0.0.1")
 * MQ_PORT - Redis queue port (default: 6379)
-* MQ_TLS - Force TLS on when True (default: None)
+* MQ_TLS - Force TLS on when True or "yes" (default: None)
 * MQ_DB - Redis queue database (default: 0)
 * MQ_USER - Redis user (default: None)
 * MQ_USER_PASSWORD - Redis user passed (default: None)
@@ -157,7 +157,7 @@ MQ_USER_PASSWORD: Optional[str] = None
 MQ_CLIENT_CACERT_PATH: Optional[str] = None
 MQ_CLIENT_CERT_PATH: Optional[str] = None
 MQ_CLIENT_KEY_PATH: Optional[str] = None
-MQ_TLS: Optional[bool] = None
+MQ_TLS: Optional[Union[bool, str]] = None
 MQ_DB: int = core.DEFAULT_REDIS_DB
 
 # The HA cluster hosts is a string of <host>:<port>[,<host>:port>]+

--- a/src/aap_eda/settings/post_load.py
+++ b/src/aap_eda/settings/post_load.py
@@ -460,7 +460,15 @@ def post_loading(loaded_settings: Dynaconf):
     )
     settings.REDIS_CLIENT_CERT_PATH = settings.get("MQ_CLIENT_CERT_PATH", None)
     settings.REDIS_CLIENT_KEY_PATH = settings.get("MQ_CLIENT_KEY_PATH", None)
-    settings.REDIS_TLS = settings.get("MQ_TLS", None)
+
+    # Handle MQ_TLS setting - convert string values to boolean
+    mq_tls = settings.get("MQ_TLS", None)
+    if mq_tls is not None and isinstance(mq_tls, str):
+        converted_tls = utils.str_to_bool(mq_tls)
+        settings.MQ_TLS = converted_tls
+        settings.REDIS_TLS = converted_tls
+    else:
+        settings.REDIS_TLS = mq_tls
     settings.REDIS_DB = settings.get("MQ_DB", settings.DEFAULT_REDIS_DB)
     settings.REDIS_HA_CLUSTER_HOSTS = settings.get(
         "MQ_REDIS_HA_CLUSTER_HOSTS", ""


### PR DESCRIPTION
Support extended set of boolean values (true/false/yes/no/1/0) for MQ_TLS setting.

Currently if a non-standard boolean value is used (yes/no/1/0), this can cause issues during an upgrade.

[AAP-52587](https://issues.redhat.com/browse/AAP-52587)

Generated with assistance from Cursor (claude-4-sonnet).