### PR TITLE
Add new service-index/object-delete endpoint in test

### DIFF
--- a/tests/integration/api/test_root.py
+++ b/tests/integration/api/test_root.py
@@ -59,6 +59,7 @@ from tests.integration.constants import api_url_v1
                 "/role_team_assignments/",
                 "/role_metadata/",
                 "/service-index/metadata/",
+                "/service-index/object-delete/",
                 "/service-index/resources/",
                 "/service-index/resource-types/",
                 "/service-index/role-types/",


### PR DESCRIPTION
New endpoint added in https://github.com/ansible/django-ansible-base/pull/834

which cause DAB EDA consume test to fail in the DAB repo with the following error

```
=========================== short test summary info ============================
FAILED tests/integration/api/test_root.py::test_v1_root[no_shared_resource] - assert 42 == 41
 +  where 42 = len({'activation-list': 'http://testserver/api/eda/v1/activations/', 'activationinstance-list': 'http://testserver/api/eda..., 'auditrule-list': 'http://testserver/api/eda/v1/audit-rules/', 'config': 'http://testserver/api/eda/v1/config/', ...})
 +    where {'activation-list': 'http://testserver/api/eda/v1/activations/', 'activationinstance-list': 'http://testserver/api/eda..., 'auditrule-list': 'http://testserver/api/eda/v1/audit-rules/', 'config': 'http://testserver/api/eda/v1/config/', ...} = <Response status_code=200, "application/json">.data
 +  and   41 = len(['/config/', '/status/', '/role_definitions/', '/role_user_assignments/', '/role_team_assignments/', '/role_metadata/', ...])
 ```
