### PR TITLE
Fix downstream failure from DAB

### DIFF
--- a/tests/integration/api/test_vault.py
+++ b/tests/integration/api/test_vault.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import pytest
+import re
 
 from aap_eda.api.vault import (
     AnsibleVaultDecryptionFailed,
@@ -21,9 +22,8 @@ from aap_eda.api.vault import (
 )
 
 PASSWORD = "secret"
-RE_ERROR_MSG = (
-    r"! Decryption failed (no vault secrets were found that could decrypt)*"
-)
+CORE = r"Decryption failed \(no vault secrets were found that could decrypt\)"
+RE_ERROR_MSG = re.compile(CORE, re.IGNORECASE | re.DOTALL)
 label = "EDA"
 
 

--- a/tests/integration/api/test_vault.py
+++ b/tests/integration/api/test_vault.py
@@ -11,8 +11,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import pytest
 import re
+
+import pytest
 
 from aap_eda.api.vault import (
     AnsibleVaultDecryptionFailed,


### PR DESCRIPTION
Failure documented in:

https://github.com/ansible/django-ansible-base/pull/852

I expect that DAB is seeing `test_failed_decrypt` fail because of minor differences in behavior due to versions of dependencies. The failure seems to occur due to minor and inconsequential differences in the exact syntax of the error message observed. This change generalizes the expected regex for the exception's text.