### PR TITLE
Updating transitive dependency "constantly"

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -645,14 +645,14 @@ markers = {dev = "sys_platform == \"win32\"", lint = "platform_system == \"Windo
 
 [[package]]
 name = "constantly"
-version = "15.1.0"
+version = "23.10.4"
 description = "Symbolic constants in Python"
 optional = false
-python-versions = "*"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "constantly-15.1.0-py2.py3-none-any.whl", hash = "sha256:dd2fa9d6b1a51a83f0d7dd76293d734046aa176e384bf6e33b7e44880eb37c5d"},
-    {file = "constantly-15.1.0.tar.gz", hash = "sha256:586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"},
+    {file = "constantly-23.10.4-py3-none-any.whl", hash = "sha256:3fd9b4d1c3dc1ec9757f3c52aef7e53ad9323dbe39f51dfd4c43853b68dfa3f9"},
+    {file = "constantly-23.10.4.tar.gz", hash = "sha256:aa92b70a33e2ac0bb33cd745eb61776594dc48764b06c35e0efd050b7f1c7cbd"},
 ]
 
 [[package]]
@@ -894,7 +894,7 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-ansible-base"
-version = "2026.1.14.0.dev9+g929364895"
+version = "2026.1.19.0.dev12+gedc8b5338"
 description = "A Django app used by ansible services"
 optional = false
 python-versions = ">=3.11"
@@ -933,7 +933,7 @@ testing = ["cryptography", "pytest", "pytest-django"]
 type = "git"
 url = "https://github.com/ansible/django-ansible-base.git"
 reference = "devel"
-resolved_reference = "929364895a3cd31d37217ba9ae26dc1efd5aef02"
+resolved_reference = "edc8b5338e3e836993a0f6e096e43913a5c05955"
 
 [[package]]
 name = "django-crum"
@@ -3420,4 +3420,4 @@ dev = ["psycopg-binary"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "bab7203d834dd04475d6798ccf82d1b2c6b08199f43e0ee55f21ef357d3b903b"
+content-hash = "6379fd0cf89a6a2031573e8dda2bcff5ee908970ad8519f1e9fbfe93c137149c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,10 @@ awx-plugins-core = { version = "^0.0.1a10", extras = [
                               "credentials-thycotic-dsv",
                               "credentials-thycotic-tss"
                     ]}
+# transitive dependency needed by Daphne to resolve conflicts in Konflux build
+# adding here to be captured in the building of the 
+# `requirements-poetry-export.in` file
+constantly = ">=23.10.4,<24"
 
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
Updating transitive dependency, "constantly" needed by Daphne to resolve conflicts in Konflux build. Adding here to be captured in the building of the `requirements-poetry-export.in` file from the `automation-eda-controller-container`
