### PR TITLE
[ANSTRAT-1840] Merge feature branch: Enforce JWT-only authentication for EDA

### DIFF
--- a/src/aap_eda/settings/default.py
+++ b/src/aap_eda/settings/default.py
@@ -49,6 +49,19 @@ load_standard_settings_files(
 load_envvars(DYNACONF)  # load envvars prefixed with EDA_
 DYNACONF.load_file("core.py")  # load internal non-overwritable settings
 post_loading(DYNACONF)
+
+# When deployed as part of AAP (RESOURCE_SERVER__URL is set), restrict
+# authentication to JWT-only.  WebsocketJWTAuthentication is retained
+# because rulebook workers connect back via websocket with HS256 JWT.
+if DYNACONF.get("RESOURCE_SERVER__URL", None):
+    DYNACONF.set(
+        "REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES",
+        [
+            "ansible_base.jwt_consumer.eda.auth.EDAJWTAuthentication",
+            "aap_eda.api.authentication.WebsocketJWTAuthentication",
+        ],
+    )
+
 load_dab_settings(DYNACONF)
 
 export(__name__, DYNACONF)  # export back to django.conf.settings


### PR DESCRIPTION
## Summary

Merges the `feature_anstrat-1840` branch into `main`, bringing in the auth lockdown change from the original PR:

**Original PR:** https://github.com/ansible/eda-server/pull/1474

---

### Original PR Description

#### What is being changed?

When EDA is deployed as part of AAP (indicated by `RESOURCE_SERVER__URL` being set), restrict `REST_FRAMEWORK.DEFAULT_AUTHENTICATION_CLASSES` to only allow JWT-based authentication:

- `EDAJWTAuthentication` - for gateway-proxied API requests via DAB JWT
- `WebsocketJWTAuthentication` - retained for rulebook worker websocket connections that use HS256 JWT

#### Why is this change needed?

As part of ANSTRAT-1840, all user-facing API access to EDA must go through the AAP gateway when deployed as part of the platform. Direct API access using session or token authentication must be blocked.

#### How does this change address the issue?

After `post_loading(DYNACONF)` completes, if `RESOURCE_SERVER__URL` is configured, the authentication classes are overridden to only accept:
1. DAB JWT tokens (set by the gateway's trusted proxy)
2. Websocket JWT tokens (used internally by rulebook workers)

This effectively locks out session auth, basic auth, and standalone token auth for user-facing requests while preserving internal websocket communication.

#### Does this change introduce any new dependencies, blockers or breaking changes?

- No new dependencies
- This only activates when `RESOURCE_SERVER__URL` is set (AAP deployment mode)
- Standalone EDA deployments are unaffected
- Websocket auth for rulebook workers is preserved

## Jira

- [AAP-65812](https://issues.redhat.com/browse/AAP-65812)
- [AAP-65701](https://issues.redhat.com/browse/AAP-65701)
- [ANSTRAT-1840](https://issues.redhat.com/browse/ANSTRAT-1840)

## Test plan

- [ ] Deploy EDA as part of AAP with `RESOURCE_SERVER__URL` set
- [ ] Verify API requests through the gateway work (JWT auth)
- [ ] Verify direct API requests with session/token auth are rejected
- [ ] Verify rulebook worker websocket connections still work
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)