### PR TITLE
fix: default RESOURCE_SERVER__URL to None to restore standalone auth

### DIFF
--- a/src/aap_eda/settings/defaults.py
+++ b/src/aap_eda/settings/defaults.py
@@ -193,7 +193,7 @@ ALLOW_SHARED_RESOURCE_CUSTOM_ROLES: bool = False
 # DJANGO ANSIBLE BASE RESOURCE API CLIENT
 # --------------------------------------------------------
 
-RESOURCE_SERVER__URL: Optional[str] = "https://localhost"
+RESOURCE_SERVER__URL: Optional[str] = None
 RESOURCE_SERVER__SECRET_KEY: Optional[str] = ""
 RESOURCE_SERVER__VALIDATE_HTTPS: bool = False
 RESOURCE_JWT_USER_ID: Optional[str] = None


### PR DESCRIPTION
After we merged this [1], all user-facing API access to EDA must go
through the AAP gateway when deployed as part of the platform.

However, `RESOURCE_SERVER__URL` defaults to `"https://localhost"`, which
causes the JWT-only authentication override in default.py to fire unconditionally.
This breaks session-based UI login for standalone deployments.

Setting the default to None ensures SessionAuthentication is preserved unless
`RESOURCE_SERVER__URL` is explicitly configured, which only happens when
deployed behind the AAP Gateway.

The reason this didn't break any development scenarios, `"task docker:up"` or similar
is because docker-compose-dev.yaml sets `EDA_MODE=development`, which loads
up development_defaults.py instead, which then sets `RESOURCE_SERVER["URL"]` to
None by default.

[1] https://github.com/ansible/eda-server/pull/1495

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Default resource server URL is now unset by default instead of using a localhost value.
  * This prevents accidental local connections and requires explicit configuration for external resource servers, making deployments safer and configuration behavior more predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->