### PR TITLE
feat: add support for rule engine system credential

### DIFF
--- a/src/aap_eda/core/management/commands/create_initial_data.py
+++ b/src/aap_eda/core/management/commands/create_initial_data.py
@@ -2387,6 +2387,7 @@ class Command(BaseCommand):
             settings_registry.persist_registry_data()
             self._preload_credential_types()
             self._update_postgres_credentials()
+            self._update_rule_engine_credentials()
             self._create_org_roles()
             self._create_obj_roles()
             self._remove_deprecated_credential_kinds()
@@ -2494,6 +2495,80 @@ class Command(BaseCommand):
             name=settings.DEFAULT_SYSTEM_PG_NOTIFY_CREDENTIAL_NAME,
             defaults={
                 "description": "Default PG Notify Credentials",
+                "managed": True,
+                "credential_type": cred_type,
+                "inputs": inputs_to_store(inputs),
+                "organization": get_default_organization(),
+            },
+        )
+
+    def _update_rule_engine_credentials(self):
+        if not settings.EVENT_PERSISTENCE_DB_HOST:
+            return
+
+        use_cert_auth = (
+            settings.EVENT_PERSISTENCE_PGSSLCERT
+            and settings.EVENT_PERSISTENCE_PGSSLKEY
+        )
+
+        required = {
+            "EVENT_PERSISTENCE_DB_PORT": settings.EVENT_PERSISTENCE_DB_PORT,
+            "EVENT_PERSISTENCE_DB_USER": settings.EVENT_PERSISTENCE_DB_USER,
+        }
+        if not use_cert_auth:
+            required[
+                "EVENT_PERSISTENCE_DB_PASSWORD"
+            ] = settings.EVENT_PERSISTENCE_DB_PASSWORD
+
+        missing = [k for k, v in required.items() if not v]
+        if missing:
+            raise ImproperlyConfigured(
+                "EVENT_PERSISTENCE_DB_HOST is set but the following "
+                "required settings are missing: "
+                f"{', '.join(missing)}"
+            )
+
+        cred_type = models.CredentialType.objects.get(
+            name=enums.DefaultCredentialType.EDA_RULE_ENGINE
+        )
+
+        if use_cert_auth:
+            db_password = ""
+        else:
+            db_password = settings.EVENT_PERSISTENCE_DB_PASSWORD
+
+        inputs = {
+            "postgres_db_host": settings.EVENT_PERSISTENCE_DB_HOST,
+            "postgres_db_port": str(settings.EVENT_PERSISTENCE_DB_PORT),
+            "postgres_db_name": settings.EVENT_PERSISTENCE_DB_NAME,
+            "postgres_db_user": settings.EVENT_PERSISTENCE_DB_USER,
+            "postgres_db_password": db_password,
+            "postgres_sslmode": settings.EVENT_PERSISTENCE_PGSSLMODE,
+            "postgres_sslcert": "",
+            "postgres_sslkey": "",
+            "postgres_sslrootcert": "",
+        }
+
+        if use_cert_auth:
+            inputs["postgres_sslcert"] = self._read_file(
+                settings.EVENT_PERSISTENCE_PGSSLCERT,
+                "EVENT_PERSISTENCE_PGSSLCERT",
+            )
+            inputs["postgres_sslkey"] = self._read_file(
+                settings.EVENT_PERSISTENCE_PGSSLKEY,
+                "EVENT_PERSISTENCE_PGSSLKEY",
+            )
+
+        if settings.EVENT_PERSISTENCE_PGSSLROOTCERT:
+            inputs["postgres_sslrootcert"] = self._read_file(
+                settings.EVENT_PERSISTENCE_PGSSLROOTCERT,
+                "EVENT_PERSISTENCE_PGSSLROOTCERT",
+            )
+
+        models.EdaCredential.objects.update_or_create(
+            name=settings.DEFAULT_SYSTEM_RULE_ENGINE_CREDENTIAL_NAME,
+            defaults={
+                "description": "Default Rule Engine Credential",
                 "managed": True,
                 "credential_type": cred_type,
                 "inputs": inputs_to_store(inputs),

--- a/src/aap_eda/settings/defaults.py
+++ b/src/aap_eda/settings/defaults.py
@@ -220,6 +220,17 @@ EVENT_STREAM_DB_SSLCERT: Optional[str] = None  # Path to client certificate
 EVENT_STREAM_DB_SSLKEY: Optional[str] = None  # Path to client private key
 EVENT_STREAM_DB_SSLMODE: Optional[str] = None  # SSL mode for event streams
 
+# Database settings for the event persistence DB (rule engine)
+EVENT_PERSISTENCE_DB_HOST: Optional[str] = None
+EVENT_PERSISTENCE_DB_PORT: Optional[int] = None
+EVENT_PERSISTENCE_DB_NAME: str = "eda_event_persistence"
+EVENT_PERSISTENCE_DB_USER: Optional[str] = None
+EVENT_PERSISTENCE_DB_PASSWORD: Optional[str] = None
+EVENT_PERSISTENCE_PGSSLMODE: Optional[str] = "prefer"
+EVENT_PERSISTENCE_PGSSLCERT: Optional[str] = None
+EVENT_PERSISTENCE_PGSSLKEY: Optional[str] = None
+EVENT_PERSISTENCE_PGSSLROOTCERT: Optional[str] = None
+
 # --------------------------------------------------------
 # METRICS COLLECTIONS:
 # --------------------------------------------------------

--- a/tests/unit/commands/test_create_initial_data.py
+++ b/tests/unit/commands/test_create_initial_data.py
@@ -252,3 +252,130 @@ def test_create_initial_data_postgres_cred_no_leak_platform_certs():
         # Should use password auth credentials
         assert decoded_inputs["postgres_db_user"] == "eda_event_stream"
         assert decoded_inputs["postgres_db_password"] == "test_password"
+
+
+@pytest.mark.django_db
+def test_create_initial_data_rule_engine_cred_not_created_without_host():
+    """Test that no rule engine credential is created when
+    EVENT_PERSISTENCE_DB_HOST is not set.
+    """
+    call_command("create_initial_data")
+    assert not models.EdaCredential.objects.filter(
+        name=settings.DEFAULT_SYSTEM_RULE_ENGINE_CREDENTIAL_NAME
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_create_initial_data_rule_engine_cred_with_password_auth():
+    """Test that the rule engine credential is created with password auth."""
+    with override_settings(
+        EVENT_PERSISTENCE_DB_HOST="ep-host",
+        EVENT_PERSISTENCE_DB_PORT=5433,
+        EVENT_PERSISTENCE_DB_NAME="custom_db",
+        EVENT_PERSISTENCE_DB_USER="ep_user",
+        EVENT_PERSISTENCE_DB_PASSWORD="ep_password",
+        EVENT_PERSISTENCE_PGSSLMODE="verify-full",
+    ):
+        call_command("create_initial_data")
+        cred = models.EdaCredential.objects.get(
+            name=settings.DEFAULT_SYSTEM_RULE_ENGINE_CREDENTIAL_NAME
+        )
+        assert cred.managed is True
+        assert (
+            cred.credential_type.name
+            == enums.DefaultCredentialType.EDA_RULE_ENGINE
+        )
+
+        raw_inputs = (
+            cred.inputs.get_secret_value()
+            if isinstance(cred.inputs, SecretValue)
+            else cred.inputs
+        )
+        decoded_inputs = inputs_from_store(raw_inputs)
+
+        assert decoded_inputs["postgres_db_host"] == "ep-host"
+        assert decoded_inputs["postgres_db_port"] == "5433"
+        assert decoded_inputs["postgres_db_name"] == "custom_db"
+        assert decoded_inputs["postgres_db_user"] == "ep_user"
+        assert decoded_inputs["postgres_db_password"] == "ep_password"
+        assert decoded_inputs["postgres_sslmode"] == "verify-full"
+
+
+@pytest.mark.django_db
+def test_create_initial_data_rule_engine_cred_missing_required():
+    """Test that ImproperlyConfigured is raised when host is set
+    but other required settings are missing.
+    """
+    with override_settings(
+        EVENT_PERSISTENCE_DB_HOST="ep-host",
+        EVENT_PERSISTENCE_DB_PORT=None,
+        EVENT_PERSISTENCE_DB_USER=None,
+        EVENT_PERSISTENCE_DB_PASSWORD=None,
+    ):
+        with pytest.raises(ImproperlyConfigured, match="required settings"):
+            call_command("create_initial_data")
+
+
+@pytest.mark.django_db
+def test_create_initial_data_rule_engine_cred_cert_auth():
+    """Test that cert auth does not require a password."""
+    cert_file = tempfile.NamedTemporaryFile()
+    with open(cert_file.name, "w") as f:
+        f.write("rule-engine-cert")
+
+    key_file = tempfile.NamedTemporaryFile()
+    with open(key_file.name, "w") as f:
+        f.write("rule-engine-key")
+
+    with override_settings(
+        EVENT_PERSISTENCE_DB_HOST="ep-host",
+        EVENT_PERSISTENCE_DB_PORT=5432,
+        EVENT_PERSISTENCE_DB_USER="ep_user",
+        EVENT_PERSISTENCE_DB_PASSWORD=None,
+        EVENT_PERSISTENCE_PGSSLCERT=cert_file.name,
+        EVENT_PERSISTENCE_PGSSLKEY=key_file.name,
+    ):
+        call_command("create_initial_data")
+        cred = models.EdaCredential.objects.get(
+            name=settings.DEFAULT_SYSTEM_RULE_ENGINE_CREDENTIAL_NAME
+        )
+
+        raw_inputs = (
+            cred.inputs.get_secret_value()
+            if isinstance(cred.inputs, SecretValue)
+            else cred.inputs
+        )
+        decoded_inputs = inputs_from_store(raw_inputs)
+
+        assert decoded_inputs["postgres_db_password"] == ""
+        assert "rule-engine-cert" in decoded_inputs["postgres_sslcert"]
+        assert "rule-engine-key" in decoded_inputs["postgres_sslkey"]
+
+
+@pytest.mark.django_db
+def test_create_initial_data_rule_engine_cred_with_rootcert():
+    """Test that rootcert is read when provided."""
+    rootcert_file = tempfile.NamedTemporaryFile()
+    with open(rootcert_file.name, "w") as f:
+        f.write("rule-engine-rootcert")
+
+    with override_settings(
+        EVENT_PERSISTENCE_DB_HOST="ep-host",
+        EVENT_PERSISTENCE_DB_PORT=5432,
+        EVENT_PERSISTENCE_DB_USER="ep_user",
+        EVENT_PERSISTENCE_DB_PASSWORD="ep_password",
+        EVENT_PERSISTENCE_PGSSLROOTCERT=rootcert_file.name,
+    ):
+        call_command("create_initial_data")
+        cred = models.EdaCredential.objects.get(
+            name=settings.DEFAULT_SYSTEM_RULE_ENGINE_CREDENTIAL_NAME
+        )
+
+        raw_inputs = (
+            cred.inputs.get_secret_value()
+            if isinstance(cred.inputs, SecretValue)
+            else cred.inputs
+        )
+        decoded_inputs = inputs_from_store(raw_inputs)
+
+        assert "rule-engine-rootcert" in decoded_inputs["postgres_sslrootcert"]

--- a/tools/docker/docker-compose-dev.yaml
+++ b/tools/docker/docker-compose-dev.yaml
@@ -51,6 +51,11 @@ x-environment: &common-env
   EDA_AUTOMATION_ANALYTICS_GATHER_INTERVAL: ${EDA_AUTOMATION_ANALYTICS_GATHER_INTERVAL:-14400}
   EDA_REDHAT_USERNAME: ${EDA_REDHAT_USERNAME:-''}
   EDA_REDHAT_PASSWORD: ${EDA_REDHAT_PASSWORD:-''}
+  EDA_EVENT_PERSISTENCE_DB_HOST: ${EDA_EVENT_PERSISTENCE_DB_HOST:-postgres}
+  EDA_EVENT_PERSISTENCE_DB_PORT: ${EDA_EVENT_PERSISTENCE_DB_PORT:-5432}
+  EDA_EVENT_PERSISTENCE_DB_NAME: ${EDA_EVENT_PERSISTENCE_DB_NAME:-eda_event_persistence}
+  EDA_EVENT_PERSISTENCE_DB_USER: ${EDA_EVENT_PERSISTENCE_DB_USER:-eda}
+  EDA_EVENT_PERSISTENCE_DB_PASSWORD: ${EDA_EVENT_PERSISTENCE_DB_PASSWORD:-secret}
   PYTHONPATH: ./dispatcherd:${PYTHONPATH}
 
 
@@ -80,10 +85,13 @@ services:
       POSTGRESQL_PASSWORD: secret
       POSTGRESQL_ADMIN_PASSWORD: secret
       POSTGRESQL_DATABASE: eda
+      EDA_EVENT_PERSISTENCE_DB_NAME: ${EDA_EVENT_PERSISTENCE_DB_NAME:-eda_event_persistence}
+      EDA_EVENT_PERSISTENCE_DB_USER: ${EDA_EVENT_PERSISTENCE_DB_USER:-eda}
     ports:
       - '${EDA_PG_PORT:-5432}:5432'
     volumes:
       - 'postgres_data:/var/lib/pgsql/data'
+      - './postgres/initdb.d/create_event_persistence_db.sh:/opt/app-root/src/postgresql-start/create_event_persistence_db.sh:z'
     healthcheck:
       test: [ 'CMD', 'pg_isready', '-U', 'postgres' ]
       interval: 5s

--- a/tools/docker/docker-compose-mac.yml
+++ b/tools/docker/docker-compose-mac.yml
@@ -55,6 +55,11 @@ x-environment:
   - EDA_AUTOMATION_ANALYTICS_GATHER_INTERVAL=${EDA_AUTOMATION_ANALYTICS_GATHER_INTERVAL:-14400}
   - EDA_REDHAT_USERNAME=${EDA_REDHAT_USERNAME:-''}
   - EDA_REDHAT_PASSWORD=${EDA_REDHAT_PASSWORD:-''}
+  - EDA_EVENT_PERSISTENCE_DB_HOST=${EDA_EVENT_PERSISTENCE_DB_HOST:-postgres}
+  - EDA_EVENT_PERSISTENCE_DB_PORT=${EDA_EVENT_PERSISTENCE_DB_PORT:-5432}
+  - EDA_EVENT_PERSISTENCE_DB_NAME=${EDA_EVENT_PERSISTENCE_DB_NAME:-eda_event_persistence}
+  - EDA_EVENT_PERSISTENCE_DB_USER=${EDA_EVENT_PERSISTENCE_DB_USER:-eda}
+  - EDA_EVENT_PERSISTENCE_DB_PASSWORD=${EDA_EVENT_PERSISTENCE_DB_PASSWORD:-secret}
 
 
 services:
@@ -65,10 +70,13 @@ services:
       POSTGRESQL_PASSWORD: secret
       POSTGRESQL_ADMIN_PASSWORD: secret
       POSTGRESQL_DATABASE: eda
+      EDA_EVENT_PERSISTENCE_DB_NAME: ${EDA_EVENT_PERSISTENCE_DB_NAME:-eda_event_persistence}
+      EDA_EVENT_PERSISTENCE_DB_USER: ${EDA_EVENT_PERSISTENCE_DB_USER:-eda}
     ports:
       - '${EDA_PG_PORT:-5432}:5432'
     volumes:
       - 'postgres_data:/var/lib/pgsql/data'
+      - './postgres/initdb.d/create_event_persistence_db.sh:/opt/app-root/src/postgresql-start/create_event_persistence_db.sh:z'
     healthcheck:
       test: [ 'CMD', 'pg_isready', '-U', 'postgres' ]
       interval: 5s

--- a/tools/docker/docker-compose-stage.yaml
+++ b/tools/docker/docker-compose-stage.yaml
@@ -52,6 +52,11 @@ x-environment:
   - EDA_AUTOMATION_ANALYTICS_GATHER_INTERVAL=${EDA_AUTOMATION_ANALYTICS_GATHER_INTERVAL:-14400}
   - EDA_REDHAT_USERNAME=${EDA_REDHAT_USERNAME:-''}
   - EDA_REDHAT_PASSWORD=${EDA_REDHAT_PASSWORD:-''}
+  - EDA_EVENT_PERSISTENCE_DB_HOST=${EDA_EVENT_PERSISTENCE_DB_HOST:-postgres}
+  - EDA_EVENT_PERSISTENCE_DB_PORT=${EDA_EVENT_PERSISTENCE_DB_PORT:-5432}
+  - EDA_EVENT_PERSISTENCE_DB_NAME=${EDA_EVENT_PERSISTENCE_DB_NAME:-eda_event_persistence}
+  - EDA_EVENT_PERSISTENCE_DB_USER=${EDA_EVENT_PERSISTENCE_DB_USER:-eda}
+  - EDA_EVENT_PERSISTENCE_DB_PASSWORD=${EDA_EVENT_PERSISTENCE_DB_PASSWORD:-secret}
 
 services:
   podman:
@@ -70,10 +75,13 @@ services:
       POSTGRESQL_PASSWORD: secret
       POSTGRESQL_ADMIN_PASSWORD: secret
       POSTGRESQL_DATABASE: eda
+      EDA_EVENT_PERSISTENCE_DB_NAME: ${EDA_EVENT_PERSISTENCE_DB_NAME:-eda_event_persistence}
+      EDA_EVENT_PERSISTENCE_DB_USER: ${EDA_EVENT_PERSISTENCE_DB_USER:-eda}
     ports:
       - '${EDA_PG_PORT:-5432}:5432'
     volumes:
       - 'postgres_data:/var/lib/pgsql/data'
+      - './postgres/initdb.d/create_event_persistence_db.sh:/opt/app-root/src/postgresql-start/create_event_persistence_db.sh:z'
     healthcheck:
       test: [ 'CMD', 'pg_isready', '-U', 'postgres' ]
       interval: 5s

--- a/tools/docker/postgres/initdb.d/create_event_persistence_db.sh
+++ b/tools/docker/postgres/initdb.d/create_event_persistence_db.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Create the event persistence database if it does not exist.
+DB_NAME="${EDA_EVENT_PERSISTENCE_DB_NAME:-eda_event_persistence}"
+DB_USER="${EDA_EVENT_PERSISTENCE_DB_USER:-eda}"
+
+psql -U postgres -v db_name="${DB_NAME}" -v db_user="${DB_USER}" <<-'EOSQL'
+    SELECT 'CREATE ROLE "' || :'db_user' || '" LOGIN'
+    WHERE NOT EXISTS (
+        SELECT FROM pg_roles WHERE rolname = :'db_user'
+    )\gexec
+
+    SELECT 'CREATE DATABASE "' || :'db_name' || '" OWNER "' || :'db_user' || '"'
+    WHERE NOT EXISTS (
+        SELECT FROM pg_database WHERE datname = :'db_name'
+    )\gexec
+EOSQL


### PR DESCRIPTION
Adding rule engine system credential for event persistence. Update containerized deployment to support new database for the event persistence feature.

https://redhat.atlassian.net/browse/AAP-66375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add configurable event-persistence DB settings with password or TLS certificate auth and validation.
  * Automatically create/update the Rule Engine persistence credential during initialization when configured.

* **Tests**
  * Added unit tests for credential creation, missing-required-settings validation, password vs. certificate auth, and root-certificate handling.

* **Chores**
  * Updated local Docker setup to provision the event-persistence database at container startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->