### PR TITLE
fix(deps): upgrade PyJWT 2.7.0 → 2.12.1 (CVE-2026-32597)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -931,7 +931,7 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-ansible-base"
-version = "2026.1.14.0.dev9+g929364895"
+version = "2026.4.7.0.dev4+g1d99b5cb7"
 description = "A Django app used by ansible services"
 optional = false
 python-versions = ">=3.11"
@@ -970,7 +970,7 @@ testing = ["cryptography", "pytest", "pytest-django"]
 type = "git"
 url = "https://github.com/ansible/django-ansible-base.git"
 reference = "devel"
-resolved_reference = "a44f62b77729b214bffff4326a45f5b3ca7586a1"
+resolved_reference = "1d99b5cb7eda50b0460a65b5f6f70045669694d2"
 
 [[package]]
 name = "django-crum"
@@ -2388,14 +2388,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pyjwt"
-version = "2.7.0"
+version = "2.12.1"
 description = "JSON Web Token implementation in Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "PyJWT-2.7.0-py3-none-any.whl", hash = "sha256:ba2b425b15ad5ef12f200dc67dd56af4e26de2331f965c5439994dad075876e1"},
-    {file = "PyJWT-2.7.0.tar.gz", hash = "sha256:bd6ca4a3c4285c1a2d4349e5a035fdf8fb94e04ccd0fcbe6ba289dae9cc3e074"},
+    {file = "pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"},
+    {file = "pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"},
 ]
 
 [package.dependencies]
@@ -2403,9 +2403,9 @@ cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"cryp
 
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]
-dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
-docs = ["sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
-tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
+dev = ["coverage[toml] (==7.10.7)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=8.4.2,<9.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
+docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
 
 [[package]]
 name = "pynacl"
@@ -3451,4 +3451,4 @@ dev = ["psycopg-binary"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "be2a2581b3a0ddae97be12fb4a3d0eadd8acc2de0416e65c7704756f35e2b500"
+content-hash = "2b57dc6032ca2f1618613a496af9b5b4718397293dac8f2386512402b181d3be"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ python-gnupg = "^0.5.2"
 autobahn = ">=24.4.2"
 psycopg = "^3.1.17"
 xxhash = "3.4.*"
-pyjwt = { version = "2.7.*", extras = ["crypto"] }
+pyjwt = { version = ">=2.12.1,<3", extras = ["crypto"] }
 ecdsa = "0.18.*"
 validators = "^0.34.0"
 django-flags = "^5.0.13"

--- a/src/aap_eda/services/auth.py
+++ b/src/aap_eda/services/auth.py
@@ -87,7 +87,7 @@ def get_jwt_token(user_id, expiration, **kwargs):
 
 def parse_jwt_token(token: str) -> dict:
     try:
-        return jwt.decode(token, settings.SECRET_KEY, JWT_ALGORITHM)
+        return jwt.decode(token, settings.SECRET_KEY, [JWT_ALGORITHM])
     except jwt.DecodeError as e:
         raise InvalidTokenError("Bad token") from e
     except jwt.ExpiredSignatureError as e:


### PR DESCRIPTION
## Summary
- Upgrades PyJWT from 2.7.0 to 2.12.1 to remediate CVE-2026-32597 (CVSS 7.5 HIGH)
- PyJWT < 2.12.0 silently accepts JWS tokens with unrecognized `crit` header extensions, violating RFC 7515 §4.1.11
- Fixes `algorithms` parameter in `parse_jwt_token()` to pass a list instead of a bare string

Jira issue: [AAP-68398](https://redhat.atlassian.net/browse/AAP-68398)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated JWT authentication library dependency to a newer version with expanded compatibility range.

* **Bug Fixes**
  * Fixed JWT token validation to ensure proper algorithm handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->