### PR TITLE
Prevents port numbers from changing datatype.

### DIFF
--- a/src/aap_eda/settings/post_load.py
+++ b/src/aap_eda/settings/post_load.py
@@ -302,10 +302,10 @@ def _get_default_pg_notify_dsn_server(settings: Dynaconf) -> str:
         f"dbname={settings.DATABASES['default']['NAME']} "
         f"user={settings.DATABASES['default']['USER']} "
         f"password={settings.DATABASES['default']['PASSWORD']} "
-        f"sslmode={db_options.get('sslmode','allow')} "
-        f"sslcert={db_options.get('sslcert','')} "
-        f"sslkey={db_options.get('sslkey','')} "
-        f"sslrootcert={db_options.get('sslrootcert','')} "
+        f"sslmode={db_options.get('sslmode', 'allow')} "
+        f"sslcert={db_options.get('sslcert', '')} "
+        f"sslkey={db_options.get('sslkey', '')} "
+        f"sslrootcert={db_options.get('sslrootcert', '')} "
     )
 
 
@@ -320,6 +320,27 @@ def _set_resource_server(settings: Dynaconf) -> None:
         ] = {"schedule": 900}
 
 
+def _enforce_optional_str_type(settings: Dynaconf, key: str, value) -> None:
+    """Enforce Optional[str] type, converting int to str if needed."""
+    if value is None:
+        # None is valid for Optional[str]
+        pass
+    elif isinstance(value, int):
+        settings[key] = str(value)
+    elif isinstance(value, str):
+        settings[key] = _get_stripped_str(settings, key)
+    else:
+        _validate_type(key, value, Optional[str])
+
+
+def _enforce_str_type(settings: Dynaconf, key: str, value) -> None:
+    """Enforce str type."""
+    if isinstance(value, str):
+        settings[key] = _get_stripped_str(settings, key)
+    else:
+        _validate_type(key, value, str)
+
+
 def _enforce_types(settings: Dynaconf) -> None:
     for key, key_type in get_type_hints(defaults).items():
         if key_type is defaults.StrToList:
@@ -330,10 +351,12 @@ def _enforce_types(settings: Dynaconf) -> None:
             settings[key] = _get_int(settings, key)
         elif key_type is defaults.UrlSlash:
             settings[key] = _get_url_end_slash(settings, key)
+        elif key_type is Optional[str]:
+            _enforce_optional_str_type(settings, key, settings[key])
+        elif key_type is str:
+            _enforce_str_type(settings, key, settings[key])
         elif not isinstance(settings[key], key_type):
             _validate_type(key, settings[key], key_type)
-        elif key_type is str or key_type is Optional[str]:
-            settings[key] = _get_stripped_str(settings, key)
 
 
 def _validate_type(key: str, value, key_type) -> None:

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -133,6 +133,11 @@ def test_duplicated_worker_queue(mock_settings):
         ("PODMAN_EXTRA_ARGS", "opt=val", ImproperlyConfigured),
         ("RESOURCE_JWT_USER_ID", " eda ", "eda"),
         ("RESOURCE_JWT_USER_ID", ["eda"], ImproperlyConfigured),
+        # EVENT_PERSISTENCE_DB_PORT should accept int and convert to str
+        ("EVENT_PERSISTENCE_DB_PORT", 5432, "5432"),
+        ("EVENT_PERSISTENCE_DB_PORT", "5432", "5432"),
+        ("EVENT_PERSISTENCE_DB_PORT", " 5433 ", "5433"),
+        ("EVENT_PERSISTENCE_DB_PORT", None, None),
     ],
 )
 def test_types(mock_settings, name, value, expected):


### PR DESCRIPTION
PDE reporting an issue where the new event persistence feature was breaking the CI job.  turns out Dynaconf was loading the `EVENT_PERSISTENCE_DB_PORT` env var as an integer but it was typed as an `Optional[str]`.  This pr fixes that problem, and adds tests to ensure it doesn't return.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Settings validation now accepts integer inputs for values expected as strings by converting them to strings, trims surrounding whitespace from string inputs, and preserves explicit null values. No public configuration interfaces were changed.

* **Tests**
  * Added unit tests verifying integer-to-string coercion, whitespace trimming, and null-preservation during settings post-load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->