### PR TITLE
chore: update openapi spec workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,8 @@ jobs:
     uses: ./.github/workflows/sync-openapi-spec.yml
     secrets:
       OPENAPI_SPEC_SYNC_TOKEN: ${{ secrets.OPENAPI_SPEC_SYNC_TOKEN }}
+      OPENAPI_SPEC_REPO: ${{ secrets.OPENAPI_SPEC_REPO }}
+      OPENAPI_SPEC_SYNC_GPG_PRIVATE_KEY: ${{ secrets.OPENAPI_SPEC_SYNC_GPG_PRIVATE_KEY }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-openapi-spec.yml
+++ b/.github/workflows/sync-openapi-spec.yml
@@ -8,6 +8,10 @@ on:
     secrets:
       OPENAPI_SPEC_SYNC_TOKEN:
         required: true
+      OPENAPI_SPEC_REPO:
+        required: true
+      OPENAPI_SPEC_SYNC_GPG_PRIVATE_KEY:
+        required: true
 
 jobs:
   sync:
@@ -49,7 +53,7 @@ jobs:
         continue-on-error: true
         uses: actions/checkout@v6
         with:
-          repository: ansible-automation-platform/aap-openapi-specs
+          repository: ${{ secrets.OPENAPI_SPEC_REPO }}
           ref: ${{ steps.branch_map.outputs.spec_branch }}
           path: spec-repo
           token: ${{ secrets.OPENAPI_SPEC_SYNC_TOKEN }}
@@ -85,22 +89,51 @@ jobs:
             fi
           fi
 
-      - name: Create PR in spec repo
+      - name: Create or update PR in spec repo
         if: steps.check.outputs.has_diff == 'true'
         working-directory: spec-repo
         env:
           GH_TOKEN: ${{ secrets.OPENAPI_SPEC_SYNC_TOKEN }}
+          GPG_PRIVATE_KEY: ${{ secrets.OPENAPI_SPEC_SYNC_GPG_PRIVATE_KEY }}
+          SPEC_REPO: ${{ secrets.OPENAPI_SPEC_REPO }}
           SPEC_BRANCH: ${{ steps.branch_map.outputs.spec_branch }}
           SOURCE_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          # Configure git
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Import GPG key and configure git for signed commits
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import 2>/dev/null
+          GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format long 2>/dev/null | grep sec | head -1 | awk '{print $2}' | cut -d'/' -f2)
+          if [ -z "$GPG_KEY_ID" ]; then
+            echo "❌ Failed to import GPG key or extract key ID"
+            exit 1
+          fi
+          git config user.name "aap-api-bot"
+          git config user.email "aap-api-bot@redhat.com"
+          git config commit.gpgsign true
+          git config user.signingkey "$GPG_KEY_ID"
 
-          # Create branch for PR
-          SHORT_SHA="${{ github.sha }}"
-          SHORT_SHA="${SHORT_SHA:0:7}"
-          BRANCH_NAME="update-EDA-${SPEC_BRANCH}-${SHORT_SHA}"
+          # Configure git to use the token for push
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${SPEC_REPO}.git"
+
+          # Use a stable branch name so we can reuse it across runs
+          BRANCH_NAME="auto/update-eda-${SPEC_BRANCH}"
+          
+          # Check if there's already an open PR from this branch
+          EXISTING_PR=$(gh pr list \
+            --repo "$SPEC_REPO" \
+            --head "$BRANCH_NAME" \
+            --base "$SPEC_BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "📝 Found existing PR #${EXISTING_PR} - will update it"
+          else
+            echo "📝 No existing PR found - will create a new one"
+            # Clean up stale remote branch from a previously merged PR
+            git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
+          fi
+          
           git checkout -b "$BRANCH_NAME"
 
           # Add and commit changes
@@ -121,7 +154,7 @@ jobs:
           Co-Authored-By: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
 
           # Push branch
-          git push origin "$BRANCH_NAME"
+          git push --force origin "$BRANCH_NAME"
 
           # Create PR (commit message passed via env var to avoid script injection)
           PR_TITLE="[${SPEC_BRANCH}] Update EDA spec from merged commit"
@@ -148,13 +181,20 @@ jobs:
           EOF
           )
 
-          gh pr create \
-            --title "$PR_TITLE" \
-            --body "$PR_BODY" \
-            --base "${SPEC_BRANCH}" \
-            --head "$BRANCH_NAME"
-
-          echo "✅ Created PR in spec repo"
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr edit "$EXISTING_PR" \
+              --repo "$SPEC_REPO" \
+              --body "$PR_BODY"
+            echo "✅ Updated existing PR #${EXISTING_PR}"
+          else
+            gh pr create \
+              --repo "$SPEC_REPO" \
+              --title "$PR_TITLE" \
+              --body "$PR_BODY" \
+              --base "$SPEC_BRANCH" \
+              --head "$BRANCH_NAME"
+            echo "✅ Created PR in spec repo"
+          fi
 
       - name: Report results
         if: always()


### PR DESCRIPTION
- Add logic for git commit signing
- Add logic to update existing PR's

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Use a stable branch and update or deduplicate existing pull requests instead of creating per-run PRs.
  * Add support for supplying a GPG private key to cryptographically sign automated commits.
  * Allow the sync workflow to accept repository and key secrets for flexible syncing.
  * Change push behavior to force-update the stable branch and prefer editing existing PRs over always creating new ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->