### PR TITLE
chore: add reviewer team to openapi spec PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,7 @@ jobs:
       OPENAPI_SPEC_SYNC_TOKEN: ${{ secrets.OPENAPI_SPEC_SYNC_TOKEN }}
       OPENAPI_SPEC_REPO: ${{ secrets.OPENAPI_SPEC_REPO }}
       OPENAPI_SPEC_SYNC_GPG_PRIVATE_KEY: ${{ secrets.OPENAPI_SPEC_SYNC_GPG_PRIVATE_KEY }}
+      OPENAPI_SPEC_PR_REVIEW_TEAM: ${{ secrets.OPENAPI_SPEC_PR_REVIEW_TEAM }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-openapi-spec.yml
+++ b/.github/workflows/sync-openapi-spec.yml
@@ -1,5 +1,5 @@
 ---
-# Sync generated OpenAPI spec to ansible-automation-platform/aap-openapi-specs.
+# Sync generated OpenAPI spec to the central spec repository.
 # Called by CI workflows after spec generation via workflow_call.
 name: Sync OpenAPI Spec
 
@@ -11,6 +11,8 @@ on:
       OPENAPI_SPEC_REPO:
         required: true
       OPENAPI_SPEC_SYNC_GPG_PRIVATE_KEY:
+        required: true
+      OPENAPI_SPEC_PR_REVIEW_TEAM:
         required: true
 
 jobs:
@@ -96,6 +98,7 @@ jobs:
           GH_TOKEN: ${{ secrets.OPENAPI_SPEC_SYNC_TOKEN }}
           GPG_PRIVATE_KEY: ${{ secrets.OPENAPI_SPEC_SYNC_GPG_PRIVATE_KEY }}
           SPEC_REPO: ${{ secrets.OPENAPI_SPEC_REPO }}
+          SPEC_PR_REVIEW_TEAM: ${{ secrets.OPENAPI_SPEC_PR_REVIEW_TEAM }}
           SPEC_BRANCH: ${{ steps.branch_map.outputs.spec_branch }}
           SOURCE_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
@@ -116,7 +119,7 @@ jobs:
 
           # Use a stable branch name so we can reuse it across runs
           BRANCH_NAME="auto/update-eda-${SPEC_BRANCH}"
-          
+
           # Check if there's already an open PR from this branch
           EXISTING_PR=$(gh pr list \
             --repo "$SPEC_REPO" \
@@ -133,7 +136,7 @@ jobs:
             # Clean up stale remote branch from a previously merged PR
             git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
           fi
-          
+
           git checkout -b "$BRANCH_NAME"
 
           # Add and commit changes
@@ -192,7 +195,8 @@ jobs:
               --title "$PR_TITLE" \
               --body "$PR_BODY" \
               --base "$SPEC_BRANCH" \
-              --head "$BRANCH_NAME"
+              --head "$BRANCH_NAME" \
+              --reviewer "$SPEC_PR_REVIEW_TEAM"
             echo "✅ Created PR in spec repo"
           fi
 


### PR DESCRIPTION
This change adds the --reviewer flag to the gh pr create command so that new PRs that are opened to the spec repo will automatically add the reviewing team, so that spec update PRs do not go unnoticed.

The secret has already been added to the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to streamline the review assignment process for OpenAPI specification synchronization pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->