### PR TITLE
fix: auto-restart activations after project branch correction (AAP-72814)

### DIFF
--- a/src/aap_eda/services/project/imports.py
+++ b/src/aap_eda/services/project/imports.py
@@ -74,6 +74,7 @@ def _project_import_wrapper(
         except Exception as e:
             project.import_state = models.Project.ImportState.FAILED
             project.import_error = str(e)
+            project.git_hash = ""
             error = e
         finally:
             try:

--- a/src/aap_eda/tasks/project.py
+++ b/src/aap_eda/tasks/project.py
@@ -240,48 +240,7 @@ def _auto_restart_activations(project: models.Project):
     for activation in activations:
         checked_count += 1
         try:
-            current_rulebook = models.Rulebook.objects.get(
-                id=activation.rulebook_id
-            )
-            current_sha256 = current_rulebook.rulesets_sha256
-            current_git_hash = project.git_hash
-
-            content_changed = (
-                activation.rulebook_rulesets_sha256 != current_sha256
-            )
-            hash_changed = activation.git_hash != current_git_hash
-
-            if content_changed and activation.source_mappings:
-                logger.warning(
-                    f"Skipping auto-restart for activation "
-                    f"'{activation.name}' - has event stream "
-                    f"source mappings that need manual update"
-                )
-                continue
-
-            # Only auto-restart activations have their cached
-            # rulesets updated (filtered by query above).
-            if content_changed or hash_changed:
-                activation.rulebook_rulesets = current_rulebook.rulesets or ""
-                activation.rulebook_rulesets_sha256 = current_sha256
-                activation.git_hash = current_git_hash
-                activation.save(
-                    update_fields=[
-                        "rulebook_rulesets",
-                        "rulebook_rulesets_sha256",
-                        "git_hash",
-                    ]
-                )
-
-            if content_changed:
-                logger.info(
-                    f"Content changed for activation "
-                    f"'{activation.name}', "
-                    f"triggering auto-restart"
-                )
-                _restart_activation(activation)
-                restart_count += 1
-
+            restart_count += _check_and_restart_activation(activation, project)
         except ObjectDoesNotExist:
             logger.warning(
                 f"Rulebook for activation "
@@ -302,8 +261,71 @@ def _auto_restart_activations(project: models.Project):
     )
 
 
-def _restart_activation(activation: models.Activation):
-    """Execute auto-restart for an activation."""
+def _check_and_restart_activation(
+    activation: models.Activation,
+    project: models.Project,
+) -> int:
+    """Check a single activation and restart if needed.
+
+    Returns 1 if a restart was triggered, 0 otherwise.
+    """
+    current_rulebook = models.Rulebook.objects.get(id=activation.rulebook_id)
+    current_sha256 = current_rulebook.rulesets_sha256
+    current_git_hash = project.git_hash
+
+    content_changed = activation.rulebook_rulesets_sha256 != current_sha256
+    hash_changed = activation.git_hash != current_git_hash
+
+    if content_changed and activation.source_mappings:
+        logger.warning(
+            f"Skipping auto-restart for activation "
+            f"'{activation.name}' - has event stream "
+            f"source mappings that need manual update"
+        )
+        return 0
+
+    if content_changed or hash_changed:
+        activation.rulebook_rulesets = current_rulebook.rulesets or ""
+        activation.rulebook_rulesets_sha256 = current_sha256
+        activation.git_hash = current_git_hash
+        activation.save(
+            update_fields=[
+                "rulebook_rulesets",
+                "rulebook_rulesets_sha256",
+                "git_hash",
+            ]
+        )
+
+    activation_failed = activation.status in (
+        ActivationStatus.FAILED,
+        ActivationStatus.ERROR,
+    )
+
+    if not content_changed and not activation_failed:
+        return 0
+
+    reason = (
+        "Content changed"
+        if content_changed
+        else "Recovering failed activation"
+    )
+    logger.info(
+        f"{reason} for activation "
+        f"'{activation.name}', "
+        f"triggering auto-restart"
+    )
+    restarted = _restart_activation(activation)
+    if activation_failed and restarted:
+        activation.failure_count = 0
+        activation.save(update_fields=["failure_count"])
+    return 1
+
+
+def _restart_activation(activation: models.Activation) -> bool:
+    """Execute auto-restart for an activation.
+
+    Returns True if the restart was submitted successfully.
+    """
     try:
         restart_rulebook_process(
             process_parent_type=ProcessParentType.ACTIVATION,
@@ -328,7 +350,7 @@ def _restart_activation(activation: models.Activation):
                 f"'{activation.name}': {save_err}",
                 exc_info=True,
             )
-        return
+        return False
 
     try:
         activation.restart_count += 1
@@ -341,6 +363,7 @@ def _restart_activation(activation: models.Activation):
         )
 
     logger.info(f"Auto-restarted activation '{activation.name}'")
+    return True
 
 
 def _update_activation_content(

--- a/tests/integration/services/test_project_import.py
+++ b/tests/integration/services/test_project_import.py
@@ -316,3 +316,64 @@ def test_project_import_with_invalid_rulebooks(
     assert project.import_state == models.Project.ImportState.COMPLETED
     assert caplog.text.count("WARNING") == 20
     assert project.rulebook_set.count() == 1
+
+
+# ------------------------------------------------------------------
+# AAP-72814: git_hash cleared on sync failure
+# ------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_sync_failure_clears_git_hash(
+    default_organization: models.Organization,
+    service_tempdir_patch,
+):
+    """When sync fails, git_hash is cleared to empty string so the
+    next successful sync does not early-exit."""
+    project = models.Project.objects.create(
+        name="test-clear-hash",
+        url="https://git.example.com/repo.git",
+        organization=default_organization,
+        git_hash="original-hash-abc123",
+        import_state=models.Project.ImportState.COMPLETED,
+    )
+
+    git_mock = mock.Mock(name="ScmRepository", spec=ScmRepository)
+    git_mock.clone.side_effect = Exception("Failed to checkout foobar")
+
+    service = ProjectImportService(scm_cls=git_mock)
+    with pytest.raises(Exception, match="Failed to import the project"):
+        service.sync_project(project)
+
+    project.refresh_from_db()
+    assert project.git_hash == ""
+    assert project.import_state == models.Project.ImportState.FAILED
+    assert "Failed to checkout foobar" in project.import_error
+
+
+@pytest.mark.django_db
+def test_sync_recovery_after_failure_reprocesses(
+    default_organization: models.Organization,
+    storage_save_patch,
+    service_tempdir_patch,
+):
+    """After a failed sync clears git_hash, a subsequent successful
+    sync with the same commit reprocesses rulebooks (no early-exit)."""
+    project = models.Project.objects.create(
+        name="test-recovery",
+        url="https://git.example.com/repo.git",
+        organization=default_organization,
+        git_hash="",
+        import_state=models.Project.ImportState.FAILED,
+    )
+
+    git_mock = _mock_git_clone(
+        "project-02", "e5fa44f2b31c1fb553b6021e7360d07d5d91ff5e"
+    )
+    service = ProjectImportService(scm_cls=git_mock)
+    service.sync_project(project)
+    project.refresh_from_db()
+
+    assert project.git_hash == "e5fa44f2b31c1fb553b6021e7360d07d5d91ff5e"
+    assert project.import_state == models.Project.ImportState.COMPLETED
+    assert project.rulebook_set.count() > 0

--- a/tests/integration/tasks/test_projects.py
+++ b/tests/integration/tasks/test_projects.py
@@ -1887,3 +1887,228 @@ def test_recover_orphaned_exception_handling(
     activation.refresh_from_db()
     # Still stuck because save failed
     assert activation.awaiting_project_sync is True
+
+
+# ------------------------------------------------------------------
+# AAP-72814: Auto-restart FAILED/ERROR activations on successful sync
+# ------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@patch("aap_eda.tasks.project.restart_rulebook_process")
+def test_auto_restart_failed_activation_on_sync(
+    mock_restart,
+    default_organization,
+):
+    """FAILED activation with restart_on_project_update=True restarts
+    after successful sync even when content is unchanged."""
+    project = models.Project.objects.create(
+        name="Test Project",
+        url="https://github.com/example/repo",
+        organization=default_organization,
+        git_hash="abc123",
+    )
+    rulebook = _create_test_rulebook(
+        project,
+        default_organization,
+        rulesets="same-content",
+    )
+    activation = _create_test_activation(
+        project,
+        default_organization,
+        rulebook,
+        name="failed-activation",
+        restart_on_project_update=True,
+        rulebook_rulesets="same-content",
+        git_hash="abc123",
+        status=ActivationStatus.FAILED,
+        failure_count=3,
+    )
+
+    _auto_restart_activations(project)
+
+    mock_restart.assert_called_once()
+    activation.refresh_from_db()
+    assert activation.failure_count == 0
+
+
+@pytest.mark.django_db
+@patch("aap_eda.tasks.project.restart_rulebook_process")
+def test_auto_restart_error_activation_on_sync(
+    mock_restart,
+    default_organization,
+):
+    """ERROR activation with restart_on_project_update=True restarts
+    after successful sync even when content is unchanged."""
+    project = models.Project.objects.create(
+        name="Test Project",
+        url="https://github.com/example/repo",
+        organization=default_organization,
+        git_hash="abc123",
+    )
+    rulebook = _create_test_rulebook(
+        project,
+        default_organization,
+        rulesets="same-content",
+    )
+    activation = _create_test_activation(
+        project,
+        default_organization,
+        rulebook,
+        name="error-activation",
+        restart_on_project_update=True,
+        rulebook_rulesets="same-content",
+        git_hash="abc123",
+        status=ActivationStatus.ERROR,
+        failure_count=5,
+    )
+
+    _auto_restart_activations(project)
+
+    mock_restart.assert_called_once()
+    activation.refresh_from_db()
+    assert activation.failure_count == 0
+
+
+@pytest.mark.django_db
+@patch("aap_eda.tasks.project.restart_rulebook_process")
+def test_auto_restart_running_activation_not_restarted(
+    mock_restart,
+    default_organization,
+):
+    """RUNNING activation with unchanged content is NOT restarted."""
+    project = models.Project.objects.create(
+        name="Test Project",
+        url="https://github.com/example/repo",
+        organization=default_organization,
+        git_hash="abc123",
+    )
+    rulebook = _create_test_rulebook(
+        project,
+        default_organization,
+        rulesets="same-content",
+    )
+    _create_test_activation(
+        project,
+        default_organization,
+        rulebook,
+        name="running-activation",
+        restart_on_project_update=True,
+        rulebook_rulesets="same-content",
+        git_hash="abc123",
+        status=ActivationStatus.RUNNING,
+    )
+
+    _auto_restart_activations(project)
+
+    mock_restart.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch("aap_eda.tasks.project.restart_rulebook_process")
+def test_auto_restart_failed_activation_without_restart_flag(
+    mock_restart,
+    default_organization,
+):
+    """FAILED activation with restart_on_project_update=False is NOT
+    restarted (excluded by queryset filter)."""
+    project = models.Project.objects.create(
+        name="Test Project",
+        url="https://github.com/example/repo",
+        organization=default_organization,
+        git_hash="abc123",
+    )
+    rulebook = _create_test_rulebook(
+        project,
+        default_organization,
+        rulesets="same-content",
+    )
+    _create_test_activation(
+        project,
+        default_organization,
+        rulebook,
+        name="no-restart-flag",
+        restart_on_project_update=False,
+        rulebook_rulesets="same-content",
+        git_hash="abc123",
+        status=ActivationStatus.FAILED,
+    )
+
+    _auto_restart_activations(project)
+
+    mock_restart.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch("aap_eda.tasks.project.restart_rulebook_process")
+def test_auto_restart_content_changed_still_works(
+    mock_restart,
+    default_organization,
+):
+    """Content-changed restart still works as before (regression guard)."""
+    project = models.Project.objects.create(
+        name="Test Project",
+        url="https://github.com/example/repo",
+        organization=default_organization,
+        git_hash="abc123",
+    )
+    rulebook = _create_test_rulebook(
+        project,
+        default_organization,
+        rulesets="new-content",
+    )
+    activation = _create_test_activation(
+        project,
+        default_organization,
+        rulebook,
+        name="content-changed",
+        restart_on_project_update=True,
+        rulebook_rulesets="old-content",
+        git_hash="abc123",
+        status=ActivationStatus.RUNNING,
+    )
+
+    _auto_restart_activations(project)
+
+    mock_restart.assert_called_once()
+    activation.refresh_from_db()
+    assert activation.rulebook_rulesets == "new-content"
+
+
+@pytest.mark.django_db
+@patch("aap_eda.tasks.project.restart_rulebook_process")
+def test_auto_restart_failed_with_content_change(
+    mock_restart,
+    default_organization,
+):
+    """FAILED activation with content change: both failure_count reset
+    and content update occur, log shows 'Content changed'."""
+    project = models.Project.objects.create(
+        name="Test Project",
+        url="https://github.com/example/repo",
+        organization=default_organization,
+        git_hash="abc123",
+    )
+    rulebook = _create_test_rulebook(
+        project,
+        default_organization,
+        rulesets="new-content",
+    )
+    activation = _create_test_activation(
+        project,
+        default_organization,
+        rulebook,
+        name="failed-content-changed",
+        restart_on_project_update=True,
+        rulebook_rulesets="old-content",
+        git_hash="abc123",
+        status=ActivationStatus.FAILED,
+        failure_count=3,
+    )
+
+    _auto_restart_activations(project)
+
+    mock_restart.assert_called_once()
+    activation.refresh_from_db()
+    assert activation.rulebook_rulesets == "new-content"
+    assert activation.failure_count == 0


### PR DESCRIPTION
## Summary

Fixes [[AAP-72814](https://redhat.atlassian.net/browse/AAP-72814)] — when a project sync fails (e.g., invalid branch) and the branch is later corrected, activations do not auto-restart.

Two root causes:

1. `_project_import_wrapper` preserves a stale `git_hash` on sync failure, causing the next successful sync to early-exit at the hash comparison (`imports.py:117-126`) without reprocessing rulebooks.
2. `_auto_restart_activations()` only restarts on content change (SHA256 diff). Activations stuck in FAILED/ERROR from a prior sync failure have no recovery path.

## Changes

- Clear `project.git_hash` on sync failure so subsequent syncs reprocess rulebooks
- Restart FAILED/ERROR activations with `restart_on_project_update=True` after successful sync
- Reset `failure_count` after restart so retry policy starts fresh

## Test plan

- [x] `test_sync_failure_clears_git_hash` — hash cleared to empty string on failure
- [x] `test_sync_recovery_after_failure_reprocesses` — recovery sync doesn't early-exit
- [x] `test_auto_restart_failed_activation_on_sync` — FAILED activation restarts, failure_count reset
- [x] `test_auto_restart_error_activation_on_sync` — ERROR activation restarts
- [x] `test_auto_restart_running_activation_not_restarted` — no spurious restarts
- [x] `test_auto_restart_failed_activation_without_restart_flag` — opt-in respected
- [x] `test_auto_restart_content_changed_still_works` — regression guard
- [x] `test_auto_restart_failed_with_content_change` — both conditions together
- [x] Reproduced locally via Django shell: full cycle from sync failure through recovery
- [x] All 17 existing auto-restart tests pass (zero regressions)