### PR TITLE
fix: prevent secret redaction oracle attack in project sync errors (AAP-72813)

### DIFF
--- a/src/aap_eda/services/project/scm.py
+++ b/src/aap_eda/services/project/scm.py
@@ -243,9 +243,17 @@ class ScmRepository:
                 git_hash = _executor(extra_vars=extra_vars, env_vars=env_vars)
         except ScmError as e:
             msg = str(e)
-            if secret:
-                msg = msg.replace(secret, "****", 1)
-                msg = msg.replace(quote(secret, safe=""), "****", 1)
+            # Replace credential-embedded URL with clean URL instead
+            # of redacting the password substring (which would create
+            # an oracle attack vector — see AAP-72813).
+            if final_url != url:
+                msg = msg.replace(final_url, url)
+            # Handle URL-decoded form for passwords with special chars
+            # (e.g., "p@ss" is encoded as "p%40ss" in final_url, but
+            # git may print the decoded form in error messages).
+            if secret and secret != quote(secret, safe=""):
+                raw_url = final_url.replace(quote(secret, safe=""), secret)
+                msg = msg.replace(raw_url, url)
             logger.warning("SCM clone failed: %s", msg)
             raise e.__class__(msg) from None
         finally:

--- a/tests/unit/test_scm.py
+++ b/tests/unit/test_scm.py
@@ -165,7 +165,7 @@ def test_git_clone_leak_password(
     def raise_error(**kwargs):
         raise scm.ScmError(
             "fatal: Unable to access "
-            "'https://me:supersecret@git.example.com/repo.git'"
+            "'https://adam:secret@git.example.com/repo.git'"
         )
 
     executor.side_effect = raise_error
@@ -178,8 +178,72 @@ def test_git_clone_leak_password(
                 credential=credential,
                 _executor=executor,
             )
-    assert "supersecret" not in str(exc_info)
-    assert "****" in str(exc_info)
+    error_msg = str(exc_info.value)
+    assert "secret" not in error_msg
+    assert "adam:secret@" not in error_msg
+    assert "git.example.com/repo.git" in error_msg
+
+
+@pytest.mark.django_db
+def test_git_clone_no_oracle_attack(
+    credential: models.EdaCredential,
+):
+    """Secret substrings in non-URL parts of the error are not redacted,
+    preventing an oracle attack (AAP-72813)."""
+    executor = mock.MagicMock()
+
+    def raise_error(**kwargs):
+        raise scm.ScmError(
+            "Project Import Error: " '"Failed to checkout first-secret-second"'
+        )
+
+    executor.side_effect = raise_error
+
+    with pytest.raises(scm.ScmError) as exc_info:
+        with tempfile.TemporaryDirectory() as dest_path:
+            scm.ScmRepository.clone(
+                "https://git.example.com/repo.git",
+                dest_path,
+                credential=credential,
+                _executor=executor,
+            )
+    error_msg = str(exc_info.value)
+    assert "first-secret-second" in error_msg
+
+
+@pytest.mark.django_db
+def test_git_clone_sanitizes_decoded_url(
+    default_organization: models.Organization,
+):
+    """URL-decoded credentials are also sanitized (AAP-72813)."""
+    credential = models.EdaCredential.objects.create(
+        name="special-char-cred",
+        inputs={"username": "user", "password": "p@ss"},
+        organization=default_organization,
+    )
+    credential.refresh_from_db()
+    executor = mock.MagicMock()
+
+    def raise_error(**kwargs):
+        raise scm.ScmError(
+            "fatal: Unable to access "
+            "'https://user:p@ss@git.example.com/repo.git'"
+        )
+
+    executor.side_effect = raise_error
+
+    with pytest.raises(scm.ScmError) as exc_info:
+        with tempfile.TemporaryDirectory() as dest_path:
+            scm.ScmRepository.clone(
+                "https://git.example.com/repo.git",
+                dest_path,
+                credential=credential,
+                _executor=executor,
+            )
+    error_msg = str(exc_info.value)
+    assert "p@ss" not in error_msg
+    assert "p%40ss" not in error_msg
+    assert "git.example.com/repo.git" in error_msg
 
 
 def test_git_clone_without_ssl_verification():


### PR DESCRIPTION
## Summary

Fixes [[AAP-72813](https://redhat.atlassian.net/browse/AAP-72813)] — project sync error redaction creates an oracle attack vector.

The previous code did `msg.replace(secret, "****")` on the entire error message. An attacker controlling a git server could craft responses containing candidate strings. When one matches the password, it gets replaced with `****`, revealing the secret.

Example: password `abc123`, branch `first-abc123-second` → error shows `first-****-second`.

## Changes

Replaced secret-based substring matching with URL-based replacement:
- Replace the full credential-embedded URL with the clean URL
- Handle both URL-encoded and decoded password forms for special characters
- Branch names, server responses, and other error content are left untouched

## Test plan

- [x] `test_git_clone_leak_password` — credentials sanitized from URL in error
- [x] `test_git_clone_no_oracle_attack` — secret in branch name NOT redacted (oracle blocked)
- [x] `test_git_clone_sanitizes_decoded_url` — special-char passwords sanitized in both encoded and decoded forms
- [x] All 31 existing scm tests pass (zero regressions)
- [x] Reproduced locally: branch name containing password preserved as-is, credential URL properly sanitized

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential redaction in source-control clone error messages: embedded credentials (including URL-decoded and URL-encoded forms) are fully removed while preserving host/repo details.
* **Tests**
  * Expanded tests to verify redaction behavior, ensure secret-like text outside credential fields remains visible, and confirm sanitization for passwords with special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->