### PR TITLE
fix: remove double restart_count increment on project sync (AAP-72812)

### DIFF
--- a/src/aap_eda/tasks/project.py
+++ b/src/aap_eda/tasks/project.py
@@ -352,16 +352,6 @@ def _restart_activation(activation: models.Activation) -> bool:
             )
         return False
 
-    try:
-        activation.restart_count += 1
-        activation.save(update_fields=["restart_count"])
-    except Exception as e:
-        logger.warning(
-            f"Restart succeeded for '{activation.name}' "
-            f"but failed to update restart_count: {e}",
-            exc_info=True,
-        )
-
     logger.info(f"Auto-restarted activation '{activation.name}'")
     return True
 

--- a/tests/integration/tasks/test_projects.py
+++ b/tests/integration/tasks/test_projects.py
@@ -1737,11 +1737,15 @@ def test_restart_activation_save_error_after_failure(
 
 @pytest.mark.django_db
 @patch("aap_eda.tasks.project.restart_rulebook_process")
-def test_restart_activation_count_save_failure(
+def test_restart_activation_does_not_increment_count(
     mock_restart,
     default_organization,
 ):
-    """Restart count save failure doesn't set ERROR."""
+    """_restart_activation does not increment restart_count (AAP-72812).
+
+    The activation manager handles the count via
+    _increase_restart_count when processing the restart request.
+    """
     project = models.Project.objects.create(
         name="Test Project",
         url="https://github.com/example/repo",
@@ -1754,27 +1758,15 @@ def test_restart_activation_count_save_failure(
         project,
         default_organization,
         rulebook,
-        name="count-fail",
+        name="no-double-count",
+        restart_count=5,
     )
 
-    original_save = activation.save
+    _restart_activation(activation)
 
-    call_count = 0
-
-    def fail_on_second_save(**kwargs):
-        nonlocal call_count
-        call_count += 1
-        if call_count > 1:
-            raise RuntimeError("count save failed")
-        original_save(**kwargs)
-
-    with patch.object(
-        type(activation), "save", side_effect=fail_on_second_save
-    ):
-        _restart_activation(activation)
-
-    # Restart succeeded, count save failed but no ERROR
     mock_restart.assert_called_once()
+    activation.refresh_from_db()
+    assert activation.restart_count == 5
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

Fixes [[AAP-72812](https://redhat.atlassian.net/browse/AAP-72812)] — restart count increments by 2 instead of 1 on each project sync restart.

`restart_count` was incremented in two places during a sync-triggered restart:
1. `_restart_activation()` in `project.py` — immediately after queuing the restart request
2. `ActivationManager._increase_restart_count()` in `activation_manager.py` — when the restart is actually processed via `start(is_restart=True)`

Removed the eager increment from `_restart_activation` since the activation manager already handles it at the correct lifecycle point.

## Test plan

- [x] `test_restart_activation_does_not_increment_count` — verifies `_restart_activation` does not touch `restart_count`
- [x] All 14 existing restart-related tests pass (zero regressions)
- [x] Reproduced locally: reset count to 0, trigger one restart, observed count=2 (before fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automatic activation restart so the stored restart count is preserved and no longer changes unexpectedly during restart.

* **Tests**
  * Updated integration tests to validate that restart count remains stable after a restart operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->