### PR TITLE
fix: api remains reachable when workers are offline

### DIFF
--- a/src/aap_eda/core/views.py
+++ b/src/aap_eda/core/views.py
@@ -12,7 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from ansible_base.lib.constants import STATUS_FAILED, STATUS_GOOD
+from ansible_base.lib.constants import (
+    STATUS_DEGRADED,
+    STATUS_FAILED,
+    STATUS_GOOD,
+)
 from django.db import connection
 from django.db.utils import OperationalError
 from drf_spectacular.utils import OpenApiResponse, extend_schema
@@ -56,16 +60,20 @@ class StatusView(APIView):
         responses={
             status.HTTP_200_OK: OpenApiResponse(
                 StatusResponseSerializer,
+                description="EDA is healthy or degraded (workers down "
+                "but database is available).",
             ),
             status.HTTP_500_INTERNAL_SERVER_ERROR: OpenApiResponse(
                 StatusResponseSerializer,
+                description="EDA is unavailable (database failure).",
             ),
         },
     )
     def get(self, request):
         errors = []
+        db_healthy = self._check_database()
 
-        if not self._check_database():
+        if not db_healthy:
             errors.append("Database connection failed")
 
         if not check_dispatcherd_workers_health():
@@ -74,10 +82,18 @@ class StatusView(APIView):
         if not errors:
             return Response({"status": STATUS_GOOD}, status=status.HTTP_200_OK)
 
+        if db_healthy:
+            # Workers are down but DB is fine. System degraded but not failed
+            resp_status = STATUS_DEGRADED
+            http_status = status.HTTP_200_OK
+        else:
+            resp_status = STATUS_FAILED
+            http_status = status.HTTP_500_INTERNAL_SERVER_ERROR
+
         return Response(
             {
-                "status": STATUS_FAILED,
+                "status": resp_status,
                 "message": "; ".join(errors),
             },
-            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status=http_status,
         )

--- a/tests/integration/core/test_views.py
+++ b/tests/integration/core/test_views.py
@@ -1,7 +1,11 @@
 from unittest.mock import patch
 
 import pytest
-from ansible_base.lib.constants import STATUS_FAILED, STATUS_GOOD
+from ansible_base.lib.constants import (
+    STATUS_DEGRADED,
+    STATUS_FAILED,
+    STATUS_GOOD,
+)
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -59,9 +63,9 @@ def test_status_view_dispatcherd_failure():
         return_value=False,
     ):
         response = client.get(f"{api_url_v1}/status/")
-        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert response.status_code == status.HTTP_200_OK
         assert response.data == {
-            "status": STATUS_FAILED,
+            "status": STATUS_DEGRADED,
             "message": "Dispatcherd workers unavailable",
         }
 


### PR DESCRIPTION
This change reworks the logic of the /status endpoint so that the EDA API will continue to respond when the workers are offline. Currently, if all activation workers or all default workers are offline EDA will report HTTP 500. This presents a problem for upstream proxies such as Gateway, that interpret this to mean that the EDA API is non-functional and therefore removes the node from processing and returns HTTP 503 with 'no healthy upstream' for any EDA requests.

With the change, if the workers are offline then the API will return HTTP 200 and `STATUS_DEGRADED`, so that the upstream proxy will continue to send requests to the EDA node but is aware that its in a degraded state. The API will respond HTTP 500 if the database is unreachable.

https://redhat.atlassian.net/browse/AAP-73535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system health status reporting. The status endpoint now correctly distinguishes between degraded states (when worker services are unavailable but the database remains healthy) and failed states, returning appropriate HTTP status codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->