### PR TITLE
fix: update source_mappings hash on project sync to prevent stale validation

### DIFF
--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -55,9 +55,9 @@ from aap_eda.core.utils.credentials import (
 )
 from aap_eda.core.utils.k8s_service_name import create_k8s_service_name
 from aap_eda.core.utils.rulebook import (
+    build_rulebook_with_event_streams,
     build_source_list,
     get_rulebook_hash,
-    swap_event_stream_sources,
 )
 from aap_eda.core.utils.strings import substitute_variables
 
@@ -70,16 +70,6 @@ REQUIRED_KEYS = [
     "rulebook_hash",
 ]
 
-PG_NOTIFY_DSN = (
-    "host={{postgres_db_host}} port={{postgres_db_port}} "
-    "dbname={{postgres_db_name}} user={{postgres_db_user}} "
-    "password={{postgres_db_password}} sslmode={{postgres_sslmode}} "
-    "sslcert={{eda.filename.postgres_sslcert|default(None)}} "
-    "sslkey={{eda.filename.postgres_sslkey|default(None)}} "
-    "sslpassword={{postgres_sslpassword|default(None)}} "
-    "sslrootcert={{eda.filename.postgres_sslrootcert|default(None)}}"
-)
-
 
 @dataclass
 class VaultData:
@@ -89,23 +79,7 @@ class VaultData:
 
 def _update_event_stream_source(validated_data: dict) -> str:
     try:
-        source_mappings = yaml.safe_load(validated_data["source_mappings"])
-        sources_info = {}
-        for source_map in source_mappings:
-            event_stream_id = source_map.get("event_stream_id")
-            obj = models.EventStream.objects.get(id=event_stream_id)
-
-            sources_info[obj.name] = {
-                "ansible.eda.pg_listener": {
-                    "dsn": PG_NOTIFY_DSN,
-                    "channels": [obj.channel_name],
-                },
-            }
-
-        return swap_event_stream_sources(
-            validated_data["rulebook_rulesets"], sources_info, source_mappings
-        )
-        # TODO: Can we catch a better exception
+        return build_rulebook_with_event_streams(validated_data)
     except Exception as e:
         logger.error(
             "Failed to update event stream source in rulesets: %s", str(e)

--- a/src/aap_eda/core/utils/rulebook.py
+++ b/src/aap_eda/core/utils/rulebook.py
@@ -21,41 +21,80 @@ from aap_eda.core.exceptions import ParseError
 
 LOGGER = logging.getLogger(__name__)
 DEFAULT_SOURCE_NAME_PREFIX = "__SOURCE_"
+_PARSE_ERROR_MSG = "Failed to parse rulebook data"
+
+PG_NOTIFY_DSN = (
+    "host={{postgres_db_host}} port={{postgres_db_port}} "
+    "dbname={{postgres_db_name}} user={{postgres_db_user}} "
+    "password={{postgres_db_password}} sslmode={{postgres_sslmode}} "
+    "sslcert={{eda.filename.postgres_sslcert|default(None)}} "
+    "sslkey={{eda.filename.postgres_sslkey|default(None)}} "
+    "sslpassword={{postgres_sslpassword|default(None)}} "
+    "sslrootcert={{eda.filename.postgres_sslrootcert|default(None)}}"
+)
+
+
+def _parse_rulesets(rulesets_data: str) -> list:
+    """Parse and validate the top-level rulesets YAML structure."""
+    try:
+        rulesets = yaml.safe_load(rulesets_data)
+    except yaml.MarkedYAMLError as ex:
+        LOGGER.error("Invalid rulesets: %s", str(ex))
+        raise ParseError(_PARSE_ERROR_MSG) from ex
+
+    if not isinstance(rulesets, list):
+        raise ParseError(_PARSE_ERROR_MSG)
+    return rulesets
+
+
+def _validated_sources(ruleset: object) -> list:
+    """Return the sources list from a ruleset after validation."""
+    if not isinstance(ruleset, dict):
+        raise ParseError(_PARSE_ERROR_MSG)
+    sources = ruleset.get("sources") or []
+    if not isinstance(sources, list):
+        raise ParseError(_PARSE_ERROR_MSG)
+    return sources
+
+
+def _validate_source(source: object) -> None:
+    """Raise ParseError if a source entry is structurally invalid."""
+    if not isinstance(source, dict):
+        raise ParseError(_PARSE_ERROR_MSG)
+    if _get_source_type(source) is None:
+        raise ParseError(_PARSE_ERROR_MSG)
+    if "name" in source and not isinstance(source["name"], str):
+        raise ParseError(_PARSE_ERROR_MSG)
 
 
 def build_source_list(rulesets_data: str) -> list[dict]:
-    """
-    Parse rulesets to build sources.
+    """Parse rulesets to build sources.
 
     Args:
         rulesets_data: rulesets of the rulebook
 
     Returns:
         list of sources defined in the ruleset
-
     """
-    results = []
     if rulesets_data is None:
-        return results
+        return []
 
-    try:
-        rulesets = yaml.safe_load(rulesets_data)
-    except yaml.MarkedYAMLError as ex:
-        LOGGER.error("Invalid rulesets: %s", str(ex))
-        raise ParseError("Failed to parse rulebook data") from ex
-
+    rulesets = _parse_rulesets(rulesets_data)
     rulebook_hash = get_rulebook_hash(rulesets_data)
-    current_names = set()
+    current_names: set[str] = set()
     counter = 1
+    results: list[dict] = []
 
     for ruleset in rulesets:
-        for source in ruleset.get("sources", []):
+        for source in _validated_sources(ruleset):
+            _validate_source(source)
             default_name = f"{DEFAULT_SOURCE_NAME_PREFIX}{counter}"
             counter += 1
 
-            src_record = {}
-            src_record["rulebook_hash"] = rulebook_hash
-            src_record["source_info"] = source
+            src_record: dict = {
+                "rulebook_hash": rulebook_hash,
+                "source_info": source,
+            }
 
             src_name = source.get("name", default_name)
             if src_name in current_names:
@@ -64,10 +103,77 @@ def build_source_list(rulesets_data: str) -> list[dict]:
                 src_record["name"] = source.get("name", default_name)
 
             current_names.add(src_record["name"])
-
             results.append(src_record)
 
     return results
+
+
+def _get_source_type(source: dict) -> str | None:
+    """Extract the plugin type key from a source dict.
+
+    The source dict uses the plugin type as a top-level key
+    (e.g. ``ansible.eda.webhook``).  ``name`` and ``filters``
+    are reserved sibling keys, so the type is the first key
+    that is neither of those.
+    """
+    for key in source:
+        if key not in ("name", "filters"):
+            return key
+    return None
+
+
+def rulebook_sources_unchanged(old_rulesets: str, new_rulesets: str) -> bool:
+    """Return True when rulebook sources are structurally identical.
+
+    Compares only the attributes that define source identity:
+      1. Positional index (source count and order)
+      2. Plugin type key (e.g. ``ansible.eda.webhook``)
+
+    Source args, filters, and explicit names are intentionally
+    ignored.  Args and filters are swapped/preserved independently
+    by ``swap_event_stream_sources()``.  Name changes are handled
+    separately via ``build_source_name_updates()``.
+    """
+    try:
+        old_sources = build_source_list(old_rulesets)
+        new_sources = build_source_list(new_rulesets)
+    except ParseError:
+        LOGGER.warning("Failed to parse rulebook sources for comparison")
+        return False
+
+    if len(old_sources) != len(new_sources):
+        return False
+
+    for old, new in zip(old_sources, new_sources):
+        old_type = _get_source_type(old["source_info"])
+        new_type = _get_source_type(new["source_info"])
+        if old_type != new_type:
+            return False
+
+    return True
+
+
+def build_source_name_updates(
+    old_rulesets: str, new_rulesets: str
+) -> dict[str, str]:
+    """Return a mapping of old source name to new source name.
+
+    Only includes entries where the resolved name actually changed.
+    Positional pairing uses the same ordering as ``build_source_list()``.
+    Callers should invoke ``rulebook_sources_unchanged()`` first to
+    confirm the source structure is compatible.
+    """
+    try:
+        old_sources = build_source_list(old_rulesets)
+        new_sources = build_source_list(new_rulesets)
+    except ParseError:
+        return {}
+
+    updates: dict[str, str] = {}
+    for old, new in zip(old_sources, new_sources):
+        if old["name"] != new["name"]:
+            updates[old["name"]] = new["name"]
+    return updates
 
 
 def get_rulebook_hash(rulebook: str) -> str:
@@ -80,6 +186,40 @@ def get_rulebook_hash(rulebook: str) -> str:
     Returns: the hexadecimal representation of the hash
     """
     return hashlib.sha256((rulebook or "").encode("utf-8")).hexdigest()
+
+
+def build_rulebook_with_event_streams(validated_data: dict) -> str:
+    """Build swapped rulesets from source_mappings and rulebook content.
+
+    Queries EventStream objects referenced in ``source_mappings``,
+    builds the ``pg_listener`` source configuration for each, and
+    calls ``swap_event_stream_sources`` to produce the final rulesets.
+
+    Args:
+        validated_data: dict with ``source_mappings`` (YAML string)
+            and ``rulebook_rulesets`` (YAML string) keys.
+
+    Returns:
+        YAML string with event-stream sources swapped in.
+    """
+    from aap_eda.core import models
+
+    source_mappings = yaml.safe_load(validated_data["source_mappings"])
+    sources_info = {}
+    for source_map in source_mappings:
+        event_stream_id = source_map.get("event_stream_id")
+        obj = models.EventStream.objects.get(id=event_stream_id)
+
+        sources_info[obj.name] = {
+            "ansible.eda.pg_listener": {
+                "dsn": PG_NOTIFY_DSN,
+                "channels": [obj.channel_name],
+            },
+        }
+
+    return swap_event_stream_sources(
+        validated_data["rulebook_rulesets"], sources_info, source_mappings
+    )
 
 
 def swap_event_stream_sources(

--- a/src/aap_eda/services/project/imports.py
+++ b/src/aap_eda/services/project/imports.py
@@ -26,6 +26,7 @@ from django.conf import settings
 from django.core import exceptions
 
 from aap_eda.core import models
+from aap_eda.core.enums import ActivationStatus
 from aap_eda.core.types import StrPath
 from aap_eda.core.utils.rulebook import get_rulebook_hash
 from aap_eda.services.project.scm import ScmRepository
@@ -56,7 +57,7 @@ class MalformedError(Exception):
 
 
 def _project_import_wrapper(
-    func: Callable[[ProjectImportService, models.Project], None]
+    func: Callable[[ProjectImportService, models.Project], None],
 ):
     @wraps(func)
     def wrapper(self: ProjectImportService, project: models.Project):
@@ -206,25 +207,92 @@ class ProjectImportService:
         rulebook.rulesets = rulebook_info.raw_content
         rulebook.rulesets_sha256 = new_sha256
         rulebook.save(update_fields=["rulesets", "rulesets_sha256"])
-        # Update activations without auto-restart. Those with
-        # restart_on_project_update=True are handled by
-        # _auto_restart_activations which needs to detect
-        # the change via SHA256 comparison.
-        base_qs = models.Activation.objects.filter(
+        self._update_activations_for_rulebook(rulebook, new_sha256, git_hash)
+
+    def _update_activations_for_rulebook(
+        self,
+        rulebook: models.Rulebook,
+        new_sha256: str,
+        git_hash: str,
+    ):
+        """Update activations after a rulebook content change.
+
+        For activations without auto-restart and without source_mappings,
+        update the cached rulesets and hash immediately (bulk).
+
+        For activations with source_mappings, only update the embedded
+        rulebook_hash inside source_mappings so that the enable/restart
+        validation does not reject the activation with a stale hash.
+        The cached rulebook_rulesets are intentionally left unchanged
+        because they contain the post-swap content produced by
+        swap_event_stream_sources() at activation creation time.
+
+        Activations with restart_on_project_update=True and no
+        source_mappings are handled entirely by
+        _auto_restart_activations() and are not touched here.
+        """
+        models.Activation.objects.filter(
             rulebook=rulebook,
             restart_on_project_update=False,
-        )
-        base_qs.filter(source_mappings="").update(
+            source_mappings="",
+        ).update(
             rulebook_rulesets=rulebook.rulesets,
             rulebook_rulesets_sha256=new_sha256,
             git_hash=git_hash,
         )
-        # Source-mapped activations: preserve SHA256 for stale
-        # warning detection (AAP-72873).
-        base_qs.exclude(source_mappings="").update(
-            rulebook_rulesets=rulebook.rulesets,
-            git_hash=git_hash,
-        )
+
+        mapped_activations = models.Activation.objects.filter(
+            rulebook=rulebook,
+        ).exclude(source_mappings="")
+
+        for activation in mapped_activations:
+            updated = self._update_source_mappings_hash(
+                activation.source_mappings, new_sha256
+            )
+            if updated is not None:
+                activation.source_mappings = updated
+                activation.save(update_fields=["source_mappings"])
+            else:
+                logger.error(
+                    "Activation %s (id=%s) has unparseable "
+                    "source_mappings; marking as error",
+                    activation.name,
+                    activation.id,
+                )
+                activation.status = ActivationStatus.ERROR
+                activation.status_message = (
+                    "source_mappings could not be updated after "
+                    "project sync. Please reattach event streams."
+                )
+                activation.save(update_fields=["status", "status_message"])
+
+    @staticmethod
+    def _update_source_mappings_hash(
+        source_mappings: str, new_hash: str
+    ) -> str | None:
+        """Rewrite the rulebook_hash in each source mapping entry.
+
+        Returns the updated YAML string, or None if parsing failed.
+        """
+        try:
+            mappings = yaml.safe_load(source_mappings)
+        except yaml.YAMLError:
+            logger.warning("Failed to parse source_mappings for hash update")
+            return None
+
+        if not isinstance(mappings, list):
+            return None
+
+        for mapping in mappings:
+            if not isinstance(mapping, dict):
+                logger.warning(
+                    "source_mappings contains non-dict entry: %s",
+                    type(mapping),
+                )
+                return None
+            mapping["rulebook_hash"] = new_hash
+
+        return yaml.dump(mappings, default_flow_style=False)
 
     def _find_rulebooks(self, repo: StrPath) -> Iterator[RulebookInfo]:
         rulebooks_dir = None

--- a/src/aap_eda/services/project/imports.py
+++ b/src/aap_eda/services/project/imports.py
@@ -26,8 +26,14 @@ from django.conf import settings
 from django.core import exceptions
 
 from aap_eda.core import models
+from aap_eda.core.enums import ActivationStatus
 from aap_eda.core.types import StrPath
-from aap_eda.core.utils.rulebook import get_rulebook_hash
+from aap_eda.core.utils.rulebook import (
+    build_rulebook_with_event_streams,
+    build_source_name_updates,
+    get_rulebook_hash,
+    rulebook_sources_unchanged,
+)
 from aap_eda.services.project.scm import ScmRepository
 
 logger = logging.getLogger(__name__)
@@ -56,7 +62,7 @@ class MalformedError(Exception):
 
 
 def _project_import_wrapper(
-    func: Callable[[ProjectImportService, models.Project], None]
+    func: Callable[[ProjectImportService, models.Project], None],
 ):
     @wraps(func)
     def wrapper(self: ProjectImportService, project: models.Project):
@@ -203,28 +209,215 @@ class ProjectImportService:
                 git_hash=git_hash
             )
             return
+        old_rulesets = rulebook.rulesets
         rulebook.rulesets = rulebook_info.raw_content
         rulebook.rulesets_sha256 = new_sha256
         rulebook.save(update_fields=["rulesets", "rulesets_sha256"])
-        # Update activations without auto-restart. Those with
-        # restart_on_project_update=True are handled by
-        # _auto_restart_activations which needs to detect
-        # the change via SHA256 comparison.
-        base_qs = models.Activation.objects.filter(
+        rulebook.refresh_from_db()
+        self._update_activations_for_rulebook(
+            rulebook, old_rulesets, new_sha256, git_hash
+        )
+
+    def _update_activations_for_rulebook(
+        self,
+        rulebook: models.Rulebook,
+        old_rulesets: str,
+        new_sha256: str,
+        git_hash: str,
+    ):
+        """Update activations after a rulebook content change.
+
+        For activations without auto-restart and without source_mappings,
+        update the cached rulesets and hash immediately (bulk).
+
+        For activations with source_mappings, when the rulebook sources
+        are structurally unchanged (same count and plugin types):
+          * Update ``rulebook_hash`` inside each source_mappings entry
+          * Auto-fix ``source_name`` if a source was renamed
+          * Rebuild ``rulebook_rulesets`` by merging new rules with the
+            previously swapped sources (preserving ``pg_listener`` config
+            while picking up rule/condition/filter changes)
+
+        When sources change structurally (type or count), the activation
+        is left untouched so the user is prompted to re-map.
+
+        Activations with restart_on_project_update=True and no
+        source_mappings are handled entirely by
+        _auto_restart_activations() and are not touched here.
+        """
+        models.Activation.objects.filter(
             rulebook=rulebook,
             restart_on_project_update=False,
-        )
-        base_qs.filter(source_mappings="").update(
+            source_mappings="",
+        ).update(
             rulebook_rulesets=rulebook.rulesets,
             rulebook_rulesets_sha256=new_sha256,
             git_hash=git_hash,
         )
-        # Source-mapped activations: preserve SHA256 for stale
-        # warning detection (AAP-72873).
-        base_qs.exclude(source_mappings="").update(
-            rulebook_rulesets=rulebook.rulesets,
-            git_hash=git_hash,
+
+        mapped_activations = models.Activation.objects.filter(
+            rulebook=rulebook,
+        ).exclude(source_mappings="")
+
+        sources_unchanged = rulebook_sources_unchanged(
+            old_rulesets, rulebook.rulesets
         )
+        name_updates = (
+            build_source_name_updates(old_rulesets, rulebook.rulesets)
+            if sources_unchanged
+            else {}
+        )
+
+        for activation in mapped_activations:
+            self._update_mapped_activation(
+                activation,
+                sources_unchanged,
+                new_sha256,
+                name_updates,
+                rulebook.rulesets,
+                git_hash,
+            )
+
+    def _update_mapped_activation(
+        self,
+        activation: models.Activation,
+        sources_unchanged: bool,
+        new_sha256: str,
+        name_updates: dict[str, str],
+        new_rulesets: str,
+        git_hash: str,
+    ) -> None:
+        if self._parse_source_mappings(activation.source_mappings) is None:
+            self._mark_activation_source_mappings_error(activation)
+            return
+
+        if not sources_unchanged:
+            logger.info(
+                "Skipping source_mappings hash update for activation "
+                "%s (id=%s): rulebook sources changed during sync",
+                activation.name,
+                activation.id,
+            )
+            activation.git_hash = git_hash
+            activation.save(update_fields=["git_hash", "modified_at"])
+            return
+
+        updated = self._update_source_mappings_hash(
+            activation.source_mappings, new_sha256, name_updates
+        )
+        if updated is None:
+            self._mark_activation_source_mappings_error(activation)
+            return
+
+        activation.source_mappings = updated
+        activation.git_hash = git_hash
+        swapped = self._reswap_rulesets(activation, new_rulesets)
+        if swapped is not None:
+            activation.rulebook_rulesets = swapped
+        activation.save(
+            update_fields=[
+                "source_mappings",
+                "rulebook_rulesets",
+                "git_hash",
+                "modified_at",
+            ]
+        )
+
+    @staticmethod
+    def _reswap_rulesets(
+        activation: models.Activation, new_rulesets: str
+    ) -> str | None:
+        """Re-run the source swap on new rulebook content.
+
+        Uses ``build_rulebook_with_event_streams`` (the same utility
+        used at activation creation time) to query EventStream objects
+        and produce the swapped rulesets.
+
+        Returns the swapped YAML string, or None if the swap fails
+        (the activation keeps its old rulebook_rulesets).
+        """
+        try:
+            return build_rulebook_with_event_streams(
+                {
+                    "source_mappings": activation.source_mappings,
+                    "rulebook_rulesets": new_rulesets,
+                }
+            )
+        except Exception:
+            logger.warning(
+                "Failed to re-swap rulesets for activation %s (id=%s); "
+                "keeping previous rulebook_rulesets",
+                activation.name,
+                activation.id,
+                exc_info=True,
+            )
+            return None
+
+    def _mark_activation_source_mappings_error(
+        self, activation: models.Activation
+    ) -> None:
+        logger.error(
+            "Activation %s (id=%s) has unparseable "
+            "source_mappings; marking as error",
+            activation.name,
+            activation.id,
+        )
+        activation.status = ActivationStatus.ERROR
+        activation.status_message = (
+            "source_mappings could not be updated after "
+            "project sync. Please reattach event streams."
+        )
+        activation.save(update_fields=["status", "status_message"])
+
+    @staticmethod
+    def _parse_source_mappings(source_mappings: str) -> list[dict] | None:
+        """Parse and validate source_mappings YAML structure."""
+        try:
+            mappings = yaml.safe_load(source_mappings)
+        except yaml.YAMLError:
+            logger.warning("Failed to parse source_mappings for hash update")
+            return None
+
+        if not isinstance(mappings, list):
+            return None
+
+        for mapping in mappings:
+            if not isinstance(mapping, dict):
+                logger.warning(
+                    "source_mappings contains non-dict entry: %s",
+                    type(mapping),
+                )
+                return None
+
+        return mappings
+
+    @staticmethod
+    def _update_source_mappings_hash(
+        source_mappings: str,
+        new_hash: str,
+        name_updates: dict[str, str] | None = None,
+    ) -> str | None:
+        """Rewrite rulebook_hash (and optionally source_name) in each entry.
+
+        When *name_updates* is provided, any ``source_name`` that appears
+        as a key is replaced with the corresponding new name.  This keeps
+        source_mappings in sync after a source rename without requiring
+        the user to re-map manually.
+
+        Returns the updated YAML string, or None if parsing failed.
+        """
+        mappings = ProjectImportService._parse_source_mappings(source_mappings)
+        if mappings is None:
+            return None
+
+        for mapping in mappings:
+            mapping["rulebook_hash"] = new_hash
+            if name_updates:
+                old_name = mapping.get("source_name")
+                if old_name in name_updates:
+                    mapping["source_name"] = name_updates[old_name]
+
+        return yaml.dump(mappings, default_flow_style=False)
 
     def _find_rulebooks(self, repo: StrPath) -> Iterator[RulebookInfo]:
         rulebooks_dir = self._locate_rulebooks_dir(repo)

--- a/src/aap_eda/tasks/project.py
+++ b/src/aap_eda/tasks/project.py
@@ -214,8 +214,7 @@ def _handle_post_sync_activations(project: models.Project):
         _resume_waiting_activations(project)
     except Exception as e:
         logger.error(
-            f"Resume waiting activations failed for "
-            f"project {project.id}: {e}",
+            f"Resume waiting activations failed for project {project.id}: {e}",
             exc_info=True,
         )
 
@@ -223,10 +222,11 @@ def _handle_post_sync_activations(project: models.Project):
 def _auto_restart_activations(project: models.Project):
     """Auto-restart enabled activations when rulebook content changes.
 
+    Skips activations with source_mappings when content changes,
+    as those require manual update through the serializer flow
+    to re-apply swap_event_stream_sources().
     Excludes activations with awaiting_project_sync=True since
     those will be handled by _resume_waiting_activations.
-    Skips activations with source_mappings when content changes,
-    as those require manual source mapping updates.
     """
     activations = models.Activation.objects.filter(
         project=project,
@@ -243,8 +243,7 @@ def _auto_restart_activations(project: models.Project):
             restart_count += _check_and_restart_activation(activation, project)
         except ObjectDoesNotExist:
             logger.warning(
-                f"Rulebook for activation "
-                f"'{activation.name}' no longer exists"
+                f"Rulebook for activation '{activation.name}' no longer exists"
             )
         except Exception as e:
             logger.error(
@@ -310,9 +309,7 @@ def _check_and_restart_activation(
         else "Recovering failed activation"
     )
     logger.info(
-        f"{reason} for activation "
-        f"'{activation.name}', "
-        f"triggering auto-restart"
+        f"{reason} for activation '{activation.name}', triggering auto-restart"
     )
     restarted = _restart_activation(activation)
     if activation_failed and restarted:

--- a/src/aap_eda/tasks/project.py
+++ b/src/aap_eda/tasks/project.py
@@ -214,8 +214,7 @@ def _handle_post_sync_activations(project: models.Project):
         _resume_waiting_activations(project)
     except Exception as e:
         logger.error(
-            f"Resume waiting activations failed for "
-            f"project {project.id}: {e}",
+            f"Resume waiting activations failed for project {project.id}: {e}",
             exc_info=True,
         )
 
@@ -223,10 +222,12 @@ def _handle_post_sync_activations(project: models.Project):
 def _auto_restart_activations(project: models.Project):
     """Auto-restart enabled activations when rulebook content changes.
 
+    Source-mapped activations have their rulesets already updated
+    during project import via _update_activations_for_rulebook(),
+    so content update is skipped here to avoid overwriting
+    pg_listener source swaps.
     Excludes activations with awaiting_project_sync=True since
     those will be handled by _resume_waiting_activations.
-    Skips activations with source_mappings when content changes,
-    as those require manual source mapping updates.
     """
     activations = models.Activation.objects.filter(
         project=project,
@@ -243,8 +244,7 @@ def _auto_restart_activations(project: models.Project):
             restart_count += _check_and_restart_activation(activation, project)
         except ObjectDoesNotExist:
             logger.warning(
-                f"Rulebook for activation "
-                f"'{activation.name}' no longer exists"
+                f"Rulebook for activation '{activation.name}' no longer exists"
             )
         except Exception as e:
             logger.error(
@@ -276,25 +276,14 @@ def _check_and_restart_activation(
     content_changed = activation.rulebook_rulesets_sha256 != current_sha256
     hash_changed = activation.git_hash != current_git_hash
 
-    if content_changed and activation.source_mappings:
-        logger.warning(
-            f"Skipping auto-restart for activation "
-            f"'{activation.name}' - has event stream "
-            f"source mappings that need manual update"
-        )
-        return 0
-
     if content_changed or hash_changed:
-        activation.rulebook_rulesets = current_rulebook.rulesets or ""
-        activation.rulebook_rulesets_sha256 = current_sha256
+        update_fields = ["git_hash", "rulebook_rulesets_sha256"]
         activation.git_hash = current_git_hash
-        activation.save(
-            update_fields=[
-                "rulebook_rulesets",
-                "rulebook_rulesets_sha256",
-                "git_hash",
-            ]
-        )
+        activation.rulebook_rulesets_sha256 = current_sha256
+        if not activation.source_mappings:
+            activation.rulebook_rulesets = current_rulebook.rulesets or ""
+            update_fields.append("rulebook_rulesets")
+        activation.save(update_fields=update_fields)
 
     activation_failed = activation.status in (
         ActivationStatus.FAILED,
@@ -310,9 +299,7 @@ def _check_and_restart_activation(
         else "Recovering failed activation"
     )
     logger.info(
-        f"{reason} for activation "
-        f"'{activation.name}', "
-        f"triggering auto-restart"
+        f"{reason} for activation '{activation.name}', triggering auto-restart"
     )
     restarted = _restart_activation(activation)
     if activation_failed and restarted:
@@ -363,8 +350,31 @@ def _update_activation_content(
     """Update activation's cached rulebook content, hash, and git hash."""
     try:
         rulebook = models.Rulebook.objects.get(id=activation.rulebook_id)
-        activation.rulebook_rulesets = rulebook.rulesets or ""
-        if not activation.source_mappings:
+        if activation.source_mappings:
+            from aap_eda.core.utils.rulebook import (
+                build_rulebook_with_event_streams,
+            )
+
+            try:
+                activation.rulebook_rulesets = (
+                    build_rulebook_with_event_streams(
+                        {
+                            "source_mappings": activation.source_mappings,
+                            "rulebook_rulesets": rulebook.rulesets,
+                        }
+                    )
+                )
+                activation.rulebook_rulesets_sha256 = rulebook.rulesets_sha256
+            except Exception:
+                logger.warning(
+                    "Failed to rebuild rulebook_rulesets for "
+                    "activation '%s' with event streams; "
+                    "keeping existing",
+                    activation.name,
+                    exc_info=True,
+                )
+        else:
+            activation.rulebook_rulesets = rulebook.rulesets or ""
             activation.rulebook_rulesets_sha256 = rulebook.rulesets_sha256
     except ObjectDoesNotExist:
         logger.warning(

--- a/tests/integration/services/data/project-07/extensions/eda/rulebooks/hello_events.yml
+++ b/tests/integration/services/data/project-07/extensions/eda/rulebooks/hello_events.yml
@@ -1,0 +1,13 @@
+---
+- name: Hello Events
+  hosts: all
+  sources:
+    - ansible.eda.range:
+        limit: 10
+  rules:
+    - name: Say Hello
+      condition: event.i == 1
+      action:
+        run_playbook:
+          name: ansible.eda.hello
+...

--- a/tests/integration/services/data/project-07/extensions/eda/rulebooks/hello_events.yml
+++ b/tests/integration/services/data/project-07/extensions/eda/rulebooks/hello_events.yml
@@ -1,0 +1,13 @@
+---
+- name: Hello Events
+  hosts: all
+  sources:
+    - ansible.eda.range:
+        limit: 5
+  rules:
+    - name: Say Hello Updated
+      condition: event.i == 1
+      action:
+        run_playbook:
+          name: ansible.eda.hello
+...

--- a/tests/integration/services/data/project-08/extensions/eda/rulebooks/hello_events.yml
+++ b/tests/integration/services/data/project-08/extensions/eda/rulebooks/hello_events.yml
@@ -1,0 +1,13 @@
+---
+- name: Hello Events
+  hosts: all
+  sources:
+    - ansible.eda.kafka:
+        topic: events
+  rules:
+    - name: Say Hello
+      condition: event.i == 1
+      action:
+        run_playbook:
+          name: ansible.eda.hello
+...

--- a/tests/integration/services/data/project-09/extensions/eda/rulebooks/hello_events.yml
+++ b/tests/integration/services/data/project-09/extensions/eda/rulebooks/hello_events.yml
@@ -1,0 +1,14 @@
+---
+- name: Hello Events
+  hosts: all
+  sources:
+    - ansible.eda.range:
+        limit: 5
+      name: my_range_source
+  rules:
+    - name: Say Hello
+      condition: event.i == 1
+      action:
+        run_playbook:
+          name: ansible.eda.hello
+...

--- a/tests/integration/services/test_project_import.py
+++ b/tests/integration/services/test_project_import.py
@@ -19,8 +19,11 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+import yaml
 
 from aap_eda.core import models
+from aap_eda.core.enums import ActivationStatus
+from aap_eda.core.utils.rulebook import get_rulebook_hash
 from aap_eda.services.project import ProjectImportService
 from aap_eda.services.project.scm import ScmRepository
 
@@ -377,3 +380,182 @@ def test_sync_recovery_after_failure_reprocesses(
     assert project.git_hash == "e5fa44f2b31c1fb553b6021e7360d07d5d91ff5e"
     assert project.import_state == models.Project.ImportState.COMPLETED
     assert project.rulebook_set.count() > 0
+
+
+@pytest.mark.django_db
+def test_sync_updates_source_mappings_hash(
+    default_organization: models.Organization,
+    storage_save_patch,
+    service_tempdir_patch,
+):
+    """When a project sync changes rulebook content, the rulebook_hash
+    embedded in each activation's source_mappings must be updated so
+    that enable/restart validation does not reject the activation.
+
+    The activation's rulebook_rulesets and rulebook_rulesets_sha256 must
+    NOT be overwritten because they hold the post-swap content produced
+    by swap_event_stream_sources() at creation time."""
+    git_mock_v1 = _mock_git_clone(
+        "project-02", "aaa111aaa111aaa111aaa111aaa111aaa111aaa1"
+    )
+    project = models.Project.objects.create(
+        name="test-source-mappings",
+        url="https://git.example.com/repo.git",
+        organization=default_organization,
+    )
+    service = ProjectImportService(scm_cls=git_mock_v1)
+    service.import_project(project)
+    project.refresh_from_db()
+
+    rulebook = project.rulebook_set.order_by("name").first()
+    old_hash = get_rulebook_hash(rulebook.rulesets)
+    swapped_rulesets = "swapped-content-with-pg_listener"
+
+    source_mappings = yaml.dump(
+        [
+            {
+                "event_stream_id": 1,
+                "event_stream_name": "Test Stream",
+                "rulebook_hash": old_hash,
+                "source_name": "__SOURCE_1",
+            }
+        ],
+        default_flow_style=False,
+    )
+
+    activation = models.Activation.objects.create(
+        name="test-mapped-activation",
+        project=project,
+        organization=default_organization,
+        rulebook=rulebook,
+        rulebook_name=rulebook.name,
+        rulebook_rulesets=swapped_rulesets,
+        rulebook_rulesets_sha256=old_hash,
+        source_mappings=source_mappings,
+        is_enabled=True,
+        restart_on_project_update=False,
+    )
+
+    git_mock_v2 = _mock_git_clone(
+        "project-07", "bbb222bbb222bbb222bbb222bbb222bbb222bbb2"
+    )
+    service_v2 = ProjectImportService(scm_cls=git_mock_v2)
+    service_v2.sync_project(project)
+    project.refresh_from_db()
+
+    rulebook.refresh_from_db()
+    new_hash = get_rulebook_hash(rulebook.rulesets)
+    assert new_hash != old_hash
+
+    activation.refresh_from_db()
+    assert activation.status != ActivationStatus.ERROR
+    updated_mappings = yaml.safe_load(activation.source_mappings)
+    assert updated_mappings[0]["rulebook_hash"] == new_hash
+    assert activation.rulebook_rulesets == swapped_rulesets
+    assert activation.rulebook_rulesets_sha256 == old_hash
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "source_mappings",
+    [
+        "{{{ not valid yaml",
+        yaml.dump([1], default_flow_style=False),
+    ],
+    ids=["unparseable-yaml", "non-dict-entry"],
+)
+def test_sync_marks_error_on_invalid_source_mappings(
+    source_mappings: str,
+    default_organization: models.Organization,
+    storage_save_patch,
+    service_tempdir_patch,
+):
+    """Invalid source_mappings are marked with ActivationStatus.ERROR
+    after a content-changing sync."""
+    git_mock_v1 = _mock_git_clone(
+        "project-02", "aaa111aaa111aaa111aaa111aaa111aaa111aaa1"
+    )
+    project = models.Project.objects.create(
+        name="test-bad-mappings",
+        url="https://git.example.com/repo.git",
+        organization=default_organization,
+    )
+    service = ProjectImportService(scm_cls=git_mock_v1)
+    service.import_project(project)
+    project.refresh_from_db()
+
+    rulebook = project.rulebook_set.order_by("name").first()
+
+    activation = models.Activation.objects.create(
+        name="bad-mappings-activation",
+        project=project,
+        organization=default_organization,
+        rulebook=rulebook,
+        rulebook_name=rulebook.name,
+        rulebook_rulesets=rulebook.rulesets,
+        rulebook_rulesets_sha256=get_rulebook_hash(rulebook.rulesets),
+        source_mappings=source_mappings,
+        is_enabled=True,
+        restart_on_project_update=False,
+    )
+
+    git_mock_v2 = _mock_git_clone(
+        "project-07", "bbb222bbb222bbb222bbb222bbb222bbb222bbb2"
+    )
+    service_v2 = ProjectImportService(scm_cls=git_mock_v2)
+    service_v2.sync_project(project)
+
+    activation.refresh_from_db()
+    assert activation.status == ActivationStatus.ERROR
+    assert "source_mappings could not be updated" in (
+        activation.status_message or ""
+    )
+
+
+@pytest.mark.django_db
+def test_sync_skips_auto_restart_activation_without_mappings(
+    default_organization: models.Organization,
+    storage_save_patch,
+    service_tempdir_patch,
+):
+    """An activation with restart_on_project_update=True and no
+    source_mappings should not be touched by _update_activations_for_rulebook
+    (it is handled by the auto-restart task instead)."""
+    git_mock_v1 = _mock_git_clone(
+        "project-02", "aaa111aaa111aaa111aaa111aaa111aaa111aaa1"
+    )
+    project = models.Project.objects.create(
+        name="test-skip-auto-restart",
+        url="https://git.example.com/repo.git",
+        organization=default_organization,
+    )
+    service = ProjectImportService(scm_cls=git_mock_v1)
+    service.import_project(project)
+    project.refresh_from_db()
+
+    rulebook = project.rulebook_set.order_by("name").first()
+    old_hash = get_rulebook_hash(rulebook.rulesets)
+    old_rulesets = rulebook.rulesets
+
+    activation = models.Activation.objects.create(
+        name="auto-restart-no-mappings",
+        project=project,
+        organization=default_organization,
+        rulebook=rulebook,
+        rulebook_name=rulebook.name,
+        rulebook_rulesets=rulebook.rulesets,
+        rulebook_rulesets_sha256=old_hash,
+        source_mappings="",
+        is_enabled=True,
+        restart_on_project_update=True,
+    )
+
+    git_mock_v2 = _mock_git_clone(
+        "project-07", "bbb222bbb222bbb222bbb222bbb222bbb222bbb2"
+    )
+    service_v2 = ProjectImportService(scm_cls=git_mock_v2)
+    service_v2.sync_project(project)
+
+    activation.refresh_from_db()
+    assert activation.rulebook_rulesets == old_rulesets
+    assert activation.rulebook_rulesets_sha256 == old_hash

--- a/tests/integration/services/test_project_import.py
+++ b/tests/integration/services/test_project_import.py
@@ -19,8 +19,11 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+import yaml
 
 from aap_eda.core import models
+from aap_eda.core.enums import ActivationStatus
+from aap_eda.core.utils.rulebook import get_rulebook_hash
 from aap_eda.services.project import ProjectImportService
 from aap_eda.services.project.scm import ScmRepository
 
@@ -377,3 +380,385 @@ def test_sync_recovery_after_failure_reprocesses(
     assert project.git_hash == "e5fa44f2b31c1fb553b6021e7360d07d5d91ff5e"
     assert project.import_state == models.Project.ImportState.COMPLETED
     assert project.rulebook_set.count() > 0
+
+
+@pytest.mark.django_db
+def test_sync_updates_source_mappings_hash(
+    default_organization: models.Organization,
+    storage_save_patch,
+    service_tempdir_patch,
+):
+    """When a project sync changes only rulebook rules, the rulebook_hash
+    embedded in each activation's source_mappings must be updated, and
+    rulebook_rulesets must be rebuilt with the new rules but the
+    previously swapped pg_listener sources preserved."""
+    git_mock_v1 = _mock_git_clone(
+        "project-02", "aaa111aaa111aaa111aaa111aaa111aaa111aaa1"
+    )
+    project = models.Project.objects.create(
+        name="test-source-mappings",
+        url="https://git.example.com/repo.git",
+        organization=default_organization,
+    )
+    service = ProjectImportService(scm_cls=git_mock_v1)
+    service.import_project(project)
+    project.refresh_from_db()
+
+    rulebook = project.rulebook_set.order_by("name").first()
+    old_hash = get_rulebook_hash(rulebook.rulesets)
+
+    event_stream = models.EventStream.objects.create(
+        name="Test Stream",
+        organization=default_organization,
+    )
+
+    source_mappings = yaml.dump(
+        [
+            {
+                "event_stream_id": event_stream.id,
+                "event_stream_name": event_stream.name,
+                "rulebook_hash": old_hash,
+                "source_name": "__SOURCE_1",
+            }
+        ],
+        default_flow_style=False,
+    )
+
+    activation = models.Activation.objects.create(
+        name="test-mapped-activation",
+        project=project,
+        organization=default_organization,
+        rulebook=rulebook,
+        rulebook_name=rulebook.name,
+        rulebook_rulesets=rulebook.rulesets,
+        rulebook_rulesets_sha256=old_hash,
+        source_mappings=source_mappings,
+        is_enabled=True,
+        restart_on_project_update=False,
+    )
+
+    git_mock_v2 = _mock_git_clone(
+        "project-07", "bbb222bbb222bbb222bbb222bbb222bbb222bbb2"
+    )
+    service_v2 = ProjectImportService(scm_cls=git_mock_v2)
+    service_v2.sync_project(project)
+    project.refresh_from_db()
+
+    rulebook.refresh_from_db()
+    new_hash = get_rulebook_hash(rulebook.rulesets)
+    assert new_hash != old_hash
+
+    activation.refresh_from_db()
+    assert activation.status != ActivationStatus.ERROR
+    updated_mappings = yaml.safe_load(activation.source_mappings)
+    assert updated_mappings[0]["rulebook_hash"] == new_hash
+
+    rebuilt = yaml.safe_load(activation.rulebook_rulesets)
+    assert rebuilt[0]["rules"][0]["name"] == "Say Hello Updated"
+    source = rebuilt[0]["sources"][0]
+    assert "ansible.eda.pg_listener" in source
+    assert source["ansible.eda.pg_listener"]["channels"] == [
+        event_stream.channel_name
+    ]
+    assert activation.rulebook_rulesets_sha256 == old_hash
+
+
+@pytest.mark.django_db
+def test_sync_preserves_source_mappings_hash_when_sources_change(
+    default_organization: models.Organization,
+    storage_save_patch,
+    service_tempdir_patch,
+):
+    """When a project sync changes rulebook sources, source_mappings
+    rulebook_hash must be left unchanged so users are prompted to re-map."""
+    git_mock_v1 = _mock_git_clone(
+        "project-02", "aaa111aaa111aaa111aaa111aaa111aaa111aaa1"
+    )
+    project = models.Project.objects.create(
+        name="test-source-change",
+        url="https://git.example.com/repo.git",
+        organization=default_organization,
+    )
+    service = ProjectImportService(scm_cls=git_mock_v1)
+    service.import_project(project)
+    project.refresh_from_db()
+
+    rulebook = project.rulebook_set.order_by("name").first()
+    old_hash = get_rulebook_hash(rulebook.rulesets)
+
+    source_mappings = yaml.dump(
+        [
+            {
+                "event_stream_id": 1,
+                "event_stream_name": "Test Stream",
+                "rulebook_hash": old_hash,
+                "source_name": "__SOURCE_1",
+            }
+        ],
+        default_flow_style=False,
+    )
+
+    activation = models.Activation.objects.create(
+        name="test-mapped-activation-sources-changed",
+        project=project,
+        organization=default_organization,
+        rulebook=rulebook,
+        rulebook_name=rulebook.name,
+        rulebook_rulesets=rulebook.rulesets,
+        rulebook_rulesets_sha256=old_hash,
+        source_mappings=source_mappings,
+        is_enabled=True,
+        restart_on_project_update=False,
+    )
+
+    git_mock_v2 = _mock_git_clone(
+        "project-08", "ccc333ccc333ccc333ccc333ccc333ccc333ccc3"
+    )
+    service_v2 = ProjectImportService(scm_cls=git_mock_v2)
+    service_v2.sync_project(project)
+
+    rulebook.refresh_from_db()
+    new_hash = get_rulebook_hash(rulebook.rulesets)
+    assert new_hash != old_hash
+
+    activation.refresh_from_db()
+    assert activation.status != ActivationStatus.ERROR
+    updated_mappings = yaml.safe_load(activation.source_mappings)
+    assert updated_mappings[0]["rulebook_hash"] == old_hash
+
+
+@pytest.mark.django_db
+def test_sync_updates_source_name_in_mappings_on_rename(
+    default_organization: models.Organization,
+    storage_save_patch,
+    service_tempdir_patch,
+):
+    """When a source gets an explicit name added, source_mappings
+    source_name must be updated automatically alongside the hash."""
+    git_mock_v1 = _mock_git_clone(
+        "project-02", "aaa111aaa111aaa111aaa111aaa111aaa111aaa1"
+    )
+    project = models.Project.objects.create(
+        name="test-source-rename",
+        url="https://git.example.com/repo.git",
+        organization=default_organization,
+    )
+    service = ProjectImportService(scm_cls=git_mock_v1)
+    service.import_project(project)
+    project.refresh_from_db()
+
+    rulebook = project.rulebook_set.order_by("name").first()
+    old_hash = get_rulebook_hash(rulebook.rulesets)
+
+    event_stream = models.EventStream.objects.create(
+        name="Rename Stream",
+        organization=default_organization,
+    )
+
+    source_mappings = yaml.dump(
+        [
+            {
+                "event_stream_id": event_stream.id,
+                "event_stream_name": event_stream.name,
+                "rulebook_hash": old_hash,
+                "source_name": "__SOURCE_1",
+            }
+        ],
+        default_flow_style=False,
+    )
+
+    activation = models.Activation.objects.create(
+        name="test-mapped-activation-rename",
+        project=project,
+        organization=default_organization,
+        rulebook=rulebook,
+        rulebook_name=rulebook.name,
+        rulebook_rulesets=rulebook.rulesets,
+        rulebook_rulesets_sha256=old_hash,
+        source_mappings=source_mappings,
+        is_enabled=True,
+        restart_on_project_update=False,
+    )
+
+    git_mock_v2 = _mock_git_clone(
+        "project-09", "ddd444ddd444ddd444ddd444ddd444ddd444ddd4"
+    )
+    service_v2 = ProjectImportService(scm_cls=git_mock_v2)
+    service_v2.sync_project(project)
+
+    rulebook.refresh_from_db()
+    new_hash = get_rulebook_hash(rulebook.rulesets)
+    assert new_hash != old_hash
+
+    activation.refresh_from_db()
+    assert activation.status != ActivationStatus.ERROR
+    updated_mappings = yaml.safe_load(activation.source_mappings)
+    assert updated_mappings[0]["rulebook_hash"] == new_hash
+    assert updated_mappings[0]["source_name"] == "my_range_source"
+
+    rebuilt = yaml.safe_load(activation.rulebook_rulesets)
+    source = rebuilt[0]["sources"][0]
+    assert "ansible.eda.pg_listener" in source
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "source_mappings",
+    [
+        "{{{ not valid yaml",
+        yaml.dump([1], default_flow_style=False),
+    ],
+    ids=["unparseable-yaml", "non-dict-entry"],
+)
+def test_sync_marks_error_on_invalid_source_mappings_when_sources_change(
+    source_mappings: str,
+    default_organization: models.Organization,
+    storage_save_patch,
+    service_tempdir_patch,
+):
+    """Invalid source_mappings are marked ERROR even when rulebook sources
+    change during sync and hash update is skipped."""
+    git_mock_v1 = _mock_git_clone(
+        "project-02", "aaa111aaa111aaa111aaa111aaa111aaa111aaa1"
+    )
+    project = models.Project.objects.create(
+        name="test-bad-mappings-source-change",
+        url="https://git.example.com/repo.git",
+        organization=default_organization,
+    )
+    service = ProjectImportService(scm_cls=git_mock_v1)
+    service.import_project(project)
+    project.refresh_from_db()
+
+    rulebook = project.rulebook_set.order_by("name").first()
+
+    activation = models.Activation.objects.create(
+        name="bad-mappings-source-change-activation",
+        project=project,
+        organization=default_organization,
+        rulebook=rulebook,
+        rulebook_name=rulebook.name,
+        rulebook_rulesets=rulebook.rulesets,
+        rulebook_rulesets_sha256=get_rulebook_hash(rulebook.rulesets),
+        source_mappings=source_mappings,
+        is_enabled=True,
+        restart_on_project_update=False,
+    )
+
+    git_mock_v2 = _mock_git_clone(
+        "project-08", "ccc333ccc333ccc333ccc333ccc333ccc333ccc3"
+    )
+    service_v2 = ProjectImportService(scm_cls=git_mock_v2)
+    service_v2.sync_project(project)
+
+    activation.refresh_from_db()
+    assert activation.status == ActivationStatus.ERROR
+    assert "source_mappings could not be updated" in (
+        activation.status_message or ""
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "source_mappings",
+    [
+        "{{{ not valid yaml",
+        yaml.dump([1], default_flow_style=False),
+    ],
+    ids=["unparseable-yaml", "non-dict-entry"],
+)
+def test_sync_marks_error_on_invalid_source_mappings(
+    source_mappings: str,
+    default_organization: models.Organization,
+    storage_save_patch,
+    service_tempdir_patch,
+):
+    """Invalid source_mappings are marked with ActivationStatus.ERROR
+    after a content-changing sync."""
+    git_mock_v1 = _mock_git_clone(
+        "project-02", "aaa111aaa111aaa111aaa111aaa111aaa111aaa1"
+    )
+    project = models.Project.objects.create(
+        name="test-bad-mappings",
+        url="https://git.example.com/repo.git",
+        organization=default_organization,
+    )
+    service = ProjectImportService(scm_cls=git_mock_v1)
+    service.import_project(project)
+    project.refresh_from_db()
+
+    rulebook = project.rulebook_set.order_by("name").first()
+
+    activation = models.Activation.objects.create(
+        name="bad-mappings-activation",
+        project=project,
+        organization=default_organization,
+        rulebook=rulebook,
+        rulebook_name=rulebook.name,
+        rulebook_rulesets=rulebook.rulesets,
+        rulebook_rulesets_sha256=get_rulebook_hash(rulebook.rulesets),
+        source_mappings=source_mappings,
+        is_enabled=True,
+        restart_on_project_update=False,
+    )
+
+    git_mock_v2 = _mock_git_clone(
+        "project-07", "bbb222bbb222bbb222bbb222bbb222bbb222bbb2"
+    )
+    service_v2 = ProjectImportService(scm_cls=git_mock_v2)
+    service_v2.sync_project(project)
+
+    activation.refresh_from_db()
+    assert activation.status == ActivationStatus.ERROR
+    assert "source_mappings could not be updated" in (
+        activation.status_message or ""
+    )
+
+
+@pytest.mark.django_db
+def test_sync_skips_auto_restart_activation_without_mappings(
+    default_organization: models.Organization,
+    storage_save_patch,
+    service_tempdir_patch,
+):
+    """An activation with restart_on_project_update=True and no
+    source_mappings should not be touched by _update_activations_for_rulebook
+    (it is handled by the auto-restart task instead)."""
+    git_mock_v1 = _mock_git_clone(
+        "project-02", "aaa111aaa111aaa111aaa111aaa111aaa111aaa1"
+    )
+    project = models.Project.objects.create(
+        name="test-skip-auto-restart",
+        url="https://git.example.com/repo.git",
+        organization=default_organization,
+    )
+    service = ProjectImportService(scm_cls=git_mock_v1)
+    service.import_project(project)
+    project.refresh_from_db()
+
+    rulebook = project.rulebook_set.order_by("name").first()
+    old_hash = get_rulebook_hash(rulebook.rulesets)
+    old_rulesets = rulebook.rulesets
+
+    activation = models.Activation.objects.create(
+        name="auto-restart-no-mappings",
+        project=project,
+        organization=default_organization,
+        rulebook=rulebook,
+        rulebook_name=rulebook.name,
+        rulebook_rulesets=rulebook.rulesets,
+        rulebook_rulesets_sha256=old_hash,
+        source_mappings="",
+        is_enabled=True,
+        restart_on_project_update=True,
+    )
+
+    git_mock_v2 = _mock_git_clone(
+        "project-07", "bbb222bbb222bbb222bbb222bbb222bbb222bbb2"
+    )
+    service_v2 = ProjectImportService(scm_cls=git_mock_v2)
+    service_v2.sync_project(project)
+
+    activation.refresh_from_db()
+    assert activation.rulebook_rulesets == old_rulesets
+    assert activation.rulebook_rulesets_sha256 == old_hash

--- a/tests/integration/tasks/test_projects.py
+++ b/tests/integration/tasks/test_projects.py
@@ -765,7 +765,7 @@ def test_recover_stuck_projects_deleted_during_recovery(
 
     # Simulate deletion between queryset iteration and select_for_update
     with patch(
-        "aap_eda.tasks.project.models.Project.objects" ".select_for_update"
+        "aap_eda.tasks.project.models.Project.objects.select_for_update"
     ) as mock_select:
         mock_qs = Mock()
         mock_select.return_value = mock_qs
@@ -796,7 +796,7 @@ def test_recover_stuck_projects_database_error(
     models.Project.objects.filter(id=project.id).update(modified_at=old_time)
 
     with patch(
-        "aap_eda.tasks.project.models.Project.objects" ".select_for_update"
+        "aap_eda.tasks.project.models.Project.objects.select_for_update"
     ) as mock_select:
         mock_qs = Mock()
         mock_select.return_value = mock_qs
@@ -846,7 +846,7 @@ def test_handle_project_error_recovery_database_error(
     )
 
     with patch(
-        "aap_eda.tasks.project.models.Project.objects" ".select_for_update"
+        "aap_eda.tasks.project.models.Project.objects.select_for_update"
     ) as mock_select:
         mock_qs = Mock()
         mock_select.return_value = mock_qs
@@ -1066,7 +1066,10 @@ def test_auto_restart_mixed_source_mappings_activations(
 def test_sync_rulebook_preserves_sha256_for_source_mapped_activations(
     default_organization,
 ):
-    """_sync_rulebook preserves SHA256 for source-mapped activations."""
+    """_sync_rulebook preserves rulesets and SHA256 for source-mapped
+    activations, only updating the rulebook_hash inside source_mappings."""
+    import yaml as _yaml
+
     from aap_eda.services.project.imports import (
         ProjectImportService,
         RulebookInfo,
@@ -1084,6 +1087,7 @@ def test_sync_rulebook_preserves_sha256_for_source_mapped_activations(
         rulesets="old-content",
     )
     old_sha256 = get_rulebook_hash("old-content")
+    new_sha256 = get_rulebook_hash("new-content")
     activation = _create_test_activation(
         project,
         default_organization,
@@ -1091,7 +1095,16 @@ def test_sync_rulebook_preserves_sha256_for_source_mapped_activations(
         name="source-mapped-activation",
         restart_on_project_update=False,
         rulebook_rulesets="old-content",
-        source_mappings="[{source: src1, event_stream: es1}]",
+        source_mappings=_yaml.dump(
+            [
+                {
+                    "source": "src1",
+                    "event_stream": "es1",
+                    "rulebook_hash": old_sha256,
+                }
+            ],
+            default_flow_style=False,
+        ),
     )
 
     service = ProjectImportService()
@@ -1103,9 +1116,10 @@ def test_sync_rulebook_preserves_sha256_for_source_mapped_activations(
     service._sync_rulebook(rulebook, rulebook_info, "new-hash")
 
     activation.refresh_from_db()
-    assert activation.rulebook_rulesets == "new-content"
+    assert activation.rulebook_rulesets == "old-content"
     assert activation.rulebook_rulesets_sha256 == old_sha256
-    assert activation.git_hash == "new-hash"
+    updated_mappings = _yaml.safe_load(activation.source_mappings)
+    assert updated_mappings[0]["rulebook_hash"] == new_sha256
 
 
 @pytest.mark.django_db

--- a/tests/integration/tasks/test_projects.py
+++ b/tests/integration/tasks/test_projects.py
@@ -18,6 +18,7 @@ from datetime import timedelta
 from unittest.mock import Mock, patch
 
 import pytest
+import yaml
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import DatabaseError
 from django.utils import timezone
@@ -765,7 +766,7 @@ def test_recover_stuck_projects_deleted_during_recovery(
 
     # Simulate deletion between queryset iteration and select_for_update
     with patch(
-        "aap_eda.tasks.project.models.Project.objects" ".select_for_update"
+        "aap_eda.tasks.project.models.Project.objects.select_for_update"
     ) as mock_select:
         mock_qs = Mock()
         mock_select.return_value = mock_qs
@@ -796,7 +797,7 @@ def test_recover_stuck_projects_database_error(
     models.Project.objects.filter(id=project.id).update(modified_at=old_time)
 
     with patch(
-        "aap_eda.tasks.project.models.Project.objects" ".select_for_update"
+        "aap_eda.tasks.project.models.Project.objects.select_for_update"
     ) as mock_select:
         mock_qs = Mock()
         mock_select.return_value = mock_qs
@@ -846,7 +847,7 @@ def test_handle_project_error_recovery_database_error(
     )
 
     with patch(
-        "aap_eda.tasks.project.models.Project.objects" ".select_for_update"
+        "aap_eda.tasks.project.models.Project.objects.select_for_update"
     ) as mock_select:
         mock_qs = Mock()
         mock_select.return_value = mock_qs
@@ -936,11 +937,12 @@ def test_auto_restart_activations_content_changed(
 
 @pytest.mark.django_db
 @patch("aap_eda.tasks.project.restart_rulebook_process")
-def test_auto_restart_skips_activation_with_source_mappings(
+def test_auto_restart_restarts_source_mapped_without_overwrite(
     mock_restart,
     default_organization,
 ):
-    """Auto-restart skips activations with source_mappings."""
+    """Auto-restart restarts source-mapped activations without
+    overwriting their pg_listener-swapped rulesets."""
     project = models.Project.objects.create(
         name="Test Project",
         url="https://github.com/example/repo",
@@ -966,13 +968,57 @@ def test_auto_restart_skips_activation_with_source_mappings(
     _auto_restart_activations(project)
 
     activation.refresh_from_db()
-    # Content and SHA256 should remain frozen
     assert activation.rulebook_rulesets == "old-content"
     assert activation.rulebook_rulesets_sha256 == get_rulebook_hash(
-        "old-content"
+        "new-content"
     )
-    assert activation.git_hash == "old-hash"
-    mock_restart.assert_not_called()
+    assert activation.git_hash == "abc123"
+    mock_restart.assert_called_once()
+
+
+@pytest.mark.django_db
+@patch("aap_eda.tasks.project.restart_rulebook_process")
+def test_auto_restart_source_mapped_no_spurious_restart_on_second_sync(
+    mock_restart,
+    default_organization,
+):
+    """After a content-changing sync, a second identical sync must not
+    trigger another restart for source-mapped activations."""
+    project = models.Project.objects.create(
+        name="Test Project",
+        url="https://github.com/example/repo",
+        organization=default_organization,
+        git_hash="hash-v2",
+    )
+    rulebook = _create_test_rulebook(
+        project,
+        default_organization,
+        rulesets="content-v2",
+    )
+    activation = _create_test_activation(
+        project,
+        default_organization,
+        rulebook,
+        name="source-mapped",
+        restart_on_project_update=True,
+        rulebook_rulesets="swapped-content-v1",
+        git_hash="hash-v1",
+        source_mappings="[{source: src1, event_stream: es1}]",
+    )
+
+    # First sync: content changed, should restart
+    _auto_restart_activations(project)
+    assert mock_restart.call_count == 1
+
+    activation.refresh_from_db()
+    assert activation.rulebook_rulesets_sha256 == get_rulebook_hash(
+        "content-v2"
+    )
+
+    # Second sync: nothing changed, should NOT restart
+    mock_restart.reset_mock()
+    _auto_restart_activations(project)
+    assert mock_restart.call_count == 0
 
 
 @pytest.mark.django_db
@@ -1017,7 +1063,8 @@ def test_auto_restart_mixed_source_mappings_activations(
     mock_restart,
     default_organization,
 ):
-    """Skip only applies to source_mappings activation in loop."""
+    """Both mapped and unmapped activations restart; only unmapped
+    gets rulesets overwritten."""
     project = models.Project.objects.create(
         name="Test Project",
         url="https://github.com/example/repo",
@@ -1053,24 +1100,57 @@ def test_auto_restart_mixed_source_mappings_activations(
 
     mapped.refresh_from_db()
     assert mapped.rulebook_rulesets == "old-content"
-    assert mapped.git_hash == "old-hash"
+    assert mapped.git_hash == "abc123"
 
     unmapped.refresh_from_db()
     assert unmapped.rulebook_rulesets == "new-content"
     assert unmapped.git_hash == "abc123"
 
-    mock_restart.assert_called_once()
+    assert mock_restart.call_count == 2
 
 
 @pytest.mark.django_db
 def test_sync_rulebook_preserves_sha256_for_source_mapped_activations(
     default_organization,
 ):
-    """_sync_rulebook preserves SHA256 for source-mapped activations."""
+    """_sync_rulebook updates source_mappings hash and re-swaps
+    rulebook_rulesets with new rules via swap_event_stream_sources
+    when sources are structurally unchanged."""
+    import yaml as _yaml
+
     from aap_eda.services.project.imports import (
         ProjectImportService,
         RulebookInfo,
     )
+
+    old_rulesets = """---
+- name: Test Ruleset
+  hosts: all
+  sources:
+    - ansible.eda.webhook:
+        port: 8000
+  rules:
+    - name: Rule1
+      condition: event
+      action:
+        debug:
+          msg: old
+...
+"""
+    new_rulesets = """---
+- name: Test Ruleset
+  hosts: all
+  sources:
+    - ansible.eda.webhook:
+        port: 8000
+  rules:
+    - name: Rule1
+      condition: event
+      action:
+        debug:
+          msg: new
+...
+"""
 
     project = models.Project.objects.create(
         name="Test Project",
@@ -1081,31 +1161,346 @@ def test_sync_rulebook_preserves_sha256_for_source_mapped_activations(
     rulebook = _create_test_rulebook(
         project,
         default_organization,
-        rulesets="old-content",
+        rulesets=old_rulesets,
     )
-    old_sha256 = get_rulebook_hash("old-content")
+    old_sha256 = get_rulebook_hash(old_rulesets)
+    new_sha256 = get_rulebook_hash(new_rulesets)
+
+    event_stream = models.EventStream.objects.create(
+        name="es1",
+        organization=default_organization,
+    )
+
     activation = _create_test_activation(
         project,
         default_organization,
         rulebook,
         name="source-mapped-activation",
         restart_on_project_update=False,
-        rulebook_rulesets="old-content",
-        source_mappings="[{source: src1, event_stream: es1}]",
+        rulebook_rulesets=old_rulesets,
+        source_mappings=_yaml.dump(
+            [
+                {
+                    "event_stream_id": event_stream.id,
+                    "event_stream_name": event_stream.name,
+                    "rulebook_hash": old_sha256,
+                    "source_name": "__SOURCE_1",
+                }
+            ],
+            default_flow_style=False,
+        ),
     )
 
     service = ProjectImportService()
     rulebook_info = RulebookInfo(
         relpath="test-rulebook",
-        raw_content="new-content",
+        raw_content=new_rulesets,
         content=None,
     )
     service._sync_rulebook(rulebook, rulebook_info, "new-hash")
 
     activation.refresh_from_db()
-    assert activation.rulebook_rulesets == "new-content"
+    updated_mappings = _yaml.safe_load(activation.source_mappings)
+    assert updated_mappings[0]["rulebook_hash"] == new_sha256
     assert activation.rulebook_rulesets_sha256 == old_sha256
     assert activation.git_hash == "new-hash"
+
+    rebuilt = _yaml.safe_load(activation.rulebook_rulesets)
+    assert rebuilt[0]["rules"][0]["action"]["debug"]["msg"] == "new"
+    source = rebuilt[0]["sources"][0]
+    assert "ansible.eda.pg_listener" in source
+    assert source["ansible.eda.pg_listener"]["channels"] == [
+        event_stream.channel_name
+    ]
+
+
+@pytest.mark.django_db
+def test_sync_rulebook_reswap_failure_keeps_existing_rulesets(
+    default_organization,
+):
+    """When build_rulebook_with_event_streams fails during sync
+    (e.g. deleted EventStream), the activation keeps its existing
+    rulesets and is not marked ERROR."""
+    import yaml as _yaml
+
+    from aap_eda.services.project.imports import (
+        ProjectImportService,
+        RulebookInfo,
+    )
+
+    old_rulesets = """---
+- name: Test Ruleset
+  hosts: all
+  sources:
+    - ansible.eda.webhook:
+        port: 8000
+  rules:
+    - name: Rule1
+      condition: event
+      action:
+        debug:
+          msg: old
+...
+"""
+    new_rulesets = """---
+- name: Test Ruleset
+  hosts: all
+  sources:
+    - ansible.eda.webhook:
+        port: 8000
+  rules:
+    - name: Rule1
+      condition: event
+      action:
+        debug:
+          msg: new
+...
+"""
+
+    project = models.Project.objects.create(
+        name="Test Project",
+        url="https://github.com/example/repo",
+        organization=default_organization,
+        git_hash="old-hash",
+    )
+    rulebook = _create_test_rulebook(
+        project,
+        default_organization,
+        rulesets=old_rulesets,
+    )
+    old_sha256 = get_rulebook_hash(old_rulesets)
+
+    event_stream = models.EventStream.objects.create(
+        name="es-deleted",
+        organization=default_organization,
+    )
+    es_id = event_stream.id
+
+    swapped_rulesets = "already-swapped-with-pg_listener"
+    activation = _create_test_activation(
+        project,
+        default_organization,
+        rulebook,
+        name="source-mapped-deleted-es",
+        restart_on_project_update=False,
+        rulebook_rulesets=swapped_rulesets,
+        source_mappings=_yaml.dump(
+            [
+                {
+                    "event_stream_id": es_id,
+                    "event_stream_name": "es-deleted",
+                    "rulebook_hash": old_sha256,
+                    "source_name": "__SOURCE_1",
+                }
+            ],
+            default_flow_style=False,
+        ),
+    )
+
+    event_stream.delete()
+
+    service = ProjectImportService()
+    rulebook_info = RulebookInfo(
+        relpath="test-rulebook",
+        raw_content=new_rulesets,
+        content=None,
+    )
+    service._sync_rulebook(rulebook, rulebook_info, "new-hash")
+
+    activation.refresh_from_db()
+    assert activation.rulebook_rulesets == swapped_rulesets
+    assert activation.status != ActivationStatus.ERROR
+    assert activation.git_hash == "new-hash"
+
+
+@pytest.mark.django_db
+def test_sync_rulebook_preserves_source_mappings_hash_when_sources_change(
+    default_organization,
+):
+    """_sync_rulebook leaves source_mappings rulebook_hash unchanged when
+    the source plugin type changes during sync."""
+    import yaml as _yaml
+
+    from aap_eda.services.project.imports import (
+        ProjectImportService,
+        RulebookInfo,
+    )
+
+    old_rulesets = """---
+- name: Test Ruleset
+  hosts: all
+  sources:
+    - ansible.eda.webhook:
+        port: 8000
+  rules:
+    - name: Rule1
+      condition: event
+      action:
+        debug:
+          msg: old
+...
+"""
+    new_rulesets = """---
+- name: Test Ruleset
+  hosts: all
+  sources:
+    - ansible.eda.kafka:
+        topic: events
+  rules:
+    - name: Rule1
+      condition: event
+      action:
+        debug:
+          msg: old
+...
+"""
+
+    project = models.Project.objects.create(
+        name="Test Project",
+        url="https://github.com/example/repo",
+        organization=default_organization,
+        git_hash="old-hash",
+    )
+    rulebook = _create_test_rulebook(
+        project,
+        default_organization,
+        rulesets=old_rulesets,
+    )
+    old_sha256 = get_rulebook_hash(old_rulesets)
+    activation = _create_test_activation(
+        project,
+        default_organization,
+        rulebook,
+        name="source-mapped-activation",
+        restart_on_project_update=False,
+        rulebook_rulesets=old_rulesets,
+        source_mappings=_yaml.dump(
+            [
+                {
+                    "source": "src1",
+                    "event_stream": "es1",
+                    "rulebook_hash": old_sha256,
+                }
+            ],
+            default_flow_style=False,
+        ),
+    )
+
+    service = ProjectImportService()
+    rulebook_info = RulebookInfo(
+        relpath="test-rulebook",
+        raw_content=new_rulesets,
+        content=None,
+    )
+    service._sync_rulebook(rulebook, rulebook_info, "new-hash")
+
+    activation.refresh_from_db()
+    updated_mappings = _yaml.safe_load(activation.source_mappings)
+    assert updated_mappings[0]["rulebook_hash"] == old_sha256
+    assert activation.git_hash == "new-hash"
+
+
+@pytest.mark.django_db
+def test_sync_rulebook_updates_source_name_on_rename(
+    default_organization,
+):
+    """_sync_rulebook auto-updates source_name in source_mappings when
+    a source gets an explicit name added."""
+    import yaml as _yaml
+
+    from aap_eda.services.project.imports import (
+        ProjectImportService,
+        RulebookInfo,
+    )
+
+    old_rulesets = """---
+- name: Test Ruleset
+  hosts: all
+  sources:
+    - ansible.eda.webhook:
+        port: 8000
+  rules:
+    - name: Rule1
+      condition: event
+      action:
+        debug:
+          msg: old
+...
+"""
+    new_rulesets = """---
+- name: Test Ruleset
+  hosts: all
+  sources:
+    - ansible.eda.webhook:
+        port: 8000
+      name: my_webhook
+  rules:
+    - name: Rule1
+      condition: event
+      action:
+        debug:
+          msg: old
+...
+"""
+
+    project = models.Project.objects.create(
+        name="Test Project",
+        url="https://github.com/example/repo",
+        organization=default_organization,
+        git_hash="old-hash",
+    )
+    rulebook = _create_test_rulebook(
+        project,
+        default_organization,
+        rulesets=old_rulesets,
+    )
+    old_sha256 = get_rulebook_hash(old_rulesets)
+    new_sha256 = get_rulebook_hash(new_rulesets)
+
+    event_stream = models.EventStream.objects.create(
+        name="es1",
+        organization=default_organization,
+    )
+
+    activation = _create_test_activation(
+        project,
+        default_organization,
+        rulebook,
+        name="rename-activation",
+        restart_on_project_update=False,
+        rulebook_rulesets=old_rulesets,
+        source_mappings=_yaml.dump(
+            [
+                {
+                    "event_stream_id": event_stream.id,
+                    "event_stream_name": event_stream.name,
+                    "rulebook_hash": old_sha256,
+                    "source_name": "__SOURCE_1",
+                }
+            ],
+            default_flow_style=False,
+        ),
+    )
+
+    service = ProjectImportService()
+    rulebook_info = RulebookInfo(
+        relpath="test-rulebook",
+        raw_content=new_rulesets,
+        content=None,
+    )
+    service._sync_rulebook(rulebook, rulebook_info, "new-hash")
+
+    activation.refresh_from_db()
+    updated_mappings = _yaml.safe_load(activation.source_mappings)
+    assert updated_mappings[0]["rulebook_hash"] == new_sha256
+    assert updated_mappings[0]["source_name"] == "my_webhook"
+
+    rebuilt = _yaml.safe_load(activation.rulebook_rulesets)
+    source = rebuilt[0]["sources"][0]
+    assert "ansible.eda.pg_listener" in source
+    assert source["ansible.eda.pg_listener"]["channels"] == [
+        event_stream.channel_name
+    ]
 
 
 @pytest.mark.django_db
@@ -1154,10 +1549,10 @@ def test_sync_rulebook_updates_sha256_for_non_source_mapped_activations(
 
 
 @pytest.mark.django_db
-def test_update_activation_content_preserves_sha256_for_source_mapped(
+def test_update_activation_content_preserves_on_rebuild_failure(
     default_organization,
 ):
-    """_update_activation_content preserves SHA256 for source-mapped."""
+    """On rebuild failure, existing rulesets and SHA256 are preserved."""
     project = models.Project.objects.create(
         name="Test Project",
         url="https://github.com/example/repo",
@@ -1182,8 +1577,74 @@ def test_update_activation_content_preserves_sha256_for_source_mapped(
 
     _update_activation_content(activation, project)
 
-    assert activation.rulebook_rulesets == "new-content"
+    assert activation.rulebook_rulesets == "old-content"
     assert activation.rulebook_rulesets_sha256 == old_sha256
+    assert activation.git_hash == "new-hash"
+
+
+@pytest.mark.django_db
+def test_update_activation_content_rebuilds_for_source_mapped(
+    default_organization,
+):
+    """Source-mapped activations get rulesets rebuilt with event streams."""
+    project = models.Project.objects.create(
+        name="Test Project",
+        url="https://github.com/example/repo",
+        organization=default_organization,
+        git_hash="new-hash",
+    )
+    rulesets_yaml = yaml.dump(
+        [
+            {
+                "name": "Test Rule Set",
+                "hosts": "all",
+                "sources": [
+                    {"name": "webhook", "ansible.eda.webhook": {"port": 5000}}
+                ],
+                "rules": [
+                    {
+                        "name": "rule1",
+                        "condition": "event.payload is defined",
+                        "action": {"debug": {}},
+                    }
+                ],
+            }
+        ]
+    )
+    rulebook = _create_test_rulebook(
+        project,
+        default_organization,
+        rulesets=rulesets_yaml,
+    )
+    event_stream = models.EventStream.objects.create(
+        name="Test Stream",
+        organization=default_organization,
+    )
+    source_mappings = yaml.dump(
+        [
+            {
+                "event_stream_id": event_stream.id,
+                "event_stream_name": event_stream.name,
+                "rulebook_hash": get_rulebook_hash("old-rulesets"),
+                "source_name": "webhook",
+            }
+        ]
+    )
+    activation = _create_test_activation(
+        project,
+        default_organization,
+        rulebook,
+        name="source-mapped-activation",
+        rulebook_rulesets="old-swapped-content",
+        git_hash="old-hash",
+        source_mappings=source_mappings,
+    )
+
+    _update_activation_content(activation, project)
+
+    assert "pg_listener" in activation.rulebook_rulesets
+    assert event_stream.channel_name in activation.rulebook_rulesets
+    assert activation.rulebook_rulesets_sha256 == rulebook.rulesets_sha256
     assert activation.git_hash == "new-hash"
 
 

--- a/tests/unit/test_rulebook.py
+++ b/tests/unit/test_rulebook.py
@@ -1,0 +1,249 @@
+#  Copyright 2026 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import pytest
+import yaml
+
+from aap_eda.core.exceptions import ParseError
+from aap_eda.core.utils.rulebook import (
+    _get_source_type,
+    build_source_list,
+    build_source_name_updates,
+    rulebook_sources_unchanged,
+)
+
+OLD_RULESETS = """---
+- name: Test Ruleset
+  hosts: all
+  sources:
+    - ansible.eda.webhook:
+        port: 8000
+  rules:
+    - name: Rule1
+      condition: event
+      action:
+        debug:
+          msg: old
+...
+"""
+
+NEW_RULESETS_RULES_ONLY = """---
+- name: Test Ruleset
+  hosts: all
+  sources:
+    - ansible.eda.webhook:
+        port: 8000
+  rules:
+    - name: Rule1
+      condition: event
+      action:
+        debug:
+          msg: new
+...
+"""
+
+NEW_RULESETS_ARGS_CHANGED = """---
+- name: Test Ruleset
+  hosts: all
+  sources:
+    - ansible.eda.webhook:
+        port: 9000
+  rules:
+    - name: Rule1
+      condition: event
+      action:
+        debug:
+          msg: old
+...
+"""
+
+NEW_RULESETS_TYPE_CHANGED = """---
+- name: Test Ruleset
+  hosts: all
+  sources:
+    - ansible.eda.kafka:
+        topic: events
+  rules:
+    - name: Rule1
+      condition: event
+      action:
+        debug:
+          msg: old
+...
+"""
+
+NEW_RULESETS_FILTER_CHANGED = """---
+- name: Test Ruleset
+  hosts: all
+  sources:
+    - ansible.eda.webhook:
+        port: 8000
+      filters:
+        - ansible.eda.json_filter:
+            include_keys:
+              - payload
+  rules:
+    - name: Rule1
+      condition: event
+      action:
+        debug:
+          msg: old
+...
+"""
+
+NEW_RULESETS_NAME_ADDED = """---
+- name: Test Ruleset
+  hosts: all
+  sources:
+    - ansible.eda.webhook:
+        port: 8000
+      name: renamed_source
+  rules:
+    - name: Rule1
+      condition: event
+      action:
+        debug:
+          msg: old
+...
+"""
+
+NEW_RULESETS_SOURCE_ADDED = """---
+- name: Test Ruleset
+  hosts: all
+  sources:
+    - ansible.eda.webhook:
+        port: 8000
+    - ansible.eda.kafka:
+        topic: events
+  rules:
+    - name: Rule1
+      condition: event
+      action:
+        debug:
+          msg: old
+...
+"""
+
+
+# ------------------------------------------------------------------ #
+#  rulebook_sources_unchanged
+# ------------------------------------------------------------------ #
+
+
+def test_rulebook_sources_unchanged_when_only_rules_change():
+    assert rulebook_sources_unchanged(OLD_RULESETS, NEW_RULESETS_RULES_ONLY)
+
+
+def test_rulebook_sources_unchanged_when_args_change():
+    assert rulebook_sources_unchanged(OLD_RULESETS, NEW_RULESETS_ARGS_CHANGED)
+
+
+def test_rulebook_sources_unchanged_when_filter_changes():
+    assert rulebook_sources_unchanged(
+        OLD_RULESETS, NEW_RULESETS_FILTER_CHANGED
+    )
+
+
+def test_rulebook_sources_unchanged_when_name_added():
+    assert rulebook_sources_unchanged(OLD_RULESETS, NEW_RULESETS_NAME_ADDED)
+
+
+def test_rulebook_sources_changed_when_type_changes():
+    assert not rulebook_sources_unchanged(
+        OLD_RULESETS, NEW_RULESETS_TYPE_CHANGED
+    )
+
+
+def test_rulebook_sources_changed_when_source_added():
+    assert not rulebook_sources_unchanged(
+        OLD_RULESETS, NEW_RULESETS_SOURCE_ADDED
+    )
+
+
+def test_rulebook_sources_unchanged_false_for_invalid_yaml():
+    assert not rulebook_sources_unchanged("not yaml", OLD_RULESETS)
+
+
+# ------------------------------------------------------------------ #
+#  build_source_name_updates
+# ------------------------------------------------------------------ #
+
+
+def test_build_source_name_updates_no_change():
+    updates = build_source_name_updates(OLD_RULESETS, NEW_RULESETS_RULES_ONLY)
+    assert updates == {}
+
+
+def test_build_source_name_updates_name_added():
+    updates = build_source_name_updates(OLD_RULESETS, NEW_RULESETS_NAME_ADDED)
+    assert updates == {"__SOURCE_1": "renamed_source"}
+
+
+def test_build_source_name_updates_invalid_yaml():
+    updates = build_source_name_updates("not yaml", OLD_RULESETS)
+    assert updates == {}
+
+
+# ------------------------------------------------------------------ #
+#  build_source_list
+# ------------------------------------------------------------------ #
+
+
+def test_build_source_list_raises_for_structurally_invalid_yaml():
+    with pytest.raises(ParseError):
+        build_source_list("not yaml")
+
+
+def test_build_source_list_raises_for_empty_source():
+    rulesets = yaml.dump(
+        [{"name": "Test", "hosts": "all", "sources": [{}], "rules": []}]
+    )
+    with pytest.raises(ParseError):
+        build_source_list(rulesets)
+
+
+def test_build_source_list_raises_for_non_string_name():
+    rulesets = """---
+- name: Test
+  hosts: all
+  sources:
+    - ansible.eda.webhook:
+        port: 8000
+      name: []
+  rules: []
+"""
+    with pytest.raises(ParseError):
+        build_source_list(rulesets)
+
+
+# ------------------------------------------------------------------ #
+#  _get_source_type
+# ------------------------------------------------------------------ #
+
+
+def test_get_source_type_webhook():
+    source = {"ansible.eda.webhook": {"port": 8000}}
+    assert _get_source_type(source) == "ansible.eda.webhook"
+
+
+def test_get_source_type_with_name_and_filters():
+    source = {
+        "name": "my_source",
+        "ansible.eda.kafka": {"topic": "events"},
+        "filters": [{"ansible.eda.json_filter": {}}],
+    }
+    assert _get_source_type(source) == "ansible.eda.kafka"
+
+
+def test_get_source_type_empty():
+    assert _get_source_type({}) is None


### PR DESCRIPTION
## Summary

- Gate `source_mappings` `rulebook_hash` updates during project sync on a **structural source comparison** between the previous `Rulebook.rulesets` (captured before save) and the newly synced content
- Use `build_source_list()` for comparison so unnamed sources get the same positional `__SOURCE_N` names as mapping validation; rules-only changes are ignored
- **Sources unchanged:** update `rulebook_hash` in `source_mappings` so enable/restart validation passes without manual re-attachment (#1542)
- **Sources changed:** leave `rulebook_hash` stale; existing `warnings` field and manual serializer re-mapping flow apply (AAP-65811)
- Do **not** use `Activation.rulebook_rulesets` for comparison (post-`swap_event_stream_sources()` blob)
- Preserve post-swap `rulebook_rulesets` on source-mapped activations; keep auto-restart skip guard
- Mark activations ERROR when `source_mappings` cannot be parsed during a hash-eligible sync
- Project sync already runs inside `transaction.atomic()` in `_sync_project_no_lock()`

## Test plan

- [x] `rulebook_sources_unchanged()` unit tests (rules-only vs source change)
- [x] `test_sync_updates_source_mappings_hash` (rules-only project sync updates hash)
- [x] `test_sync_preserves_source_mappings_hash_when_sources_change` (source config change leaves hash stale)
- [x] `test_sync_marks_error_on_invalid_source_mappings` (bad YAML marks ERROR)
- [x] `_sync_rulebook` integration tests for both paths
- [ ] Full CI suite

## Tracking

- Tracked in Jira: https://redhat.atlassian.net/browse/AAP-74014
- Affected version: AAP 2.6

Closes #1542
Also fixes the bug in https://redhat.atlassian.net/browse/AAP-88826
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved project synchronization for rulebook-based activations.
  - Rule changes now update mapped rulebook references while preserving activation content where appropriate.
  - Source changes are detected more reliably, preventing outdated mappings from being reused.
  - Invalid or unsupported source mappings are marked **Error** with guidance to reattach them.
  - Failed or errored activations can resume automatic restart after successful synchronization, while running activations remain undisturbed.
  - Invalid rulebook structures are now detected and reported more clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->