### PR TITLE
feat: add tolerations support for activation job pods

### DIFF
--- a/src/aap_eda/analytics/analytics_collectors.py
+++ b/src/aap_eda/analytics/analytics_collectors.py
@@ -218,6 +218,7 @@ def activations_table(
         "k8s_pod_labels",
         "k8s_pod_annotations",
         "k8s_pod_node_selector",
+        "k8s_pod_tolerations",
         "source_mappings",
         "skip_audit_events",
     )

--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -440,6 +440,7 @@ class ActivationSerializer(serializers.ModelSerializer):
             "k8s_pod_labels",
             "k8s_pod_annotations",
             "k8s_pod_node_selector",
+            "k8s_pod_tolerations",
         ]
         read_only_fields = [
             "id",
@@ -520,6 +521,7 @@ class ActivationListSerializer(
             "k8s_pod_labels",
             "k8s_pod_annotations",
             "k8s_pod_node_selector",
+            "k8s_pod_tolerations",
         ]
         read_only_fields = [
             "id",
@@ -591,6 +593,7 @@ class ActivationListSerializer(
             "enable_persistence": activation.enable_persistence,
             "rule_engine_credential_id": activation.rule_engine_credential_id,
             **_activation_k8s_pod_metadata_payload(activation),
+            "k8s_pod_tolerations": activation.k8s_pod_tolerations,
         }
 
 
@@ -626,6 +629,7 @@ class ActivationCreateSerializer(
             "k8s_pod_labels",
             "k8s_pod_annotations",
             "k8s_pod_node_selector",
+            "k8s_pod_tolerations",
         ]
 
     rulebook_id = serializers.IntegerField(
@@ -673,6 +677,11 @@ class ActivationCreateSerializer(
     rule_engine_credential_id = serializers.IntegerField(
         required=False,
         allow_null=True,
+    )
+    k8s_pod_tolerations = serializers.JSONField(
+        required=False,
+        default=list,
+        validators=[validators.validate_k8s_pod_tolerations],
     )
 
     def validate(self, data):
@@ -748,6 +757,9 @@ class ActivationCopySerializer(serializers.ModelSerializer):
         validators.check_if_k8s_pod_node_selector_valid(
             pod_metadata["k8s_pod_node_selector"]
         )
+        validators.validate_k8s_pod_tolerations(
+            activation.k8s_pod_tolerations or []
+        )
         copied_data = {
             "name": self.validated_data["name"],
             "description": activation.description,
@@ -774,6 +786,7 @@ class ActivationCopySerializer(serializers.ModelSerializer):
             "enable_persistence": activation.enable_persistence,
             "rule_engine_credential_id": activation.rule_engine_credential_id,
             **pod_metadata,
+            "k8s_pod_tolerations": activation.k8s_pod_tolerations,
         }
         if activation.eda_system_vault_credential:
             inputs = yaml.safe_load(
@@ -822,6 +835,7 @@ class ActivationUpdateSerializer(
             "k8s_pod_labels",
             "k8s_pod_annotations",
             "k8s_pod_node_selector",
+            "k8s_pod_tolerations",
         ]
 
     rulebook_id = serializers.IntegerField(
@@ -862,6 +876,11 @@ class ActivationUpdateSerializer(
         required=False,
         allow_null=True,
     )
+    k8s_pod_tolerations = serializers.JSONField(
+        required=False,
+        default=list,
+        validators=[validators.validate_k8s_pod_tolerations],
+    )
 
     def refill_needed_data(
         self, data: dict, activation: models.Activation
@@ -882,6 +901,8 @@ class ActivationUpdateSerializer(
             data["k8s_pod_node_selector"] = (
                 activation.k8s_pod_node_selector or {}
             )
+        if "k8s_pod_tolerations" not in data:
+            data["k8s_pod_tolerations"] = activation.k8s_pod_tolerations or []
         if "extra_var" not in data:
             data["extra_var"] = activation.extra_var
         data["extra_var"] = _get_user_extra_vars(activation, data["extra_var"])
@@ -1017,6 +1038,7 @@ class ActivationUpdateSerializer(
             "skip_audit_events": activation.skip_audit_events,
             "enable_persistence": activation.enable_persistence,
             "rule_engine_credential_id": activation.rule_engine_credential_id,
+            "k8s_pod_tolerations": activation.k8s_pod_tolerations,
         }
 
 
@@ -1151,6 +1173,7 @@ class ActivationReadSerializer(
             "enable_persistence",
             "rule_engine_credential_id",
             "rule_engine_credential",
+            "k8s_pod_tolerations",
         ]
         read_only_fields = [
             "id",
@@ -1294,6 +1317,7 @@ class ActivationReadSerializer(
             "enable_persistence": activation.enable_persistence,
             "rule_engine_credential_id": activation.rule_engine_credential_id,
             "rule_engine_credential": rule_engine_credential,
+            "k8s_pod_tolerations": activation.k8s_pod_tolerations,
         }
 
 
@@ -1337,6 +1361,11 @@ class PostActivationSerializer(
         required=False,
         allow_null=True,
     )
+    k8s_pod_tolerations = serializers.JSONField(
+        required=False,
+        default=list,
+        validators=[validators.validate_k8s_pod_tolerations],
+    )
 
     def validate(self, data):
         _validate_credentials_and_token_and_rulebook(data=data, creating=False)
@@ -1366,6 +1395,7 @@ class PostActivationSerializer(
             "k8s_pod_labels",
             "k8s_pod_annotations",
             "k8s_pod_node_selector",
+            "k8s_pod_tolerations",
             "source_mappings",
             "skip_audit_events",
             "enable_persistence",
@@ -1401,6 +1431,7 @@ def is_activation_valid(activation: models.Activation) -> tuple[bool, str]:
     data["enable_persistence"] = activation.enable_persistence
     data["rule_engine_credential_id"] = activation.rule_engine_credential_id
     data.update(_activation_k8s_pod_metadata_payload(activation))
+    data["k8s_pod_tolerations"] = activation.k8s_pod_tolerations or []
     serializer = PostActivationSerializer(data=data)
 
     valid = serializer.is_valid()

--- a/src/aap_eda/core/migrations/0073_activation_k8s_pod_tolerations.py
+++ b/src/aap_eda/core/migrations/0073_activation_k8s_pod_tolerations.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0072_activation_k8s_pod_metadata"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="activation",
+            name="k8s_pod_tolerations",
+            field=models.JSONField(
+                blank=True,
+                default=list,
+                help_text=(
+                    "Kubernetes tolerations applied to activation job "
+                    "pods so they can be scheduled onto tainted nodes."
+                ),
+            ),
+        ),
+    ]

--- a/src/aap_eda/core/models/activation.py
+++ b/src/aap_eda/core/models/activation.py
@@ -65,8 +65,7 @@ class Activation(
     awaiting_project_sync = models.BooleanField(
         default=False,
         help_text=(
-            "Activation is waiting for project "
-            "sync to complete before launch"
+            "Activation is waiting for project sync to complete before launch"
         ),
     )
     # TODO(alex) Since local activations are no longer supported
@@ -188,6 +187,14 @@ class Activation(
         help_text=(
             "Kubernetes nodeSelector applied to activation job pods "
             "for scheduling onto specific nodes."
+        ),
+    )
+    k8s_pod_tolerations = models.JSONField(
+        default=list,
+        blank=True,
+        help_text=(
+            "Kubernetes tolerations applied to activation job pods "
+            "so they can be scheduled onto tainted nodes."
         ),
     )
     event_streams = models.ManyToManyField(

--- a/src/aap_eda/core/validators.py
+++ b/src/aap_eda/core/validators.py
@@ -654,3 +654,93 @@ def check_if_field_exists(schema: dict, name: str):
         raise serializers.ValidationError(
             f"Field : {name} missing in source credential"
         )
+
+
+_TOLERATION_EFFECTS = frozenset(
+    {"NoSchedule", "PreferNoSchedule", "NoExecute"}
+)
+_TOLERATION_OPERATORS = frozenset({"Exists", "Equal", "Lt", "Gt"})
+
+
+def _validate_single_toleration(idx: int, item: dict) -> None:
+    """Validate a single toleration entry at *idx*."""
+    if not isinstance(item, dict):
+        raise serializers.ValidationError(
+            f"k8s_pod_tolerations[{idx}] must be a JSON object"
+        )
+
+    allowed = {
+        "key",
+        "operator",
+        "value",
+        "effect",
+        "tolerationSeconds",
+    }
+    unknown = set(item.keys()) - allowed
+    if unknown:
+        raise serializers.ValidationError(
+            f"k8s_pod_tolerations[{idx}] has unknown "
+            f"keys: {sorted(unknown)}"
+        )
+
+    key = item.get("key")
+    if key is not None and not isinstance(key, str):
+        raise serializers.ValidationError(
+            f"k8s_pod_tolerations[{idx}].key must be a string"
+        )
+    value = item.get("value")
+    if value is not None and not isinstance(value, str):
+        raise serializers.ValidationError(
+            f"k8s_pod_tolerations[{idx}].value must be a string"
+        )
+
+    operator = item.get("operator", "Equal")
+    if operator not in _TOLERATION_OPERATORS:
+        raise serializers.ValidationError(
+            f"k8s_pod_tolerations[{idx}].operator must be "
+            f"one of {sorted(_TOLERATION_OPERATORS)}"
+        )
+
+    if (key is None or key == "") and operator != "Exists":
+        raise serializers.ValidationError(
+            f"k8s_pod_tolerations[{idx}].operator must be "
+            "'Exists' when key is empty or omitted"
+        )
+
+    effect = item.get("effect")
+    if effect not in (None, "") and effect not in _TOLERATION_EFFECTS:
+        raise serializers.ValidationError(
+            f"k8s_pod_tolerations[{idx}].effect must be "
+            f"one of {sorted(_TOLERATION_EFFECTS)} or omitted"
+        )
+
+    if operator == "Exists" and "value" in item:
+        raise serializers.ValidationError(
+            f"k8s_pod_tolerations[{idx}]: 'value' must not "
+            "be set when operator is 'Exists'"
+        )
+
+    tol_seconds = item.get("tolerationSeconds")
+    if tol_seconds is not None:
+        if not isinstance(tol_seconds, int) or isinstance(tol_seconds, bool):
+            raise serializers.ValidationError(
+                f"k8s_pod_tolerations[{idx}]."
+                "tolerationSeconds must be an integer"
+            )
+        if effect != "NoExecute":
+            raise serializers.ValidationError(
+                f"k8s_pod_tolerations[{idx}]."
+                "tolerationSeconds is only valid "
+                "with effect 'NoExecute'"
+            )
+
+
+def validate_k8s_pod_tolerations(data: list) -> None:
+    """Validate user-supplied Kubernetes tolerations list."""
+    if not isinstance(data, list):
+        raise serializers.ValidationError(
+            "k8s_pod_tolerations must be a JSON array"
+        )
+
+    for idx, item in enumerate(data):
+        _validate_single_toleration(idx, item)

--- a/src/aap_eda/core/validators.py
+++ b/src/aap_eda/core/validators.py
@@ -662,6 +662,24 @@ _TOLERATION_EFFECTS = frozenset(
 _TOLERATION_OPERATORS = frozenset({"Exists", "Equal", "Lt", "Gt"})
 
 
+def _validate_toleration_seconds(idx: int, item: dict, effect: str) -> None:
+    """Validate tolerationSeconds within a single toleration entry."""
+    tol_seconds = item.get("tolerationSeconds")
+    if tol_seconds is None:
+        return
+    if not isinstance(tol_seconds, int) or isinstance(tol_seconds, bool):
+        raise serializers.ValidationError(
+            f"k8s_pod_tolerations[{idx}]."
+            "tolerationSeconds must be an integer"
+        )
+    if effect != "NoExecute":
+        raise serializers.ValidationError(
+            f"k8s_pod_tolerations[{idx}]."
+            "tolerationSeconds is only valid "
+            "with effect 'NoExecute'"
+        )
+
+
 def _validate_single_toleration(idx: int, item: dict) -> None:
     """Validate a single toleration entry at *idx*."""
     if not isinstance(item, dict):
@@ -720,19 +738,7 @@ def _validate_single_toleration(idx: int, item: dict) -> None:
             "be set when operator is 'Exists'"
         )
 
-    tol_seconds = item.get("tolerationSeconds")
-    if tol_seconds is not None:
-        if not isinstance(tol_seconds, int) or isinstance(tol_seconds, bool):
-            raise serializers.ValidationError(
-                f"k8s_pod_tolerations[{idx}]."
-                "tolerationSeconds must be an integer"
-            )
-        if effect != "NoExecute":
-            raise serializers.ValidationError(
-                f"k8s_pod_tolerations[{idx}]."
-                "tolerationSeconds is only valid "
-                "with effect 'NoExecute'"
-            )
+    _validate_toleration_seconds(idx, item, effect)
 
 
 def validate_k8s_pod_tolerations(data: list) -> None:

--- a/src/aap_eda/services/activation/engine/common.py
+++ b/src/aap_eda/services/activation/engine/common.py
@@ -130,6 +130,7 @@ class ContainerRequest(BaseModel):
     k8s_pod_labels: tp.Optional[dict] = None
     k8s_pod_annotations: tp.Optional[dict] = None
     k8s_pod_node_selector: tp.Optional[dict] = None
+    k8s_pod_tolerations: tp.Optional[list[dict]] = None
     log_tracking_id: tp.Optional[str] = None
 
 
@@ -180,6 +181,7 @@ class ContainerableMixin:
             k8s_pod_labels=self.k8s_pod_labels or {},
             k8s_pod_annotations=self.k8s_pod_annotations or {},
             k8s_pod_node_selector=self.k8s_pod_node_selector or {},
+            k8s_pod_tolerations=self.k8s_pod_tolerations or [],
             log_tracking_id=self.log_tracking_id,
             pull_policy=self.decision_environment.pull_policy,
         )

--- a/src/aap_eda/services/activation/engine/kubernetes.py
+++ b/src/aap_eda/services/activation/engine/kubernetes.py
@@ -245,7 +245,8 @@ class Engine(ContainerEngine):
                 if timestamp:
                     log_timestamp = self._set_log_timestamp(timestamp)
                     dt = datetime.fromtimestamp(
-                        int(log_timestamp), timezone.utc  # remove millisecond
+                        int(log_timestamp),
+                        timezone.utc,  # remove millisecond
                     )
                     log_handler.flush()
                     log_handler.set_log_read_at(dt)
@@ -346,6 +347,19 @@ class Engine(ContainerEngine):
         node_selector = request.k8s_pod_node_selector or {}
         if node_selector:
             spec_kwargs["node_selector"] = node_selector
+
+        tolerations = request.k8s_pod_tolerations or []
+        if tolerations:
+            spec_kwargs["tolerations"] = [
+                k8sclient.V1Toleration(
+                    key=t.get("key"),
+                    operator=t.get("operator", "Equal"),
+                    value=t.get("value"),
+                    effect=t.get("effect"),
+                    toleration_seconds=t.get("tolerationSeconds"),
+                )
+                for t in tolerations
+            ]
 
         spec = k8sclient.V1PodSpec(**spec_kwargs)
 

--- a/tests/integration/analytics/test_analytics_collectors.py
+++ b/tests/integration/analytics/test_analytics_collectors.py
@@ -375,6 +375,7 @@ def test_activations_table_collector(default_activation: models.Activation):
                 "k8s_pod_labels",
                 "k8s_pod_annotations",
                 "k8s_pod_node_selector",
+                "k8s_pod_tolerations",
                 "source_mappings",
                 "skip_audit_events",
             ]

--- a/tests/integration/services/activation/engine/test_kubernetes.py
+++ b/tests/integration/services/activation/engine/test_kubernetes.py
@@ -703,3 +703,106 @@ def test_pod_cleanup_exception_handling(
             engine._delete_job(log_handler)
 
         mock_watch.return_value.stop.assert_called_once()
+
+
+@mock.patch("aap_eda.services.activation.engine.kubernetes.watch.Watch")
+@pytest.mark.django_db
+def test_engine_start_applies_k8s_pod_tolerations(
+    mock_watch,
+    init_kubernetes_data,
+    kubernetes_engine,
+    default_organization,
+):
+    engine = kubernetes_engine
+    tolerations = [
+        {
+            "key": "dedicated",
+            "operator": "Equal",
+            "value": "eda",
+            "effect": "NoSchedule",
+        },
+        {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300,
+        },
+    ]
+    request = get_request(
+        init_kubernetes_data,
+        "test-user",
+        default_organization,
+        k8s_pod_tolerations=tolerations,
+    )
+    log_handler = mock.MagicMock(spec=LogHandler)
+
+    mock_watch.return_value.stream.return_value = iter(
+        [
+            {
+                "object": get_pod("Running"),
+                "type": "MODIFIED",
+            }
+        ]
+    )
+
+    with mock.patch.object(engine.client, "batch_api") as batch_api:
+        with mock.patch.object(engine.client, "core_api") as core_api:
+            svc_mock = core_api.list_namespaced_service
+            svc_mock.return_value.items = None
+            engine.start(request, log_handler)
+
+            call_kwargs = batch_api.create_namespaced_job.call_args
+            job_body = call_kwargs.kwargs.get(
+                "body", call_kwargs[1].get("body")
+            )
+            pod_spec = job_body.spec.template.spec
+            assert pod_spec.tolerations is not None
+            assert len(pod_spec.tolerations) == 2
+            assert pod_spec.tolerations[0].key == "dedicated"
+            assert pod_spec.tolerations[0].operator == "Equal"
+            assert pod_spec.tolerations[0].value == "eda"
+            assert pod_spec.tolerations[0].effect == "NoSchedule"
+            assert pod_spec.tolerations[1].key == (
+                "node.kubernetes.io/unreachable"
+            )
+            assert pod_spec.tolerations[1].operator == "Exists"
+            assert pod_spec.tolerations[1].toleration_seconds == 300
+
+
+@mock.patch("aap_eda.services.activation.engine.kubernetes.watch.Watch")
+@pytest.mark.django_db
+def test_engine_start_no_tolerations_by_default(
+    mock_watch,
+    init_kubernetes_data,
+    kubernetes_engine,
+    default_organization,
+):
+    engine = kubernetes_engine
+    request = get_request(
+        init_kubernetes_data,
+        "test-user",
+        default_organization,
+    )
+    log_handler = mock.MagicMock(spec=LogHandler)
+
+    mock_watch.return_value.stream.return_value = iter(
+        [
+            {
+                "object": get_pod("Running"),
+                "type": "MODIFIED",
+            }
+        ]
+    )
+
+    with mock.patch.object(engine.client, "batch_api") as batch_api:
+        with mock.patch.object(engine.client, "core_api") as core_api:
+            svc_mock = core_api.list_namespaced_service
+            svc_mock.return_value.items = None
+            engine.start(request, log_handler)
+
+            call_kwargs = batch_api.create_namespaced_job.call_args
+            job_body = call_kwargs.kwargs.get(
+                "body", call_kwargs[1].get("body")
+            )
+            pod_spec = job_body.spec.template.spec
+            assert pod_spec.tolerations is None

--- a/tests/unit/test_k8s_pod_tolerations.py
+++ b/tests/unit/test_k8s_pod_tolerations.py
@@ -1,0 +1,207 @@
+#  Copyright 2026 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+from rest_framework import serializers
+
+from aap_eda.core.validators import validate_k8s_pod_tolerations
+
+
+class TestValidateK8sPodTolerations:
+    def test_empty_list(self):
+        validate_k8s_pod_tolerations([])
+
+    def test_valid_toleration_equal(self):
+        validate_k8s_pod_tolerations(
+            [
+                {
+                    "key": "dedicated",
+                    "operator": "Equal",
+                    "value": "eda",
+                    "effect": "NoSchedule",
+                }
+            ]
+        )
+
+    def test_valid_toleration_exists(self):
+        validate_k8s_pod_tolerations(
+            [{"key": "dedicated", "operator": "Exists"}]
+        )
+
+    def test_valid_toleration_exists_with_effect(self):
+        validate_k8s_pod_tolerations(
+            [
+                {
+                    "key": "node.kubernetes.io/not-ready",
+                    "operator": "Exists",
+                    "effect": "NoExecute",
+                    "tolerationSeconds": 300,
+                }
+            ]
+        )
+
+    def test_valid_multiple_tolerations(self):
+        validate_k8s_pod_tolerations(
+            [
+                {
+                    "key": "team",
+                    "operator": "Equal",
+                    "value": "platform",
+                    "effect": "NoSchedule",
+                },
+                {
+                    "key": "node.kubernetes.io/unreachable",
+                    "operator": "Exists",
+                    "effect": "NoExecute",
+                    "tolerationSeconds": 60,
+                },
+            ]
+        )
+
+    def test_valid_toleration_lt_operator(self):
+        validate_k8s_pod_tolerations(
+            [
+                {
+                    "key": "node.kubernetes.io/memory-pressure",
+                    "operator": "Lt",
+                    "value": "100",
+                    "effect": "NoSchedule",
+                }
+            ]
+        )
+
+    def test_valid_toleration_gt_operator(self):
+        validate_k8s_pod_tolerations(
+            [
+                {
+                    "key": "node.kubernetes.io/disk-pressure",
+                    "operator": "Gt",
+                    "value": "50",
+                }
+            ]
+        )
+
+    def test_valid_empty_effect(self):
+        validate_k8s_pod_tolerations(
+            [
+                {
+                    "key": "dedicated",
+                    "operator": "Equal",
+                    "value": "eda",
+                    "effect": "",
+                }
+            ]
+        )
+
+    def test_valid_toleration_match_all_taints(self):
+        validate_k8s_pod_tolerations([{"operator": "Exists"}])
+
+    def test_valid_toleration_defaults(self):
+        validate_k8s_pod_tolerations([{"key": "example"}])
+
+    def test_not_a_list(self):
+        with pytest.raises(serializers.ValidationError, match="JSON array"):
+            validate_k8s_pod_tolerations({"key": "val"})
+
+    def test_item_not_a_dict(self):
+        with pytest.raises(serializers.ValidationError, match="JSON object"):
+            validate_k8s_pod_tolerations(["not-a-dict"])
+
+    def test_unknown_keys(self):
+        with pytest.raises(serializers.ValidationError, match="unknown keys"):
+            validate_k8s_pod_tolerations([{"key": "x", "bogus": "y"}])
+
+    def test_invalid_operator(self):
+        with pytest.raises(serializers.ValidationError, match="operator"):
+            validate_k8s_pod_tolerations([{"key": "x", "operator": "In"}])
+
+    def test_invalid_effect(self):
+        with pytest.raises(serializers.ValidationError, match="effect"):
+            validate_k8s_pod_tolerations(
+                [{"key": "x", "effect": "DoNotSchedule"}]
+            )
+
+    def test_exists_with_value_rejected(self):
+        with pytest.raises(
+            serializers.ValidationError, match="must not be set"
+        ):
+            validate_k8s_pod_tolerations(
+                [
+                    {
+                        "key": "x",
+                        "operator": "Exists",
+                        "value": "oops",
+                    }
+                ]
+            )
+
+    def test_toleration_seconds_not_int(self):
+        with pytest.raises(serializers.ValidationError, match="integer"):
+            validate_k8s_pod_tolerations(
+                [
+                    {
+                        "key": "x",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": "300",
+                    }
+                ]
+            )
+
+    def test_toleration_seconds_bool_rejected(self):
+        with pytest.raises(serializers.ValidationError, match="integer"):
+            validate_k8s_pod_tolerations(
+                [
+                    {
+                        "key": "x",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": True,
+                    }
+                ]
+            )
+
+    def test_toleration_seconds_wrong_effect(self):
+        with pytest.raises(serializers.ValidationError, match="NoExecute"):
+            validate_k8s_pod_tolerations(
+                [
+                    {
+                        "key": "x",
+                        "effect": "NoSchedule",
+                        "tolerationSeconds": 60,
+                    }
+                ]
+            )
+
+    def test_key_not_string(self):
+        with pytest.raises(serializers.ValidationError, match="key must be"):
+            validate_k8s_pod_tolerations([{"key": 123}])
+
+    def test_value_not_string(self):
+        with pytest.raises(serializers.ValidationError, match="value must be"):
+            validate_k8s_pod_tolerations(
+                [{"key": "x", "operator": "Equal", "value": 42}]
+            )
+
+    def test_empty_key_requires_exists(self):
+        with pytest.raises(
+            serializers.ValidationError, match="'Exists' when key is empty"
+        ):
+            validate_k8s_pod_tolerations(
+                [{"key": "", "operator": "Equal", "value": "v"}]
+            )
+
+    def test_missing_key_requires_exists(self):
+        with pytest.raises(
+            serializers.ValidationError, match="'Exists' when key is empty"
+        ):
+            validate_k8s_pod_tolerations([{"operator": "Equal", "value": "v"}])


### PR DESCRIPTION
## Summary

- Adds `k8s_pod_tolerations` JSONField to the Activation model so users can schedule activation job pods onto tainted Kubernetes nodes for workload isolation.
- Follows the same pattern as `k8s_pod_node_selector` from PR #1520.

## What changed

- New model field `k8s_pod_tolerations` (migration `0072`).
- `kubernetes.Engine` converts the toleration dicts to `V1Toleration` objects on the pod spec.
- API serializers (create, update, list, read, copy, post-activation validation) and analytics CSV export.
- Validation enforces Kubernetes toleration constraints (operator, effect, tolerationSeconds).
- Unit tests for validation; integration tests for engine behaviour.

## Why

Operators running EDA on shared clusters need activation job pods to tolerate node taints (e.g. dedicated workload nodes, spot instances). Without this, activation jobs cannot be scheduled onto tainted nodes even if the activation worker Deployment has tolerations configured via the EDA CRD.

## How to test

```bash
pytest tests/unit/test_k8s_pod_tolerations.py \
  tests/integration/services/activation/engine/test_kubernetes.py \
  tests/integration/analytics/test_analytics_collectors.py -q
```

## Breaking changes / dependencies

None. Field is optional with an empty list default; existing activations are unaffected.

Builds on #1520.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activations now support Kubernetes pod metadata for activation jobs: service account, labels, annotations, node selector, and tolerations; these fields are accepted on create/update and exposed in reads/exports.
  * Analytics exports include the additional Kubernetes pod metadata columns.

* **Tests**
  * New unit and integration tests for pod metadata validation, normalization, tolerations, and propagation into created jobs.

* **Chores**
  * Database migrations added to persist new pod metadata fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->