### PR TITLE
fix: preserve activation SHA256 for source-mapped activations on project sync (AAP-72873)

### DIFF
--- a/src/aap_eda/services/project/imports.py
+++ b/src/aap_eda/services/project/imports.py
@@ -210,12 +210,19 @@ class ProjectImportService:
         # restart_on_project_update=True are handled by
         # _auto_restart_activations which needs to detect
         # the change via SHA256 comparison.
-        models.Activation.objects.filter(
+        base_qs = models.Activation.objects.filter(
             rulebook=rulebook,
             restart_on_project_update=False,
-        ).update(
+        )
+        base_qs.filter(source_mappings="").update(
             rulebook_rulesets=rulebook.rulesets,
             rulebook_rulesets_sha256=new_sha256,
+            git_hash=git_hash,
+        )
+        # Source-mapped activations: preserve SHA256 for stale
+        # warning detection (AAP-72873).
+        base_qs.exclude(source_mappings="").update(
+            rulebook_rulesets=rulebook.rulesets,
             git_hash=git_hash,
         )
 

--- a/src/aap_eda/tasks/project.py
+++ b/src/aap_eda/tasks/project.py
@@ -364,7 +364,8 @@ def _update_activation_content(
     try:
         rulebook = models.Rulebook.objects.get(id=activation.rulebook_id)
         activation.rulebook_rulesets = rulebook.rulesets or ""
-        activation.rulebook_rulesets_sha256 = rulebook.rulesets_sha256
+        if not activation.source_mappings:
+            activation.rulebook_rulesets_sha256 = rulebook.rulesets_sha256
     except ObjectDoesNotExist:
         logger.warning(
             f"Rulebook for activation "

--- a/tests/integration/tasks/test_projects.py
+++ b/tests/integration/tasks/test_projects.py
@@ -1063,6 +1063,164 @@ def test_auto_restart_mixed_source_mappings_activations(
 
 
 @pytest.mark.django_db
+def test_sync_rulebook_preserves_sha256_for_source_mapped_activations(
+    default_organization,
+):
+    """_sync_rulebook preserves SHA256 for source-mapped activations."""
+    from aap_eda.services.project.imports import (
+        ProjectImportService,
+        RulebookInfo,
+    )
+
+    project = models.Project.objects.create(
+        name="Test Project",
+        url="https://github.com/example/repo",
+        organization=default_organization,
+        git_hash="old-hash",
+    )
+    rulebook = _create_test_rulebook(
+        project,
+        default_organization,
+        rulesets="old-content",
+    )
+    old_sha256 = get_rulebook_hash("old-content")
+    activation = _create_test_activation(
+        project,
+        default_organization,
+        rulebook,
+        name="source-mapped-activation",
+        restart_on_project_update=False,
+        rulebook_rulesets="old-content",
+        source_mappings="[{source: src1, event_stream: es1}]",
+    )
+
+    service = ProjectImportService()
+    rulebook_info = RulebookInfo(
+        relpath="test-rulebook",
+        raw_content="new-content",
+        content=None,
+    )
+    service._sync_rulebook(rulebook, rulebook_info, "new-hash")
+
+    activation.refresh_from_db()
+    assert activation.rulebook_rulesets == "new-content"
+    assert activation.rulebook_rulesets_sha256 == old_sha256
+    assert activation.git_hash == "new-hash"
+
+
+@pytest.mark.django_db
+def test_sync_rulebook_updates_sha256_for_non_source_mapped_activations(
+    default_organization,
+):
+    """_sync_rulebook updates SHA256 normally."""
+    from aap_eda.services.project.imports import (
+        ProjectImportService,
+        RulebookInfo,
+    )
+
+    project = models.Project.objects.create(
+        name="Test Project",
+        url="https://github.com/example/repo",
+        organization=default_organization,
+        git_hash="old-hash",
+    )
+    rulebook = _create_test_rulebook(
+        project,
+        default_organization,
+        rulesets="old-content",
+    )
+    activation = _create_test_activation(
+        project,
+        default_organization,
+        rulebook,
+        name="normal-activation",
+        restart_on_project_update=False,
+        rulebook_rulesets="old-content",
+    )
+
+    service = ProjectImportService()
+    rulebook_info = RulebookInfo(
+        relpath="test-rulebook",
+        raw_content="new-content",
+        content=None,
+    )
+    new_sha256 = get_rulebook_hash("new-content")
+    service._sync_rulebook(rulebook, rulebook_info, "new-hash")
+
+    activation.refresh_from_db()
+    assert activation.rulebook_rulesets == "new-content"
+    assert activation.rulebook_rulesets_sha256 == new_sha256
+    assert activation.git_hash == "new-hash"
+
+
+@pytest.mark.django_db
+def test_update_activation_content_preserves_sha256_for_source_mapped(
+    default_organization,
+):
+    """_update_activation_content preserves SHA256 for source-mapped."""
+    project = models.Project.objects.create(
+        name="Test Project",
+        url="https://github.com/example/repo",
+        organization=default_organization,
+        git_hash="new-hash",
+    )
+    rulebook = _create_test_rulebook(
+        project,
+        default_organization,
+        rulesets="new-content",
+    )
+    old_sha256 = get_rulebook_hash("old-content")
+    activation = _create_test_activation(
+        project,
+        default_organization,
+        rulebook,
+        name="source-mapped-activation",
+        rulebook_rulesets="old-content",
+        git_hash="old-hash",
+        source_mappings="[{source: src1, event_stream: es1}]",
+    )
+
+    _update_activation_content(activation, project)
+
+    assert activation.rulebook_rulesets == "new-content"
+    assert activation.rulebook_rulesets_sha256 == old_sha256
+    assert activation.git_hash == "new-hash"
+
+
+@pytest.mark.django_db
+def test_update_activation_content_updates_sha256_for_non_source_mapped(
+    default_organization,
+):
+    """_update_activation_content updates SHA256 without source mappings."""
+    project = models.Project.objects.create(
+        name="Test Project",
+        url="https://github.com/example/repo",
+        organization=default_organization,
+        git_hash="new-hash",
+    )
+    rulebook = _create_test_rulebook(
+        project,
+        default_organization,
+        rulesets="new-content",
+    )
+    new_sha256 = get_rulebook_hash("new-content")
+    activation = _create_test_activation(
+        project,
+        default_organization,
+        rulebook,
+        name="normal-activation",
+        rulebook_rulesets="old-content",
+        git_hash="old-hash",
+    )
+
+    _update_activation_content(activation, project)
+
+    assert activation.rulebook_rulesets == "new-content"
+    assert activation.rulebook_rulesets_sha256 == new_sha256
+    assert activation.git_hash == "new-hash"
+
+
+@pytest.mark.django_db
 @patch("aap_eda.tasks.project.restart_rulebook_process")
 def test_auto_restart_skips_unchanged_content(
     mock_restart,


### PR DESCRIPTION
## Summary

- `_sync_rulebook()` in `imports.py` bulk-updated all non-auto-restart activations' `rulebook_rulesets_sha256` without excluding source-mapped activations, synchronizing the hashes and preventing the stale warning from firing
- `_update_activation_content()` in `project.py` unconditionally set the activation hash to the rulebook hash for resume-waiting activations, with the same effect
- Both fixes preserve the activation's original SHA256 when `source_mappings` is present, matching the existing guard in `_check_and_restart_activation()` (line 279)

## Root Cause

The warning logic in `ActivationReadSerializer.to_representation()` (activation.py:1077-1089) correctly compares `activation.rulebook_rulesets_sha256` against `rulebook.rulesets_sha256` to detect divergence after a project sync. However, two code paths overwrote the activation's SHA256 to match the new rulebook hash *before* the serializer could detect the difference, making the warning unreachable.

The auto-restart path (`_check_and_restart_activation`) already handled this correctly by skipping source-mapped activations when content changes. This fix applies the same guard to the two missed paths.

## Test plan

- [x] New test: `test_sync_rulebook_preserves_sha256_for_source_mapped_activations`
- [x] New test: `test_sync_rulebook_updates_sha256_for_non_source_mapped_activations`
- [x] New test: `test_update_activation_content_preserves_sha256_for_source_mapped`
- [x] New test: `test_update_activation_content_updates_sha256_for_non_source_mapped`
- [x] All 75 existing tests in `test_projects.py` pass (no regressions)
- [ ] End-to-end: create activation with source mapping, sync project with changed rulebook, verify warning appears in API response

## Related

- **Jira:** [AAP-72873](https://redhat.atlassian.net/browse/AAP-72873)
- **Related:** [AAP-65811](https://redhat.atlassian.net/browse/AAP-65811) — original design for SHA256 staleness detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced rulebook synchronization to properly manage content validation and cache state during activation updates, improving consistency of rulebook data handling across different activation configurations.

* **Tests**
  * Added integration tests covering rulebook synchronization and activation content update behavior to ensure proper cache and content state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->