### PR TITLE
fix: increase wait() timeout for multi-message consumer tests

### DIFF
--- a/tests/integration/wsapi/test_consumer.py
+++ b/tests/integration/wsapi/test_consumer.py
@@ -292,7 +292,7 @@ async def test_handle_actions_multiple_firing(
     )
     await ws_communicator.send_json_to(payload1)
     await ws_communicator.send_json_to(payload2)
-    await ws_communicator.wait()
+    await ws_communicator.wait(timeout=TIMEOUT)
 
     assert (await get_audit_rule_count()) == 2
     assert (await get_audit_action_count()) == 2
@@ -394,7 +394,7 @@ async def test_rule_status_with_multiple_failed_actions(
     )
     await ws_communicator.send_json_to(action1)
     await ws_communicator.send_json_to(action2)
-    await ws_communicator.wait()
+    await ws_communicator.wait(timeout=TIMEOUT)
 
     assert (await get_audit_action_count()) == 2
     assert (await get_audit_rule_count()) == 1
@@ -459,7 +459,7 @@ async def test_handle_heartbeat(
     for payload in payloads:
         await ws_communicator.send_json_to(payload)
 
-    await ws_communicator.wait()
+    await ws_communicator.wait(timeout=TIMEOUT)
 
     updated_rulebook_process = await get_rulebook_process(rulebook_process_id)
     assert (
@@ -517,7 +517,7 @@ async def test_handle_heartbeat_running_status(
     for payload in payloads:
         await ws_communicator.send_json_to(payload)
 
-    await ws_communicator.wait()
+    await ws_communicator.wait(timeout=TIMEOUT)
 
     activation = await monitor_activation(activation)
     assert activation.status == ActivationStatus.RUNNING
@@ -561,7 +561,7 @@ async def test_multiple_rules_for_one_event(
 
     await ws_communicator.send_json_to(action1)
     await ws_communicator.send_json_to(action2)
-    await ws_communicator.wait()
+    await ws_communicator.wait(timeout=TIMEOUT)
 
     assert (await get_audit_action_count()) == 2
     assert (await get_audit_rule_count()) == 2


### PR DESCRIPTION
## Summary
- Tests that send multiple websocket messages before `wait()` can flake under CI load — the default 1-second timeout cancels the consumer task before all messages are processed
- `test_multiple_rules_for_one_event` was observed failing with `assert 1 == 2` because only one of two actions was processed within the 1s window
- Added explicit `timeout=TIMEOUT` (5s) to the 5 multi-message tests only, matching the pattern already used for `receive_json_from(timeout=TIMEOUT)` in the same file
- Single-message tests keep the default timeout for fast failure detection

## Test plan
- [x] `test_multiple_rules_for_one_event` passes locally
- [x] All 33 tests in `test_consumer.py` pass (72s)
- [x] Changed file passes flake8 cleanly
- [x] CI passes on this PR

🤖 Assisted by Claude Opus