### PR TITLE
feat(ci): add e2e test result notifications to PR comments

### DIFF
--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -323,3 +323,118 @@ jobs:
               state: state,
               log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             });
+
+  notify-result-e2e:
+    needs: [check-trigger, api-e2e-tests, api-e2e-multinode-tests]
+    if: >
+      always() &&
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/run-e2e')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      deployments: write
+      statuses: write
+    steps:
+      - name: Set commit status
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const e2e = '${{ needs.api-e2e-tests.result }}';
+            const multinode = '${{ needs.api-e2e-multinode-tests.result }}';
+            const allPassed = e2e === 'success' && multinode === 'success';
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.check-trigger.outputs.pr_sha }}',
+              state: allPassed ? 'success' : 'failure',
+              context: 'e2e-tests',
+              description: allPassed
+                ? 'All e2e tests passed'
+                : 'E2e tests failed',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });
+
+      - name: Update deployment status
+        if: needs.check-trigger.outputs.deployment_id != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const e2e = '${{ needs.api-e2e-tests.result }}';
+            const multinode = '${{ needs.api-e2e-multinode-tests.result }}';
+            const allPassed = e2e === 'success' && multinode === 'success';
+
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: '${{ needs.check-trigger.outputs.deployment_id }}',
+              state: allPassed ? 'success' : 'failure',
+              description: allPassed
+                ? 'All e2e tests have passed'
+                : 'E2E tests failed',
+              log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });
+
+      - name: Post result comment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const triggerResult = '${{ needs.check-trigger.result }}';
+            const e2eResult = '${{ needs.api-e2e-tests.result }}';
+            const multinodeResult = '${{ needs.api-e2e-multinode-tests.result }}';
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const statusIcon = (result) => ({
+              success: ':white_check_mark: Passed',
+              failure: ':x: Failed',
+              skipped: ':warning: Skipped',
+              cancelled: ':no_entry: Cancelled',
+            }[result] || `:question: ${result}`);
+
+            const reasons = [];
+
+            if (triggerResult === 'skipped') {
+              const body = context.payload.comment.body;
+              if (body !== '/run-e2e') {
+                reasons.push(`Comment must be exactly \`/run-e2e\` with no extra characters. Received: \`${JSON.stringify(body)}\``);
+              }
+            }
+
+            if (e2eResult === 'failure') {
+              reasons.push('**API E2E Tests** failed — see [workflow run logs](' + runUrl + ') for details.');
+            }
+            if (e2eResult === 'skipped' && triggerResult === 'success') {
+              reasons.push('**API E2E Tests** were skipped unexpectedly.');
+            }
+
+            if (multinodeResult === 'failure') {
+              reasons.push('**Multinode E2E Tests** failed — see [workflow run logs](' + runUrl + ') for details.');
+            }
+            if (multinodeResult === 'skipped' && triggerResult === 'success') {
+              reasons.push('**Multinode E2E Tests** were skipped unexpectedly.');
+            }
+
+            const allPassed = triggerResult === 'success' && e2eResult === 'success' && multinodeResult === 'success';
+
+            let body = `**E2E Test Results**\n\n`;
+
+            if (!allPassed) {
+              body += `| Trigger Check | ${statusIcon(triggerResult)} |\n`;
+              body += `| API E2E Tests | ${statusIcon(e2eResult)} |\n`;
+              body += `| Multinode E2E Tests | ${statusIcon(multinodeResult)} |\n`;
+
+              if (reasons.length > 0) {
+                body += `\n**Why:**\n\n${reasons.map(r => '- ' + r).join('\n')}\n`;
+              }
+            }
+
+            body += `\n[View workflow run](${runUrl})`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body
+            });


### PR DESCRIPTION
## Summary

- Adds a `notify-result-e2e` job to the `e2e-dispatch.yml` workflow that replies to every `/run-e2e` PR comment with the outcome
- Posts a status table showing the result of each job (trigger check, API e2e tests, multinode e2e tests)
- Includes diagnostic reasons when jobs are skipped (e.g., trailing whitespace in comment body) or fail (links to workflow run logs)
- Uses `startsWith` on the comment body so near-miss triggers (e.g., `/run-e2e\r`) still get feedback

## Test plan

- [ ] Comment `/run-e2e` on a PR and verify the result comment is posted after all jobs complete
- [ ] Verify skipped scenario: comment `/run-e2e ` (with trailing space) and confirm the reply explains the body mismatch
- [ ] Verify failure scenario: intentionally break a test and confirm the reply shows the failed job with a link to logs
- [ ] Verify the existing `check-trigger`, `api-e2e-tests`, and `api-e2e-multinode-tests` jobs are unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced end-to-end testing workflow with improved result reporting.
  * Automated status comments are posted to pull requests after E2E runs.
  * Commit status checks display aggregated E2E outcomes (success/failure).
  * Deployment status updates automatically based on combined test results.
  * Result comments include a status table, diagnostic "Why" details when issues occur, and a link to the workflow run.
  * E2E runs can be triggered from PR comments using a run command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->