### PR TITLE
fix: adjust renovate config for tekton pipeline updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
-  "tekton": {
-    "automerge": true
-  }
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Update aap-ci tekton-catalog pipeline bundles",
+      "matchPackageNames": ["/^quay\\.io\\/aap-ci\\/tekton-catalog\\/pipeline\\//"],
+      "matchManagers": ["tekton"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
# Summary
This PR modifies the mintmaker renovate configuration file to explicitly set package rules for tekton. To bump specific image bundles in e2e pipeline runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration structure to use schema-based package rules for dependency automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->