### PR TITLE
fix: context-aware activation worker health check

### DIFF
--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import logging
+from typing import Optional
 
 from ansible_base.rbac.api.related import check_related_permissions
 from ansible_base.rbac.models import RoleDefinition
@@ -249,7 +250,10 @@ class ActivationViewSet(
         # Check if activation workers are available before deleting
         # (unless force is true)
         if not force_delete:
-            check_dispatcherd_workers_health(raise_exceptions=True)
+            queue_name = self._get_activation_queue_name(activation)
+            check_dispatcherd_workers_health(
+                raise_exceptions=True, queue_name=queue_name
+            )
 
         with transaction.atomic():
             activation.status = ActivationStatus.DELETING
@@ -394,6 +398,15 @@ class ActivationViewSet(
         activation = self.get_object()
         return self._start(request, activation)
 
+    def _get_activation_queue_name(
+        self, activation: models.Activation
+    ) -> Optional[str]:
+        """Resolve the queue name for an activation's latest instance."""
+        latest = activation.latest_instance
+        if latest and hasattr(latest, "rulebookprocessqueue"):
+            return latest.rulebookprocessqueue.queue_name
+        return None
+
     def _start(self, request, activation: models.Activation) -> Response:
         if activation.is_enabled:
             return Response(status=status.HTTP_204_NO_CONTENT)
@@ -422,7 +435,10 @@ class ActivationViewSet(
             )
 
         # Check if activation workers are available before enabling
-        check_dispatcherd_workers_health(raise_exceptions=True)
+        queue_name = self._get_activation_queue_name(activation)
+        check_dispatcherd_workers_health(
+            raise_exceptions=True, queue_name=queue_name
+        )
 
         sync_response = self._sync_project_if_needed(activation)
         if sync_response:
@@ -509,7 +525,10 @@ class ActivationViewSet(
             # Check if activation workers are available before disabling
             # (unless force=true to allow operation with unhealthy workers)
             if not force_disable:
-                check_dispatcherd_workers_health(raise_exceptions=True)
+                queue_name = self._get_activation_queue_name(activation)
+                check_dispatcherd_workers_health(
+                    raise_exceptions=True, queue_name=queue_name
+                )
             if activation.status in [
                 ActivationStatus.STARTING,
                 ActivationStatus.RUNNING,
@@ -582,7 +601,10 @@ class ActivationViewSet(
         # Check if activation workers are available before restarting
         # (unless force is true)
         if not force_restart:
-            check_dispatcherd_workers_health(raise_exceptions=True)
+            queue_name = self._get_activation_queue_name(activation)
+            check_dispatcherd_workers_health(
+                raise_exceptions=True, queue_name=queue_name
+            )
 
         valid, error = is_activation_valid(activation)
         if not valid:

--- a/src/aap_eda/core/health.py
+++ b/src/aap_eda/core/health.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import logging
+from typing import Optional
 
 from django.conf import settings
 
@@ -23,19 +24,26 @@ from aap_eda.tasks.project import check_default_worker_health
 logger = logging.getLogger(__name__)
 
 
-def check_activation_worker_health() -> bool:
+def check_activation_worker_health(
+    queue_name: Optional[str] = None,
+) -> bool:
     """Check activation worker health (rulebook queues only).
+
+    Args:
+        queue_name: If provided, check only this specific queue.
+                    If None, check all configured queues and return
+                    True if any is healthy.
 
     Returns:
         bool: True if activation workers are healthy, False otherwise.
     """
     try:
-        # Check activation workers (sample one rulebook queue)
+        if queue_name is not None:
+            return check_rulebook_queue_health(queue_name)
+
         rulebook_queues = getattr(settings, "RULEBOOK_WORKER_QUEUES", [])
         if rulebook_queues:
-            # Check first configured rulebook queue as
-            # representative sample
-            return check_rulebook_queue_health(rulebook_queues[0])
+            return any(check_rulebook_queue_health(q) for q in rulebook_queues)
 
         # If no rulebook queues configured, activation workers are considered
         # healthy
@@ -48,12 +56,18 @@ def check_activation_worker_health() -> bool:
         return False
 
 
-def check_dispatcherd_workers_health(raise_exceptions=False) -> bool:
+def check_dispatcherd_workers_health(
+    raise_exceptions=False,
+    queue_name: Optional[str] = None,
+) -> bool:
     """Check dispatcherd worker health for both default and activation workers.
 
     Args:
         raise_exceptions: If True, raises WorkerUnavailable with
                          specific worker_type. If False, returns boolean.
+        queue_name: If provided, check only this specific activation queue.
+                    If None, check all configured queues (healthy if any
+                    is up).
 
     Returns:
         bool: True if both worker types are healthy, False otherwise.
@@ -71,7 +85,7 @@ def check_dispatcherd_workers_health(raise_exceptions=False) -> bool:
             return False
 
         # Check activation workers
-        if not check_activation_worker_health():
+        if not check_activation_worker_health(queue_name=queue_name):
             if raise_exceptions:
                 raise api_exc.WorkerUnavailable(worker_type="activation")
             return False

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -604,6 +604,44 @@ def test_restart_activation(
 
 
 @pytest.mark.django_db
+@patch(
+    "aap_eda.api.views.activation.check_dispatcherd_workers_health",
+    return_value=True,
+)
+def test_restart_activation_passes_queue_name(
+    mock_health_check,
+    default_activation: models.Activation,
+    default_organization: models.Organization,
+    admin_client: APIClient,
+    preseed_credential_types,
+):
+    """Test that restart resolves the activation's queue and passes it
+    to check_dispatcherd_workers_health."""
+    instance = models.RulebookProcess.objects.create(
+        name="test-instance",
+        activation=default_activation,
+        git_hash="abc123",
+        status=enums.ActivationStatus.COMPLETED,
+        organization=default_organization,
+    )
+    models.RulebookProcessQueue.objects.create(
+        process=instance,
+        queue_name="node-2",
+    )
+    default_activation.latest_instance = instance
+    default_activation.save(update_fields=["latest_instance"])
+
+    response = admin_client.post(
+        f"{api_url_v1}/activations/{default_activation.id}/restart/"
+    )
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    mock_health_check.assert_called_with(
+        raise_exceptions=True, queue_name="node-2"
+    )
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     ("force_restart", "expected_response"),
     [

--- a/tests/integration/core/test_health.py
+++ b/tests/integration/core/test_health.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 
 import pytest
 
+from aap_eda.api import exceptions as api_exc
 from aap_eda.core.health import check_dispatcherd_workers_health
 
 
@@ -70,19 +71,19 @@ def test_check_dispatcherd_workers_health_no_rulebook_queues():
 @pytest.mark.django_db
 def test_check_dispatcherd_workers_health_multiple_queues():
     """Test check_dispatcherd_workers_health with multiple rulebook queues
-    (checks first)."""
+    checks all queues when no queue_name is specified."""
     with patch(
         "aap_eda.core.health.check_default_worker_health", return_value=True
     ), patch(
         "aap_eda.core.health.check_rulebook_queue_health", return_value=True
     ) as mock_check_queue, patch(
         "aap_eda.core.health.settings.RULEBOOK_WORKER_QUEUES",
-        ["activation", "secondary", "tertiary"],
+        ["primary", "secondary", "tertiary"],
     ):
         result = check_dispatcherd_workers_health()
         assert result is True
-        # Verify only first queue was checked
-        mock_check_queue.assert_called_once_with("activation")
+        # With any(), it short-circuits on the first True
+        mock_check_queue.assert_called_once_with("primary")
 
 
 @pytest.mark.django_db
@@ -132,3 +133,54 @@ def test_check_dispatcherd_workers_health_settings_exception():
         side_effect=AttributeError("Settings not available"),
     ):
         assert check_dispatcherd_workers_health() is False
+
+
+@pytest.mark.django_db
+def test_check_dispatcherd_workers_health_specific_queue():
+    """Test check_dispatcherd_workers_health checks only the specified queue
+    when queue_name is provided."""
+    with patch(
+        "aap_eda.core.health.check_default_worker_health", return_value=True
+    ), patch(
+        "aap_eda.core.health.check_rulebook_queue_health", return_value=True
+    ) as mock_check_queue:
+        result = check_dispatcherd_workers_health(queue_name="secondary")
+        assert result is True
+        mock_check_queue.assert_called_once_with("secondary")
+
+
+@pytest.mark.django_db
+def test_check_dispatcherd_workers_health_any_queue_healthy():
+    """Test that when no queue_name is given and multiple queues exist,
+    health check returns True if any queue is healthy."""
+
+    def only_tertiary_healthy(queue):
+        return queue == "tertiary"
+
+    with patch(
+        "aap_eda.core.health.check_default_worker_health", return_value=True
+    ), patch(
+        "aap_eda.core.health.check_rulebook_queue_health",
+        side_effect=only_tertiary_healthy,
+    ), patch(
+        "aap_eda.core.health.settings.RULEBOOK_WORKER_QUEUES",
+        ["primary", "secondary", "tertiary"],
+    ):
+        result = check_dispatcherd_workers_health()
+        assert result is True
+
+
+@pytest.mark.django_db
+def test_check_dispatcherd_workers_health_specific_queue_raises():
+    """Test that when raise_exceptions=True and the specified queue is
+    unhealthy, WorkerUnavailable is raised with worker_type='activation'."""
+    with patch(
+        "aap_eda.core.health.check_default_worker_health", return_value=True
+    ), patch(
+        "aap_eda.core.health.check_rulebook_queue_health", return_value=False
+    ):
+        with pytest.raises(api_exc.WorkerUnavailable) as exc_info:
+            check_dispatcherd_workers_health(
+                raise_exceptions=True, queue_name="secondary"
+            )
+        assert "Activation" in str(exc_info.value.detail)


### PR DESCRIPTION
Health checks now target the activation's own queue instead of always sampling the first configured queue, preventing false 503s in multi-node podman deployments when an unrelated node is unhealthy.

https://redhat.atlassian.net/browse/AAP-75092

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Worker health checks are now queue-scoped; activation operations (delete/enable/disable/restart) use the activation’s resolved queue so health is evaluated per queue rather than globally, improving reliability in multi-queue setups.

* **Tests**
  * Added integration tests covering queue-scoped health checks, any-queue healthy short-circuiting, and error raising for unhealthy specified queues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->