### PR TITLE
chore: Update github actions to use OIDC for codecov. Assisted-by: Claude

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -77,7 +77,7 @@ runs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       with:
-        env_vars: OS,PYTHON
+        use_oidc: true
         fail_ci_if_error: false
         files: ./coverage.xml
         flags: "unit-int-tests-${{ inputs.python-version }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,9 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    # Required for OIDC: https://github.com/codecov/codecov-action?tab=readme-ov-file#using-oidc
+    permissions:
+      id-token: write
     strategy:
       matrix:
         python-version:


### PR DESCRIPTION
EDA-Server is already connected to codecov. So here I changed around some configuration to use the recommended OIDC method of connecting. It is simpler to maintain as less configuration is required and github itself handles all provisioning. Alongside this we are removing unused env parameters. 

Note: As part of this change, flag analytics was enabled in codecov

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security of the CI/CD infrastructure by implementing OIDC-based authentication for code coverage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->