### PR TITLE
chore: only enable tekton manager to support pipeline bundle updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": ["tekton"],
   "packageRules": [
     {
       "description": "Update aap-ci tekton-catalog pipeline bundles",


### PR DESCRIPTION
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
<!-- If applicable, provide a link to the issue that is being addressed -->

<!-- What is being changed? -->
<!-- Why is this change needed? -->
<!-- How does this change address the issue? -->
<!-- Does this change introduce any new dependencies, blockers or breaking changes? -->
<!-- How it can be tested? -->
This PR modifies the renovate configuration to only enable tekton package manager. Enabling initial support only to auto bump tekton pipeline bundles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to explicitly enable Tekton manager support for automated dependency processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->