### PR TITLE
chore: remove spurious '/' in tekton regexp

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "packageRules": [
     {
       "description": "Update aap-ci tekton-catalog pipeline bundles",
-      "matchPackageNames": ["/^quay\\.io\\/aap-ci\\/tekton-catalog\\/pipeline\\//"],
+      "matchPackageNames": ["/^quay\\.io\\/aap-ci\\/tekton-catalog\\/pipeline\\/"],
       "matchManagers": ["tekton"],
       "automerge": true
     }


### PR DESCRIPTION
This should hopefully fix the matching of the references in the tekton configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to correct pattern matching for tekton pipeline packages, narrowing targeting to the intended packages while preserving existing rule behaviors (manager scope and auto-merge remain unchanged). This is a configuration-only change that reduces incorrect matches and improves update accuracy and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->