### PR TITLE
fix: restore prior activation create and enable behaviour

### DIFF
--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -99,13 +99,6 @@ class ActivationViewSet(
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        # Check if activation workers are available for enabled activations
-        is_enabled = serializer.validated_data.get(
-            "is_enabled", models.activation.DEFAULT_ENABLED
-        )
-        if is_enabled:
-            check_dispatcherd_workers_health(raise_exceptions=True)
-
         with transaction.atomic():
             response = serializer.create(serializer.validated_data)
             check_related_permissions(
@@ -433,12 +426,6 @@ class ActivationViewSet(
             return Response(
                 {"errors": error}, status=status.HTTP_400_BAD_REQUEST
             )
-
-        # Check if activation workers are available before enabling
-        queue_name = self._get_activation_queue_name(activation)
-        check_dispatcherd_workers_health(
-            raise_exceptions=True, queue_name=queue_name
-        )
 
         sync_response = self._sync_project_if_needed(activation)
         if sync_response:


### PR DESCRIPTION
When we switched from redis to dispatcherd we added worker healthchecks to the activation create() and enable() endpoints. The result is that when all activation workers are offline, these actions will fail with a HTTP 503, which is a change in behaviour compared to previous versions running with redis. This change removes the healthchecks from these two actions in order to restore the previous behaviour.

Assisted-by: Claude

https://redhat.atlassian.net/browse/AAP-78450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed pre-flight worker availability checks from activation creation and enable workflows, so activations proceed directly to project sync and start steps when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->