### PR TITLE
fix: redact event stream headers in test mode

### DIFF
--- a/src/aap_eda/api/views/external_event_stream.py
+++ b/src/aap_eda/api/views/external_event_stream.py
@@ -230,7 +230,11 @@ class ExternalEventStreamViewSet(viewsets.GenericViewSet):
             if self.event_stream.test_mode:
                 self._update_test_data(
                     error_message=err,
-                    headers=yaml.dump(dict(request.headers)),
+                    headers=yaml.dump(
+                        self._redacted_headers(
+                            request.headers, inputs["http_header_key"]
+                        )
+                    ),
                 )
             raise
 


### PR DESCRIPTION
Ensure headers in event streams are redacted when test mode is enabled.

https://redhat.atlassian.net/browse/AAP-76116

Assisted-by: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated header handling for external event stream responses in test mode to apply the configured redaction logic instead of including raw headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->