### PR TITLE
feat(rbac): list RBAC endpoints in API root for shared-resource mode

### DIFF
--- a/src/aap_eda/api/views/root.py
+++ b/src/aap_eda/api/views/root.py
@@ -24,6 +24,15 @@ from rest_framework.views import APIView
 
 LOGGER = logging.getLogger(__name__)
 
+# Exposed regardless of ALLOW_LOCAL_RESOURCE_MANAGEMENT
+# for API parity with Controller (AAP-58905).
+ALWAYS_VISIBLE_ENDPOINTS = {
+    "roledefinition-list",
+    "roleuserassignment-list",
+    "roleteamassignment-list",
+    "role-metadata",
+}
+
 
 @extend_schema(exclude=True)
 class ApiRootView(APIView):
@@ -65,8 +74,11 @@ def get_api_v1_urls(request=None):
         return url_list
 
     if settings.ALLOW_LOCAL_RESOURCE_MANAGEMENT:
-        urls = urls.v1_urls
-    else:
-        urls = urls.eda_v1_urls
+        return list_urls(urls.v1_urls)
 
-    return list_urls(urls)
+    url_list = list_urls(urls.eda_v1_urls)
+    all_urls = list_urls(urls.dab_urls)
+    for name, url in all_urls.items():
+        if name in ALWAYS_VISIBLE_ENDPOINTS:
+            url_list[name] = url
+    return url_list

--- a/tests/integration/api/test_root.py
+++ b/tests/integration/api/test_root.py
@@ -46,6 +46,10 @@ from tests.integration.constants import api_url_v1
                 "/teams/",
                 "/event-streams/",
                 "/credential-input-sources/",
+                "/role_definitions/",
+                "/role_user_assignments/",
+                "/role_team_assignments/",
+                "/role_metadata/",
             ],
             True,
             id="with_shared_resource",
@@ -115,7 +119,7 @@ def test_v1_root(admin_client, request, expected_slugs, use_shared_resource):
     for slug in expected_slugs:
         assert any(
             slug in url for url in response.data.values()
-        ), f"Expected slug {slug} not found in response"
+        ), f"Expected slug {slug} not found in response"  # noqa: E713
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

- Add `ALWAYS_VISIBLE_ENDPOINTS` allowlist in `root.py` so `role_definitions`, `role_team_assignments`, `role_user_assignments`, and `role_metadata` appear in the API root regardless of `ALLOW_LOCAL_RESOURCE_MANAGEMENT`
- Update `test_root.py` to expect RBAC endpoints in both shared-resource and local-resource modes

## Problem

The EDA RBAC endpoints are fully functional in production (shared-resource) mode — GET, POST, and DELETE all work by direct URL and sync bidirectionally with Gateway in real time. However, they are not listed in the API root or discoverable to API consumers when `ALLOW_LOCAL_RESOURCE_MANAGEMENT=False`.

Controller (`/api/controller/v2/`) always lists these endpoints with no gating. This ticket asks for parity.

## What This Does NOT Change

- No changes to `ALLOW_LOCAL_RESOURCE_MANAGEMENT` flag behavior
- No changes to URL registration (`urls.py` untouched)
- No changes to `SharedResourceViewMixin` — user/team/org CRUD remains blocked in shared-resource mode
- No changes to views, serializers, or permissions

## Test plan

- [x] `GET /api/eda/v1/` returns `role_definitions`, `role_team_assignments`, `role_user_assignments`, `role_metadata` in shared-resource mode (verified on AAP 2.7 instance — 28 endpoints, all 4 RBAC present)
- [x] `POST /api/eda/v1/role_team_assignments/` still works (201, syncs to Gateway)
- [x] `DELETE /api/eda/v1/role_team_assignments/{id}/` still works (204, syncs to Gateway)
- [x] `POST /api/eda/v1/users/` still blocked (403 "platform ingress")
- [x] `POST /api/eda/v1/teams/` still blocked (403 "platform ingress")
- [x] `POST /api/eda/v1/organizations/` still blocked (403 "platform ingress")
- [x] Controller endpoints unaffected
- [x] Standalone EDA (`ALLOW_LOCAL_RESOURCE_MANAGEMENT=True`) unaffected — all 43 endpoints visible

Closes: https://redhat.atlassian.net/browse/AAP-79307

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured selected role-related API endpoints remain included in v1 URL output even when local resource management is disabled.
  * Improved v1 endpoint URL assembly to preserve always-visible endpoints across different configuration modes.

* **Tests**
  * Updated integration test expectations to reflect the additional role-related endpoint slugs when shared resources are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->