### PR TITLE
Fixes a test that will fail after the rbac cursor work is merged.

### DIFF
--- a/tests/integration/dab_rbac/test_role_permissions.py
+++ b/tests/integration/dab_rbac/test_role_permissions.py
@@ -41,7 +41,7 @@ def test_view_assignments_non_admin(
     url = reverse("roleuserassignment-list")
     r = user_client.get(url)
     assert r.status_code == 200
-    assert r.data["count"] == 1
+    assert len(r.data["results"]) == 1
     response_obj = r.data["results"][0]
     assert response_obj["id"] == assignment.id
     assert response_obj["summary_fields"]["content_object"] == {


### PR DESCRIPTION
This test will begin to fail once [this pr](https://github.com/ansible/django-ansible-base/pull/1025) on the dab repo is merged. So this pr is meant to head that off.  The DAB pr probably should merge first, and then this 1 should merge.
AAP-68017

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test assertion to validate paginated API response by verifying returned results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->