### PR TITLE
adds the default rule engine credential to the credentials list response

### DIFF
--- a/src/aap_eda/api/views/eda_credential.py
+++ b/src/aap_eda/api/views/eda_credential.py
@@ -17,6 +17,7 @@ import logging
 from ansible_base.rbac.api.related import check_related_permissions
 from ansible_base.rbac.models import RoleDefinition
 from django.db import transaction
+from django.db.models import Q
 from django.forms import model_to_dict
 from django_filters import rest_framework as defaultfilters
 from drf_spectacular.utils import (
@@ -33,7 +34,7 @@ from aap_eda.analytics.utils import get_analytics_interval_if_exist
 from aap_eda.api import exceptions, exceptions as api_exc, filters, serializers
 from aap_eda.api.serializers.eda_credential import get_references
 from aap_eda.core import models
-from aap_eda.core.enums import Action
+from aap_eda.core.enums import Action, DefaultCredentialType
 from aap_eda.core.utils.credential_plugins import run_plugin
 from aap_eda.core.utils.credentials import (
     build_copy_post_data,
@@ -156,7 +157,10 @@ class EdaCredentialViewSet(
         },
     )
     def list(self, request):
-        credentials = self.get_queryset().exclude(managed=True)
+        credentials = self.get_queryset().exclude(
+            Q(managed=True)
+            & ~Q(credential_type__name=DefaultCredentialType.EDA_RULE_ENGINE)
+        )
         credentials = self.filter_queryset(credentials)
 
         serializer = serializers.EdaCredentialSerializer(
@@ -180,6 +184,11 @@ class EdaCredentialViewSet(
     )
     def partial_update(self, request, pk):
         eda_credential = self.get_object()
+        if eda_credential.managed:
+            error = "Managed EDA credential cannot be updated"
+            return Response(
+                {"errors": error}, status=status.HTTP_400_BAD_REQUEST
+            )
         data = request.data
         data["inputs"] = inputs_to_store_dict(
             data.get("inputs", {}), eda_credential.inputs

--- a/tests/integration/api/test_eda_credential.py
+++ b/tests/integration/api/test_eda_credential.py
@@ -464,6 +464,48 @@ def test_list_eda_credentials(
 
 
 @pytest.mark.django_db
+def test_list_eda_credentials_includes_managed_rule_engine(
+    admin_client: APIClient,
+    default_organization: models.Organization,
+    preseed_credential_types,
+):
+    """Managed rule engine credentials should be visible in the list."""
+    rule_engine_type = models.CredentialType.objects.get(
+        name=enums.DefaultCredentialType.EDA_RULE_ENGINE
+    )
+    managed_rule_engine = models.EdaCredential.objects.create(
+        name="_DEFAULT_EDA_RULE_ENGINE_CREDS",
+        description="Default Rule Engine Credential",
+        credential_type=rule_engine_type,
+        inputs=inputs_to_store(
+            {"postgres_db_host": "localhost", "postgres_db_port": "5432"}
+        ),
+        organization=default_organization,
+        managed=True,
+    )
+    # Also create a non-rule-engine managed credential that should be hidden
+    registry_type = models.CredentialType.objects.get(
+        name=enums.DefaultCredentialType.REGISTRY
+    )
+    models.EdaCredential.objects.create(
+        name="_MANAGED_REGISTRY_CRED",
+        description="Managed Registry Credential",
+        credential_type=registry_type,
+        inputs=inputs_to_store({"username": "user", "password": "pass"}),
+        organization=default_organization,
+        managed=True,
+    )
+
+    response = admin_client.get(f"{api_url_v1}/eda-credentials/")
+    assert response.status_code == status.HTTP_200_OK
+    result_names = [r["name"] for r in response.data["results"]]
+    # Managed rule engine credential should be visible
+    assert managed_rule_engine.name in result_names
+    # Other managed credentials should remain hidden
+    assert "_MANAGED_REGISTRY_CRED" not in result_names
+
+
+@pytest.mark.django_db
 def test_list_eda_credentials_with_kind_filter(
     admin_client: APIClient,
     default_registry_credential: models.EdaCredential,
@@ -604,6 +646,27 @@ def test_delete_managed_eda_credential(
 
 
 @pytest.mark.django_db
+def test_update_managed_eda_credential(
+    admin_client: APIClient,
+    default_organization: models.Organization,
+):
+    obj = models.EdaCredential.objects.create(
+        name="eda-credential",
+        inputs={"username": "adam", "password": "secret"},
+        managed=True,
+        organization=default_organization,
+    )
+    data = {"name": "updated-name"}
+    response = admin_client.patch(
+        f"{api_url_v1}/eda-credentials/{obj.id}/", data=data
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert (
+        response.data["errors"] == "Managed EDA credential cannot be updated"
+    )
+
+
+@pytest.mark.django_db
 def test_partial_update_eda_credential_without_inputs(
     admin_client: APIClient,
     credential_type: models.CredentialType,
@@ -613,7 +676,7 @@ def test_partial_update_eda_credential_without_inputs(
         name="eda-credential",
         inputs={"username": "adam", "password": "secret"},
         credential_type_id=credential_type.id,
-        managed=True,
+        managed=False,
         organization=default_organization,
     )
     data = {"inputs": {"username": "bearny", "password": "demo"}}
@@ -638,7 +701,7 @@ def test_partial_update_eda_credential_with_invalid_inputs(
         name="eda-credential",
         inputs={"username": "adam", "password": "secret"},
         credential_type_id=credential_type.id,
-        managed=True,
+        managed=False,
         organization=default_organization,
     )
     data = {
@@ -893,7 +956,7 @@ def test_partial_update_eda_credential_with_encrypted_output(
         name="eda-credential",
         inputs={"username": "adam", "password": "secret"},
         credential_type_id=credential_type.id,
-        managed=True,
+        managed=False,
         organization=default_organization,
     )
     data = {"name": "demo2"}
@@ -1399,7 +1462,7 @@ def test_update_eda_credential_for_analytics(
         name="eda-credential",
         inputs={"username": "adam", "password": fake_secret},
         credential_type_id=credential_type.id,
-        managed=True,
+        managed=False,
         organization=default_organization,
     )
     # first try, interval 100 -> 200
@@ -2668,7 +2731,7 @@ def test_list_eda_credentials_filter_namespace(
     # so we test with drools only
     response = admin_client.get(
         f"{api_url_v1}/eda-credentials/"
-        f"?credential_type__namespace__in=drools,other_namespace"
+        f"?credential_type__namespace__in=drools,other_namespace"  # noqa: E231
     )
     assert response.status_code == status.HTTP_200_OK
     assert len(response.data["results"]) == 1


### PR DESCRIPTION
This PR adds the default rule engine credential to the response on the eda-credentials list.  It also ensures that this credential cannot be edited, or deleted.
AAP-74358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * EDA rule-engine managed credentials now correctly appear in EDA credential listings, while other managed credentials are excluded as intended.
  * PATCH updates to managed EDA credentials are now rejected with HTTP 400 and a structured `errors` payload.

* **Tests**
  * Added integration tests covering listing inclusion/exclusion for managed rule-engine credentials.
  * Added integration tests ensuring managed credential updates are rejected.
  * Updated related integration scenarios to use non-managed credentials where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->