### PR TITLE
fix: prevent race condition in project partial_update (AAP-79566)

### DIFF
--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -213,6 +213,33 @@ class ProjectViewSet(
             ),
         },
     )
+    @staticmethod
+    def _needs_project_sync(update_fields):
+        return bool({"scm_branch", "scm_refspec", "url"} & set(update_fields))
+
+    @staticmethod
+    def _mark_pending_if_idle(project, update_fields):
+        """Read fresh import_state under row lock; set PENDING if idle.
+
+        Appends 'import_state' to update_fields when the state is
+        changed so the caller's single save persists it.
+        Returns True when a sync task should be dispatched.
+        """
+        current_state = (
+            models.Project.objects.select_for_update()
+            .values_list("import_state", flat=True)
+            .get(pk=project.id)
+        )
+        if current_state in [
+            models.Project.ImportState.PENDING,
+            models.Project.ImportState.RUNNING,
+        ]:
+            return False
+
+        project.import_state = models.Project.ImportState.PENDING
+        update_fields.append("import_state")
+        return True
+
     def partial_update(self, request, pk):
         project = self.get_object()
         serializer = serializers.ProjectUpdateRequestSerializer(
@@ -227,7 +254,17 @@ class ProjectViewSet(
             setattr(project, key, value)
             update_fields.append(key)
 
+        needs_sync = self._needs_project_sync(update_fields)
+
+        if needs_sync and not check_default_worker_health():
+            raise api_exc.WorkerUnavailable(worker_type="default")
+
+        sync_needed = False
         with transaction.atomic():
+            if needs_sync:
+                sync_needed = self._mark_pending_if_idle(
+                    project, update_fields
+                )
             project.save(update_fields=update_fields)
             check_related_permissions(
                 request.user,
@@ -246,33 +283,19 @@ class ProjectViewSet(
             )
         )
 
-        if {"scm_branch", "scm_refspec", "url"}.intersection(
-            update_fields
-        ) and (
-            project.import_state
-            not in [
-                models.Project.ImportState.PENDING,
-                models.Project.ImportState.RUNNING,
-            ]
-        ):
-            # Check if project workers are available before syncing
-            if not check_default_worker_health():
-                raise api_exc.WorkerUnavailable(worker_type="default")
-
-            # With dispatcherd migration, Redis is no longer required
-
+        if sync_needed:
             job_id = tasks.sync_project(project.id)
 
-            project.import_state = models.Project.ImportState.PENDING
             if job_id:
+                models.Project.objects.filter(pk=project.id).update(
+                    import_task_id=job_id
+                )
                 project.import_task_id = job_id
 
             logger.info(
                 f"Triggered import/sync task {job_id}"
                 f" for project {project.id}"
             )
-
-            project.save()
 
         return Response(serializers.ProjectSerializer(project).data)
 

--- a/tests/integration/api/test_project.py
+++ b/tests/integration/api/test_project.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import datetime
+import uuid
 from typing import Any, Dict
 from unittest import mock
 
@@ -795,6 +796,108 @@ def test_partial_update_project_scm_refspec(
     new_project.refresh_from_db()
     assert new_project.scm_refspec == new_scm_refspec
     assert new_project.scm_refspec != original_scm_refspec
+
+
+@pytest.mark.django_db
+@mock.patch("aap_eda.api.views.project.check_default_worker_health")
+@mock.patch("aap_eda.tasks.sync_project")
+def test_partial_update_does_not_overwrite_worker_state(
+    sync_project_task: mock.Mock,
+    mock_health_check: mock.Mock,
+    new_project: models.Project,
+    admin_client: APIClient,
+):
+    """Regression test for AAP-79566: partial_update race condition.
+
+    Simulates a worker completing the sync before the API handler
+    records the job_id. The worker's import_state update must be
+    preserved — import_state should NOT be overwritten to PENDING.
+    """
+    mock_health_check.return_value = True
+    job_id = "3677eb4a-de4a-421a-a73b-411aa502484d"
+
+    def sync_side_effect(project_id):
+        models.Project.objects.filter(pk=project_id).update(
+            import_state=models.Project.ImportState.COMPLETED,
+            git_hash="worker-updated-hash",
+        )
+        return job_id
+
+    sync_project_task.side_effect = sync_side_effect
+
+    response = admin_client.patch(
+        f"{api_url_v1}/projects/{new_project.id}/",
+        data={"scm_branch": "new-branch"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    new_project.refresh_from_db()
+    assert new_project.scm_branch == "new-branch"
+    assert new_project.import_task_id == uuid.UUID(job_id)
+    assert new_project.import_state == models.Project.ImportState.COMPLETED
+    assert new_project.git_hash == "worker-updated-hash"
+
+
+@pytest.mark.django_db
+@mock.patch("aap_eda.api.views.project.check_default_worker_health")
+@mock.patch("aap_eda.tasks.sync_project")
+def test_partial_update_does_not_overwrite_unrelated_fields(
+    sync_project_task: mock.Mock,
+    mock_health_check: mock.Mock,
+    new_project: models.Project,
+    admin_client: APIClient,
+):
+    """Regression test for AAP-79566: update_fields prevents stale writes.
+
+    Verifies that partial_update only saves import_state and
+    import_task_id, not other fields that may have been updated
+    concurrently by a worker.
+    """
+    mock_health_check.return_value = True
+    job_id = "3677eb4a-de4a-421a-a73b-411aa502484d"
+
+    models.Project.objects.filter(pk=new_project.id).update(
+        import_error="concurrent-error-update",
+    )
+
+    sync_project_task.return_value = job_id
+
+    response = admin_client.patch(
+        f"{api_url_v1}/projects/{new_project.id}/",
+        data={"scm_branch": "new-branch"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    new_project.refresh_from_db()
+    assert new_project.import_error == "concurrent-error-update"
+    assert new_project.import_state == models.Project.ImportState.PENDING
+
+
+@pytest.mark.django_db
+@mock.patch("aap_eda.api.views.project.check_default_worker_health")
+@mock.patch("aap_eda.tasks.sync_project")
+def test_partial_update_skips_sync_when_already_pending(
+    sync_project_task: mock.Mock,
+    mock_health_check: mock.Mock,
+    new_project: models.Project,
+    admin_client: APIClient,
+):
+    """Verify partial_update skips sync dispatch when already PENDING."""
+    mock_health_check.return_value = True
+
+    models.Project.objects.filter(pk=new_project.id).update(
+        import_state=models.Project.ImportState.PENDING,
+    )
+
+    response = admin_client.patch(
+        f"{api_url_v1}/projects/{new_project.id}/",
+        data={"scm_branch": "new-branch"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    sync_project_task.assert_not_called()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- Fix race condition in `partial_update` where the API handler could overwrite `import_state` back to `PENDING` after a worker already completed the sync
- Set `import_state=PENDING` under a `select_for_update` row lock **before** dispatching the task, so the worker is never blocked and can freely update `import_state`
- Record `import_task_id` via a targeted `.update()` that only touches that field — the worker never writes `import_task_id`, so no lock needed
- Reduce DB writes from 3 to 2 by merging the user-field save and the `import_state` save into a single `project.save(update_fields=...)`
- Extract `_needs_project_sync()` and `_mark_pending_if_idle()` helpers for clarity

## Root Cause
In `partial_update`, when SCM fields (url, branch, refspec) change:
1. `tasks.sync_project()` dispatched the task to the queue
2. A worker picked it up and completed: PENDING → RUNNING → COMPLETED
3. `project.save()` (no `update_fields`) overwrote **all** fields from the stale in-memory object, resetting `import_state` back to PENDING
4. Project stuck in PENDING permanently — no worker will re-process it

The `sync` action endpoint didn't have this bug because it already used `select_for_update`.

## Test plan
- [ ] `test_partial_update_does_not_overwrite_worker_state` — simulates worker completing before job_id is recorded; verifies COMPLETED state preserved
- [ ] `test_partial_update_does_not_overwrite_unrelated_fields` — verifies only `import_state` and `import_task_id` written, not stale fields like `import_error`
- [ ] `test_partial_update_skips_sync_when_already_pending` — verifies no duplicate dispatch when already PENDING
- [ ] Existing `test_partial_update_project_*` tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed race conditions when updating SCM-related project fields
  * Improved project synchronization reliability during concurrent updates
  * Enhanced state consistency to prevent missed syncs and data loss

<!-- end of auto-generated comment: release notes by coderabbit.ai -->