### PR TITLE
fix: stop circuit breaker bypass via failure_count reset (AAP-78375)

### DIFF
--- a/src/aap_eda/services/activation/activation_manager.py
+++ b/src/aap_eda/services/activation/activation_manager.py
@@ -97,12 +97,6 @@ class ActivationManager(StatusManager):
         self.db_instance.save(update_fields=["failure_count", "modified_at"])
 
     @run_with_lock
-    def _reset_failure_count(self):
-        """Reset the failure count of the activation."""
-        self.db_instance.failure_count = 0
-        self.db_instance.save(update_fields=["failure_count", "modified_at"])
-
-    @run_with_lock
     def _increase_restart_count(self):
         """Increase the restart count of the activation."""
         self.db_instance.restart_count += 1
@@ -1008,7 +1002,6 @@ class ActivationManager(StatusManager):
             with transaction.atomic():
                 self.set_status(ActivationStatus.RUNNING)
                 self.set_latest_instance_status(ActivationStatus.RUNNING)
-                self._reset_failure_count()
 
     def update_logs(self):
         """Update the logs of the latest instance of the activation."""

--- a/src/aap_eda/services/activation/activation_manager.py
+++ b/src/aap_eda/services/activation/activation_manager.py
@@ -1002,6 +1002,7 @@ class ActivationManager(StatusManager):
             with transaction.atomic():
                 self.set_status(ActivationStatus.RUNNING)
                 self.set_latest_instance_status(ActivationStatus.RUNNING)
+                self.db_instance.refresh_from_db()
 
     def update_logs(self):
         """Update the logs of the latest instance of the activation."""

--- a/tests/integration/services/activation/test_manager.py
+++ b/tests/integration/services/activation/test_manager.py
@@ -383,6 +383,30 @@ def test_monitor_to_running_status(
 
 
 @pytest.mark.django_db
+def test_monitor_preserves_failure_count_on_running_transition(
+    starting_activation: models.Activation,
+    container_engine_mock: MagicMock,
+    running_container_status_mock: MagicMock,
+):
+    """AAP-78375: failure_count must not reset on STARTING->RUNNING."""
+    starting_activation.failure_count = 3
+    starting_activation.save(update_fields=["failure_count"])
+
+    activation_manager = ActivationManager(
+        db_instance=starting_activation,
+        container_engine=container_engine_mock,
+    )
+    container_engine_mock.get_status.return_value = (
+        running_container_status_mock
+    )
+    activation_manager.monitor()
+
+    starting_activation.refresh_from_db()
+    assert starting_activation.status == enums.ActivationStatus.RUNNING
+    assert starting_activation.failure_count == 3
+
+
+@pytest.mark.django_db
 def test_monitor_container_engine_error_sets_workers_offline(
     running_activation: models.Activation,
     container_engine_mock: MagicMock,


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AAP-78375

## Summary

- **Root cause:** `_detect_running_status()` unconditionally reset `failure_count` to 0 on every STARTING→RUNNING transition, preventing `ACTIVATION_MAX_RESTARTS_ON_FAILURE` from ever tripping for activations that crash after reaching RUNNING status
- **Fix:** Remove the `_reset_failure_count()` call from `_detect_running_status()` and the now-dead method (7 lines removed)
- **Test:** Added `test_monitor_preserves_failure_count_on_running_transition` to `test_manager.py`

## Details

When an activation instance survived long enough to receive its first heartbeat (transitioning from STARTING to RUNNING), the `failure_count` was reset to 0. If the activation then crashed (e.g., after 15 minutes due to cascading job failures or liveness probe timeouts), the counter started over from scratch. The circuit breaker threshold was never reached, causing infinite restart loops and cluster-wide resource exhaustion.

Customer impact: In Case 04460263, an activation reached **205 failed instances over two days** with `ACTIVATION_MAX_RESTARTS_ON_FAILURE: 5` active but ignored.

`failure_count` is still properly reset by user-initiated actions:
- User enables a disabled activation (`api/views/activation.py`)
- Project sync recovers a failed activation (`tasks/project.py`)

## Verification

Reproduced and verified on local podman pods:

| Scenario | Before fix | After fix |
|---|---|---|
| Set `failure_count=4`, watch restart cycle | Reset to **0** on STARTING→RUNNING | Preserved at **4** through multiple cycles |

## Test plan

- [x] New test: `test_monitor_preserves_failure_count_on_running_transition` verifies `failure_count` is preserved during STARTING→RUNNING transition
- [x] Existing `test_monitor_to_running_status` still passes (only checks `restart_count`, unaffected)
- [x] Project sync tests (`test_projects.py`) still pass — those test the legitimate reset paths
- [ ] CI: full test suite

Fixes: [AAP-78375](https://issues.redhat.com/browse/AAP-78375)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where an activation moving from **STARTING** to **RUNNING** could incorrectly reset its stored **failure count**.

* **Tests**
  * Added an integration test to confirm that `monitor()` preserves **failure_count** during the **STARTING → RUNNING** transition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->