### PR TITLE
fix: disable service account token automount for activation job pods

### DIFF
--- a/src/aap_eda/services/activation/engine/kubernetes.py
+++ b/src/aap_eda/services/activation/engine/kubernetes.py
@@ -346,6 +346,7 @@ class Engine(ContainerEngine):
         spec_kwargs: dict = {
             "restart_policy": "Never",
             "containers": [container],
+            "automount_service_account_token": False,
         }
         if request.credential:
             self._create_secret(request, log_handler)

--- a/tests/integration/services/activation/engine/test_kubernetes.py
+++ b/tests/integration/services/activation/engine/test_kubernetes.py
@@ -315,6 +315,7 @@ def test_engine_start_applies_k8s_pod_metadata(
 
     spec = created_body.spec.template.spec
     assert spec.service_account_name == "eda-workload"
+    assert spec.automount_service_account_token is False
     labels = created_body.spec.template.metadata.labels
     assert labels["app"] == "eda"
     assert labels["job-name"] == engine.job_name
@@ -904,3 +905,4 @@ def test_engine_start_no_tolerations_by_default(
             )
             pod_spec = job_body.spec.template.spec
             assert pod_spec.tolerations is None
+            assert pod_spec.automount_service_account_token is False


### PR DESCRIPTION
## Summary

- Activation job pods do not need Kubernetes API access — they run user-supplied rulebooks and decision environment images. This sets automount_service_account_token to False on the pod spec so the default service account token is not projected into these pods.

## Test plan

- [ ] Verify existing integration tests pass
- [ ] Deploy and confirm activation job pods no longer have /var/run/secrets/kubernetes.io/serviceaccount/token mounted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Kubernetes pods created for jobs now explicitly disable automatic service account token mounting in pod templates, improving security and reducing unnecessary token exposure.

* **Tests**
  * Updated integration tests to verify the service account token auto-mounting is disabled in pod templates across job configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->