### PR TITLE
ci: bump tekton bundle digest and fix invalid renovate config

### DIFF
--- a/.tekton/run-atf-tests-pull-request.yaml
+++ b/.tekton/run-atf-tests-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
       - name: name
         value: aap-api-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-api-tests:0.1@sha256:0d586ff0617e6bc1eef7f1dbb0e9e55383fc8472e955b79784720765eb20f3fc
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-api-tests:0.1@sha256:0c1621395487e9305fb7652feb6d65071018953a199b991dcf520bd50c0b05ef
       - name: kind
         value: pipeline
       - name: secret

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,6 @@
   "tekton": {
     "enabled": true,
     "automerge": true,
-    "schedule": ["0 */12 * * 1-5"]
+    "schedule": ["* */12 * * 1-5"]
   }
 }


### PR DESCRIPTION
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
<!-- If applicable, provide a link to the issue that is being addressed -->
This PR brings the following changes:
1. Bumps the tekton pipeline bundle digest to no longer use aws spot instances. To provide better stability when pipeline deploys instances.
2. Fix the renovate configuration for #1589 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Tekton pipeline bundle reference to the latest version.
  * Adjusted Renovate automation schedule configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->