### PR TITLE
fix: sonar issues - Reused strings set to constants

### DIFF
--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -62,6 +62,7 @@ from aap_eda.core.utils.rulebook import (
 from aap_eda.core.utils.strings import substitute_variables
 
 logger = logging.getLogger(__name__)
+DE_NEEDED_MSG = "Decision Environment is needed"
 REQUIRED_KEYS = [
     "event_stream_id",
     "event_stream_name",
@@ -648,7 +649,7 @@ class ActivationCreateSerializer(
     decision_environment_id = serializers.IntegerField(
         validators=[validators.check_if_de_exists],
         error_messages={
-            "null": "Decision Environment is needed",
+            "null": DE_NEEDED_MSG,
             "required": "Decision Environment is required",
         },
     )
@@ -850,7 +851,7 @@ class ActivationUpdateSerializer(
     )
     decision_environment_id = serializers.IntegerField(
         validators=[validators.check_if_de_exists],
-        error_messages={"null": "Decision Environment is needed"},
+        error_messages={"null": DE_NEEDED_MSG},
     )
     awx_token_id = serializers.IntegerField(
         allow_null=True,
@@ -1333,7 +1334,7 @@ class PostActivationSerializer(
     name = serializers.CharField(required=True)
     decision_environment_id = serializers.IntegerField(
         validators=[validators.check_if_de_exists],
-        error_messages={"null": "Decision Environment is needed"},
+        error_messages={"null": DE_NEEDED_MSG},
     )
     # TODO: is_activation_valid needs to tell event stream/activation
     awx_token_id = serializers.IntegerField(

--- a/src/aap_eda/api/serializers/rulebook.py
+++ b/src/aap_eda/api/serializers/rulebook.py
@@ -18,6 +18,11 @@ from rest_framework import serializers
 from aap_eda.api.serializers.fields.yaml import YAMLSerializerField
 from aap_eda.core import models
 
+FIRED_RULE_ID_HELP = "ID of the fired rule"
+FIRED_RULE_NAME_HELP = "Name of the fired rule"
+FIRED_RULE_STATUS_HELP = "Status of the fired rule"
+FIRED_RULE_TIMESTAMP_HELP = "The fired timestamp of the rule"
+
 
 class RulebookSerializer(serializers.ModelSerializer):
     project_id = serializers.PrimaryKeyRelatedField(
@@ -63,17 +68,17 @@ class RulebookRefSerializer(serializers.ModelSerializer):
 class AuditRuleSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(
         required=True,
-        help_text="ID of the fired rule",
+        help_text=FIRED_RULE_ID_HELP,
     )
 
     name = serializers.CharField(
         required=True,
-        help_text="Name of the fired rule",
+        help_text=FIRED_RULE_NAME_HELP,
     )
 
     status = serializers.CharField(
         required=False,
-        help_text="Status of the fired rule",
+        help_text=FIRED_RULE_STATUS_HELP,
     )
 
     ruleset_name = serializers.CharField(
@@ -83,7 +88,7 @@ class AuditRuleSerializer(serializers.ModelSerializer):
 
     fired_at = serializers.DateTimeField(
         required=True,
-        help_text="The fired timestamp of the rule",
+        help_text=FIRED_RULE_TIMESTAMP_HELP,
     )
 
     class Meta:
@@ -107,17 +112,17 @@ class AuditRuleSerializer(serializers.ModelSerializer):
 class AuditRuleSerializerBase(serializers.Serializer):
     id = serializers.IntegerField(
         required=True,
-        help_text="ID of the fired rule",
+        help_text=FIRED_RULE_ID_HELP,
     )
 
     name = serializers.CharField(
         required=True,
-        help_text="Name of the fired rule",
+        help_text=FIRED_RULE_NAME_HELP,
     )
 
     status = serializers.CharField(
         required=False,
-        help_text="Status of the fired rule",
+        help_text=FIRED_RULE_STATUS_HELP,
     )
 
     activation_instance = serializers.SerializerMethodField()
@@ -126,7 +131,7 @@ class AuditRuleSerializerBase(serializers.Serializer):
 
     fired_at = serializers.DateTimeField(
         required=True,
-        help_text="The fired timestamp of the rule",
+        help_text=FIRED_RULE_TIMESTAMP_HELP,
     )
 
     @extend_schema_field(

--- a/src/aap_eda/api/serializers/user.py
+++ b/src/aap_eda/api/serializers/user.py
@@ -22,6 +22,8 @@ from aap_eda.core import models
 from .fields.ansible_resource import AnsibleResourceFieldSerializer
 from .mixins import SharedResourceSerializerMixin
 
+USERNAME_HELP = "The user's log in name."
+
 
 class UserSerializer(serializers.ModelSerializer):
     resource = AnsibleResourceFieldSerializer(read_only=True)
@@ -40,7 +42,7 @@ class UserSerializer(serializers.ModelSerializer):
 
 class UserDetailSerializer(serializers.ModelSerializer):
     username = serializers.CharField(
-        help_text="The user's log in name.",
+        help_text=USERNAME_HELP,
     )
     created_at = serializers.DateTimeField(source="date_joined")
     resource = AnsibleResourceFieldSerializer(read_only=True)
@@ -78,7 +80,7 @@ class UserListSerializer(serializers.Serializer):
 
     username = serializers.CharField(
         required=True,
-        help_text="The user's log in name.",
+        help_text=USERNAME_HELP,
     )
 
     first_name = serializers.CharField(
@@ -104,7 +106,7 @@ class UserUpdateSerializerBase(
     SharedResourceSerializerMixin,
 ):
     username = serializers.CharField(
-        help_text="The user's log in name.",
+        help_text=USERNAME_HELP,
     )
     password = serializers.CharField(write_only=True)
 

--- a/src/aap_eda/core/utils/awx.py
+++ b/src/aap_eda/core/utils/awx.py
@@ -20,6 +20,8 @@ import re
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
+PRIVATE_KEY_TYPE = "PRIVATE KEY"
+
 
 # Code copied from AWX repo hoping it lands in django-anssible-base at
 # some point
@@ -80,12 +82,12 @@ def validate_pem(data, min_keys=0, max_keys=None, min_certs=0, max_certs=None):
         pem_obj_info = {}
         pem_obj_info["all"] = match.group(0)
         pem_obj_info["type"] = pem_obj_type = match.group("type")
-        if pem_obj_type.endswith("PRIVATE KEY"):
+        if pem_obj_type.endswith(PRIVATE_KEY_TYPE):
             key_count += 1
-            pem_obj_info["type"] = "PRIVATE KEY"
+            pem_obj_info["type"] = PRIVATE_KEY_TYPE
             key_type = (
-                pem_obj_type.replace("ENCRYPTED PRIVATE KEY", "")
-                .replace("PRIVATE KEY", "")
+                pem_obj_type.replace(f"ENCRYPTED {PRIVATE_KEY_TYPE}", "")
+                .replace(PRIVATE_KEY_TYPE, "")
                 .strip()
             )
             try:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AAP-77394

One of multiple PRs addressing sonar quality gate issues. Sets several reused strings to constants.

Attached is a document describing the actions taken here.

[sonarcloud-remediation-report.md](https://github.com/user-attachments/files/29103602/sonarcloud-remediation-report.md)

Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized API field help-text for fired-rule details and user username to improve consistency in generated API docs.
* **Bug Fixes**
  * Made validation messaging consistent when a required “Decision Environment” is missing during activation create/update and reactivation.
* **Chores**
  * Improved and centralized PEM private-key type handling using shared constants for clearer, more maintainable logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->