### PR TITLE
feat: add activation instance scoping to JWT tokens for WebSocket aut…

### DIFF
--- a/src/aap_eda/api/authentication.py
+++ b/src/aap_eda/api/authentication.py
@@ -49,6 +49,7 @@ class WebsocketJWTAuthentication(BaseAuthentication):
             raise AuthenticationFailed("Invalid Bearer token format")
 
         try:
-            return validate_jwt_token(parts[1], "access"), None
+            user, _ = validate_jwt_token(parts[1], "access")
+            return user, None
         except InvalidTokenError as e:
             raise AuthenticationFailed("Invalid token") from e

--- a/src/aap_eda/api/serializers/auth.py
+++ b/src/aap_eda/api/serializers/auth.py
@@ -30,7 +30,12 @@ class RefreshTokenSerializer(serializers.Serializer):
 
     def validate(self, data):
         try:
-            self.user = validate_jwt_token(data["refresh"], "refresh")
+            self.user, token_payload = validate_jwt_token(
+                data["refresh"], "refresh"
+            )
+            self.activation_instance_id = token_payload.get(
+                "activation_instance_id"
+            )
         except InvalidTokenError as e:
             raise serializers.ValidationError("Invalid token") from e
         return data

--- a/src/aap_eda/api/views/auth.py
+++ b/src/aap_eda/api/views/auth.py
@@ -116,7 +116,17 @@ class TokenRefreshView(APIView):
         serializer = RefreshTokenSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        access_token = {"access": jwt_access_token(serializer.user.id)}
+        # Preserve activation_instance_id from refresh token (if present)
+        # This ensures scoped tokens remain scoped after refresh
+        activation_instance_id = getattr(
+            serializer, "activation_instance_id", None
+        )
+
+        access_token = {
+            "access": jwt_access_token(
+                serializer.user.id, activation_instance_id
+            )
+        }
         return Response(
             access_token,
             status=status.HTTP_200_OK,

--- a/src/aap_eda/services/activation/engine/common.py
+++ b/src/aap_eda/services/activation/engine/common.py
@@ -207,7 +207,10 @@ class ContainerableMixin:
             raise ContainerableInvalidError from e
 
     def _build_cmdline(self) -> AnsibleRulebookCmdLine:
-        access_token, refresh_token = create_jwt_token()
+        # Create tokens scoped to this specific activation instance
+        access_token, refresh_token = create_jwt_token(
+            activation_instance_id=self.latest_instance.id
+        )
         return AnsibleRulebookCmdLine(
             ws_url=self._get_ws_url(),
             log_level=self._get_log_level(),

--- a/src/aap_eda/services/auth.py
+++ b/src/aap_eda/services/auth.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import logging
 from datetime import datetime, timedelta
 from itertools import groupby
 
@@ -21,6 +22,8 @@ from django.conf import settings
 
 from aap_eda.core.models.user import User
 from aap_eda.services.exceptions import InvalidTokenError
+
+logger = logging.getLogger(__name__)
 
 
 def group_permission_resource(permission_data):
@@ -42,10 +45,18 @@ def display_permissions(role_data: dict) -> dict:
 JWT_ALGORITHM = "HS256"
 
 
-def create_jwt_token() -> tuple[str, str]:
+def create_jwt_token(
+    activation_instance_id: str | int | None = None,
+) -> tuple[str, str]:
     """Create JWT access and refresh token pair.
 
     They can be sent to rulebook clients through command line arguments.
+
+    Args:
+        activation_instance_id: Optional activation instance ID to
+            scope the token. Can be string or int (will be converted
+            to string). If provided, the token can only be used for
+            this activation instance.
     """
     with no_reverse_sync():
         user, new = User.objects.get_or_create(
@@ -56,31 +67,54 @@ def create_jwt_token() -> tuple[str, str]:
         user.set_unusable_password()
         user.save(update_fields=["password"])
 
-    access_token = jwt_access_token(user.id)
-    refresh_token = jwt_refresh_token(user.id)
+    # Convert to string for consistent comparison
+    activation_id_str = (
+        str(activation_instance_id)
+        if activation_instance_id is not None
+        else None
+    )
+    access_token = jwt_access_token(user.id, activation_id_str)
+    refresh_token = jwt_refresh_token(user.id, activation_id_str)
     return (access_token, refresh_token)
 
 
-def jwt_access_token(user_id: int) -> str:
+def jwt_access_token(
+    user_id: int, activation_instance_id: str | None = None
+) -> str:
     expiration = timedelta(
         minutes=float(settings.JWT_ACCESS_TOKEN_LIFETIME_MINUTES)
     )
-    return get_jwt_token(user_id, expiration, token_type="access")
+    return get_jwt_token(
+        user_id,
+        expiration,
+        token_type="access",
+        activation_instance_id=activation_instance_id,
+    )
 
 
-def jwt_refresh_token(user_id: int) -> str:
+def jwt_refresh_token(
+    user_id: int, activation_instance_id: str | None = None
+) -> str:
     expiration = timedelta(
         days=float(settings.JWT_REFRESH_TOKEN_LIFETIME_DAYS)
     )
-    return get_jwt_token(user_id, expiration, token_type="refresh")
+    return get_jwt_token(
+        user_id,
+        expiration,
+        token_type="refresh",
+        activation_instance_id=activation_instance_id,
+    )
 
 
 def get_jwt_token(user_id, expiration, **kwargs):
+    activation_instance_id = kwargs.pop("activation_instance_id", None)
     payload = {
         "user_id": user_id,
         "exp": datetime.now() + expiration,
         **kwargs,
     }
+    if activation_instance_id is not None:
+        payload["activation_instance_id"] = activation_instance_id
 
     return jwt.encode(payload, settings.SECRET_KEY, JWT_ALGORITHM)
 
@@ -94,7 +128,26 @@ def parse_jwt_token(token: str) -> dict:
         raise InvalidTokenError("Expired token") from e
 
 
-def validate_jwt_token(token: str, token_type: str) -> User:
+def validate_jwt_token(
+    token: str,
+    token_type: str,
+    activation_instance_id: str | int | None = None,
+) -> tuple[User, dict]:
+    """Validate JWT token and optionally verify activation instance scope.
+
+    Args:
+        token: The JWT token to validate
+        token_type: Expected token type ('access' or 'refresh')
+        activation_instance_id: If provided, verify that the token
+            is scoped to this activation instance. Can be string or
+            int.
+
+    Returns:
+        A tuple of (User, token_payload)
+
+    Raises:
+        InvalidTokenError: If token is invalid or scope doesn't match
+    """
     token_dict = parse_jwt_token(token)
 
     for key in ["user_id", "exp", "token_type"]:
@@ -104,7 +157,28 @@ def validate_jwt_token(token: str, token_type: str) -> User:
     if token_dict["token_type"] != token_type:
         raise InvalidTokenError("Invalid token type")
 
+    # Validate activation_instance_id scope if required
+    if activation_instance_id is not None:
+        token_activation_id = token_dict.get("activation_instance_id")
+        if token_activation_id is None:
+            raise InvalidTokenError(
+                "Token is not scoped to an activation instance"
+            )
+        # Compare as strings to handle both int and UUID types
+        if str(token_activation_id) != str(activation_instance_id):
+            logger.debug(
+                "Token scope mismatch: token=%s, requested=%s",
+                token_activation_id,
+                activation_instance_id,
+            )
+            raise InvalidTokenError(
+                "Token scope does not match the requested "
+                "activation instance"
+            )
+
     try:
-        return User.objects.get(id=token_dict["user_id"])
+        user = User.objects.get(id=token_dict["user_id"])
     except User.DoesNotExist as e:
         raise InvalidTokenError("Invalid user") from e
+
+    return user, token_dict

--- a/src/aap_eda/wsapi/consumers.py
+++ b/src/aap_eda/wsapi/consumers.py
@@ -31,6 +31,8 @@ from aap_eda.core.utils.credentials import (
 )
 from aap_eda.core.utils.strings import extract_variables, substitute_variables
 from aap_eda.middleware.request_log_middleware import assign_log_tracking_id
+from aap_eda.services.auth import parse_jwt_token
+from aap_eda.services.exceptions import InvalidTokenError
 
 from .messages import (
     ActionMessage,
@@ -51,6 +53,7 @@ from .messages import (
 logger = logging.getLogger(__name__)
 
 BINARY_FORMATS = {"binary_base64"}
+WS_CLOSE_TOKEN_AUTH_FAILED = 4003
 
 
 class MessageType(Enum):
@@ -100,35 +103,221 @@ DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
 
 
 class AnsibleRulebookConsumer(AsyncWebsocketConsumer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._token_payload = None  # Cache parsed token payload
+        self._legacy_token_warning_logged = (
+            False  # Track if warning was logged
+        )
+
+    def _get_token_payload(self) -> dict:
+        """Get and cache the parsed JWT token payload from websocket.
+
+        The token is parsed once and cached for the lifetime of the
+        connection. Note: The token has already been validated by
+        DrfAuthMiddleware during the websocket handshake. This method
+        re-parses it to access the payload.
+
+        Returns:
+            dict: The decoded JWT token payload
+
+        Raises:
+            InvalidTokenError: If token is missing or invalid
+        """
+        if self._token_payload is not None:
+            return self._token_payload
+
+        # Get the authorization header from the scope
+        auth_value = b""
+        for key, value in self.scope.get("headers", []):
+            if key.lower() == b"authorization":
+                auth_value = value
+                break
+        try:
+            auth_header = auth_value.decode()
+        except UnicodeDecodeError as err:
+            raise InvalidTokenError(
+                f"Malformed authorization header: {err}"
+            ) from err
+
+        if not auth_header:
+            raise InvalidTokenError("No authorization header found")
+
+        parts = auth_header.split()
+        if len(parts) != 2 or parts[0] != "Bearer":
+            raise InvalidTokenError("Invalid authorization header format")
+
+        token = parts[1]
+        payload = parse_jwt_token(token)
+
+        # Security: Reject refresh tokens - only access tokens allowed
+        token_type = payload.get("token_type")
+        if token_type != "access":
+            raise InvalidTokenError(
+                f"Invalid token type '{token_type}' for WebSocket auth. "
+                "Only access tokens are permitted."
+            )
+
+        # Cache payload only after all validations pass
+        self._token_payload = payload
+        return self._token_payload
+
+    @database_sync_to_async
+    def _get_activation_name(self, activation_id: str | int) -> str:
+        """Get activation name safely for logging.
+
+        Args:
+            activation_id: The activation instance ID
+
+        Returns:
+            The activation name or error string
+        """
+        try:
+            rulebook_process_instance = models.RulebookProcess.objects.get(
+                id=activation_id
+            )
+            activation = rulebook_process_instance.get_parent()
+            return activation.name
+        except Exception as e:
+            return f"<Error: {e}>"
+
+    async def _validate_token_scope(
+        self, activation_instance_id: str | int
+    ) -> None:
+        """Validate JWT token is scoped to given activation instance.
+
+        Legacy tokens without activation_instance_id are allowed but
+        generate a security warning logged once per connection.
+
+        Args:
+            activation_instance_id: The activation instance ID from the
+            message
+
+        Raises:
+            InvalidTokenError: If token scope doesn't match the activation
+            instance
+        """
+        token_dict = self._get_token_payload()
+
+        # Check if token has activation_instance_id scope
+        token_activation_id = token_dict.get("activation_instance_id")
+
+        # If token has activation_instance_id, it must match
+        if token_activation_id is not None:
+            if str(token_activation_id) != str(activation_instance_id):
+                logger.debug(
+                    "Token scope mismatch: token=%s, message=%s",
+                    token_activation_id,
+                    activation_instance_id,
+                )
+                raise InvalidTokenError(
+                    "Token scope does not match the requested "
+                    "activation instance"
+                )
+        # Legacy token without activation_instance_id - allow but warn
+        else:
+            if not self._legacy_token_warning_logged:
+                self._legacy_token_warning_logged = True
+                activation_name = await self._get_activation_name(
+                    activation_instance_id
+                )
+                logger.warning(
+                    f"SECURITY WARNING: Legacy token without "
+                    f"activation_instance_id used for activation "
+                    f"'{activation_name}' (ID: {activation_instance_id}). "
+                    f"RECOMMENDATION: Restart activation to generate new "
+                    f"scoped token."
+                )
+
+    async def _validate_message_token_scope(self, data: dict) -> None:
+        """Validate token scope for incoming message.
+
+        Scoped tokens (with ``activation_instance_id``) require every
+        message to carry ``activation_instance_id`` and the value must
+        match. Legacy tokens (without ``activation_instance_id``) skip
+        validation.
+
+        Args:
+            data: The message data containing activation_instance_id
+
+        Raises:
+            InvalidTokenError: If token scope validation fails
+        """
+        token_dict = self._get_token_payload()
+        token_activation_id = token_dict.get("activation_instance_id")
+
+        if token_activation_id is None:
+            return
+
+        activation_instance_id = data.get("activation_instance_id")
+        if activation_instance_id is None:
+            raise InvalidTokenError(
+                "Message missing activation_instance_id "
+                "required by scoped token"
+            )
+        await self._validate_token_scope(activation_instance_id)
+
+    async def _dispatch_message(
+        self, msg_type: MessageType, data: dict
+    ) -> None:
+        """Dispatch message to appropriate handler based on type.
+
+        Args:
+            msg_type: The message type
+            data: The message data
+        """
+        if msg_type == MessageType.WORKER:
+            await self.handle_workers(WorkerMessage.parse_obj(data))
+        elif msg_type == MessageType.JOB:
+            await self.handle_jobs(JobMessage.parse_obj(data))
+        elif msg_type == MessageType.ANSIBLE_EVENT:
+            await self.handle_events(AnsibleEventMessage.parse_obj(data))
+        elif msg_type == MessageType.ACTION:
+            await self.handle_actions(ActionMessage.parse_obj(data))
+        elif msg_type == MessageType.SHUTDOWN:
+            logger.info("Websocket connection is closed.")
+        elif msg_type == MessageType.SESSION_STATS:
+            await self.handle_heartbeat(HeartbeatMessage.parse_obj(data))
+        else:
+            logger.warning(f"Unsupported message received: {data}")
+
+    def _log_message_error(
+        self, err: Exception, msg_type: MessageType, data: dict
+    ) -> None:
+        """Log message processing errors with context.
+
+        Args:
+            err: The exception that occurred
+            msg_type: The message type
+            data: The message data
+        """
+        activation_id = data.get("activation_id")
+        logger.error(  # NOSONAR
+            f"Failed to parse message (type={msg_type.value}, "
+            f"activation_id={activation_id}) "
+            f"due to {type(err).__name__}: {err}"
+        )
+
     async def receive(self, text_data=None, bytes_data=None):
         data = json.loads(text_data)
-
-        await self._set_log_tracking_id(data)
 
         logger.debug(f"AnsibleRulebookConsumer received: {data}")
         msg_type = MessageType(data.get("type"))
 
         try:
-            if msg_type == MessageType.WORKER:
-                await self.handle_workers(WorkerMessage.parse_obj(data))
-            elif msg_type == MessageType.JOB:
-                await self.handle_jobs(JobMessage.parse_obj(data))
-            # AnsibleEvent messages are no longer sent by ansible-rulebook
-            # TODO: remove later if no need to keep
-            elif msg_type == MessageType.ANSIBLE_EVENT:
-                await self.handle_events(AnsibleEventMessage.parse_obj(data))
-            elif msg_type == MessageType.ACTION:
-                await self.handle_actions(ActionMessage.parse_obj(data))
-            elif msg_type == MessageType.SHUTDOWN:
-                logger.info("Websocket connection is closed.")
-            elif msg_type == MessageType.SESSION_STATS:
-                await self.handle_heartbeat(HeartbeatMessage.parse_obj(data))
-            else:
-                logger.warning(f"Unsupported message received: {data}")
+            await self._validate_message_token_scope(data)
+            await self._set_log_tracking_id(data)
+            await self._dispatch_message(msg_type, data)
         except (DatabaseError, ObjectDoesNotExist) as err:
-            logger.error(f"Failed to parse {data} due to DB error: {err}")
+            self._log_message_error(err, msg_type, data)
         except InvalidEnvKeyError as err:
-            logger.error(f"Failed to parse {data} due to Env error: {err}")
+            self._log_message_error(err, msg_type, data)
+        except InvalidTokenError as err:
+            logger.error(  # NOSONAR
+                f"Token auth failed for message (type={msg_type.value}, "
+                f"activation_id={data.get('activation_id')}): {err}"
+            )
+            await self.close(code=WS_CLOSE_TOKEN_AUTH_FAILED)
 
     async def handle_workers(self, message: WorkerMessage):
         additional_credentials = []

--- a/tests/integration/api/test_auth.py
+++ b/tests/integration/api/test_auth.py
@@ -116,3 +116,79 @@ def test_refresh_token_with_bad_token(base_client: RequestsClient):
     url = f"https://testserver{api_url_v1}/auth/token/refresh/"
     response = base_client.post(url, data)
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_refresh_token_preserves_activation_instance_id(
+    base_client: RequestsClient,
+):
+    """Test that refresh token preserves activation_instance_id in new
+    access token.
+    """
+    from aap_eda.services.auth import create_jwt_token, parse_jwt_token
+
+    activation_id = "123"
+    _, refresh_token = create_jwt_token(activation_instance_id=activation_id)
+
+    data = {"refresh": refresh_token}
+    url = f"https://testserver{api_url_v1}/auth/token/refresh/"
+    response = base_client.post(url, data)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert "access" in response.data
+
+    # Parse new access token and verify activation_instance_id is preserved
+    new_access_token = response.data["access"]
+    payload = parse_jwt_token(new_access_token)
+
+    assert payload["activation_instance_id"] == activation_id
+    assert payload["token_type"] == "access"
+
+
+@pytest.mark.django_db
+def test_refresh_token_preserves_activation_instance_id_uuid(
+    base_client: RequestsClient,
+):
+    """Test that refresh token preserves UUID activation_instance_id."""
+    from aap_eda.services.auth import create_jwt_token, parse_jwt_token
+
+    activation_id = "550e8400-e29b-41d4-a716-446655440000"
+    _, refresh_token = create_jwt_token(activation_instance_id=activation_id)
+
+    data = {"refresh": refresh_token}
+    url = f"https://testserver{api_url_v1}/auth/token/refresh/"
+    response = base_client.post(url, data)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    # Verify UUID is preserved
+    new_access_token = response.data["access"]
+    payload = parse_jwt_token(new_access_token)
+
+    assert payload["activation_instance_id"] == activation_id
+
+
+@pytest.mark.django_db
+def test_refresh_token_without_activation_instance_id_legacy(
+    base_client: RequestsClient,
+):
+    """Test that legacy refresh token without activation_instance_id
+    creates legacy access token.
+    """
+    from aap_eda.services.auth import create_jwt_token, parse_jwt_token
+
+    # Create legacy token without activation_instance_id
+    _, refresh_token = create_jwt_token()
+
+    data = {"refresh": refresh_token}
+    url = f"https://testserver{api_url_v1}/auth/token/refresh/"
+    response = base_client.post(url, data)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    # Verify new access token also has no activation_instance_id
+    new_access_token = response.data["access"]
+    payload = parse_jwt_token(new_access_token)
+
+    assert "activation_instance_id" not in payload
+    assert payload["token_type"] == "access"

--- a/tests/integration/api/test_auth_serializers.py
+++ b/tests/integration/api/test_auth_serializers.py
@@ -1,0 +1,139 @@
+#  Copyright 2024 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tests for auth serializers, specifically RefreshTokenSerializer
+scope preservation.
+"""
+
+import pytest
+
+from aap_eda.api.serializers.auth import RefreshTokenSerializer
+from aap_eda.services.auth import create_jwt_token
+
+
+@pytest.mark.django_db
+class TestRefreshTokenSerializer:
+    """Tests for RefreshTokenSerializer activation_instance_id
+    extraction.
+    """
+
+    def test_validate_extracts_activation_instance_id_from_scoped_token(
+        self,
+    ):
+        """Test that serializer extracts activation_instance_id from
+        scoped refresh token.
+        """
+        activation_id = "123"
+        _, refresh_token = create_jwt_token(
+            activation_instance_id=activation_id
+        )
+
+        serializer = RefreshTokenSerializer(data={"refresh": refresh_token})
+        assert serializer.is_valid()
+
+        # Verify activation_instance_id was extracted and stored
+        assert hasattr(serializer, "activation_instance_id")
+        assert serializer.activation_instance_id == activation_id
+        assert serializer.user is not None
+
+    def test_validate_extracts_activation_instance_id_uuid(self):
+        """Test that serializer extracts UUID activation_instance_id."""
+        activation_id = "550e8400-e29b-41d4-a716-446655440000"
+        _, refresh_token = create_jwt_token(
+            activation_instance_id=activation_id
+        )
+
+        serializer = RefreshTokenSerializer(data={"refresh": refresh_token})
+        assert serializer.is_valid()
+
+        assert serializer.activation_instance_id == activation_id
+
+    def test_validate_sets_none_for_legacy_token_without_activation_id(
+        self,
+    ):
+        """Test that serializer sets activation_instance_id to None for
+        legacy tokens.
+        """
+        # Create legacy token without activation_instance_id
+        _, refresh_token = create_jwt_token()
+
+        serializer = RefreshTokenSerializer(data={"refresh": refresh_token})
+        assert serializer.is_valid()
+
+        # Verify activation_instance_id is None for legacy tokens
+        assert hasattr(serializer, "activation_instance_id")
+        assert serializer.activation_instance_id is None
+        assert serializer.user is not None
+
+    def test_validate_fails_with_invalid_token(self):
+        """Test that serializer fails validation with invalid token."""
+        serializer = RefreshTokenSerializer(data={"refresh": "invalid_token"})
+
+        assert not serializer.is_valid()
+        assert "non_field_errors" in serializer.errors
+        assert "Invalid token" in str(serializer.errors)
+
+    def test_validate_fails_with_expired_token(self):
+        """Test that serializer fails validation with expired token."""
+        from unittest.mock import patch
+
+        # Create token with 0 lifetime (immediately expired)
+        with patch(
+            "aap_eda.services.auth.settings.JWT_REFRESH_TOKEN_LIFETIME_DAYS",
+            "0",
+        ):
+            _, refresh_token = create_jwt_token()
+
+        import time
+
+        time.sleep(1)
+
+        serializer = RefreshTokenSerializer(data={"refresh": refresh_token})
+
+        assert not serializer.is_valid()
+        assert "non_field_errors" in serializer.errors
+        assert "Invalid token" in str(serializer.errors)
+
+    def test_validate_fails_with_access_token_instead_of_refresh(self):
+        """Test that serializer fails when access token is used instead of
+        refresh token.
+        """
+        # Create tokens and use access token instead of refresh
+        access_token, _ = create_jwt_token(activation_instance_id="123")
+
+        serializer = RefreshTokenSerializer(data={"refresh": access_token})
+
+        assert not serializer.is_valid()
+        assert "non_field_errors" in serializer.errors
+        assert "Invalid token" in str(serializer.errors)
+
+    def test_validate_preserves_user_from_token(self):
+        """Test that serializer properly extracts and stores user from
+        token.
+        """
+        from aap_eda.core.models.user import User
+
+        # Get the service user that will be in the token
+        user, _ = User.objects.get_or_create(
+            username="_token_service_user",
+            is_service_account=True,
+        )
+
+        _, refresh_token = create_jwt_token(activation_instance_id="123")
+
+        serializer = RefreshTokenSerializer(data={"refresh": refresh_token})
+        assert serializer.is_valid()
+
+        assert serializer.user.id == user.id
+        assert serializer.user.username == "_token_service_user"

--- a/tests/integration/services/test_auth.py
+++ b/tests/integration/services/test_auth.py
@@ -19,6 +19,8 @@ import pytest
 
 from aap_eda.services.auth import (
     create_jwt_token,
+    jwt_access_token,
+    jwt_refresh_token,
     parse_jwt_token,
     validate_jwt_token,
 )
@@ -32,8 +34,8 @@ def test_create_jwt_token():
     assert token.count(".") == 2
     assert refresh.count(".") == 2
 
-    validate_jwt_token(token, "access")
-    validate_jwt_token(refresh, "refresh")
+    validate_jwt_token(token, "access")[0]
+    validate_jwt_token(refresh, "refresh")[0]
 
     assert {"user_id", "exp", "token_type"} <= parse_jwt_token(token).keys()
     assert {"user_id", "exp", "token_type"} <= parse_jwt_token(refresh).keys()
@@ -55,3 +57,162 @@ def test_token_expired_exception():
     with pytest.raises(InvalidTokenError) as error_info:
         parse_jwt_token(token)
     assert str(error_info.value) == "Expired token"
+
+
+# ========== Activation Instance Scoping Tests ==========
+
+
+@pytest.mark.django_db
+def test_create_jwt_token_with_activation_instance_id():
+    """Test creating tokens with activation_instance_id (int)."""
+    activation_id = 123
+    token, refresh = create_jwt_token(activation_instance_id=activation_id)
+
+    assert token.count(".") == 2
+    assert refresh.count(".") == 2
+
+    # Parse and verify activation_instance_id is in payload
+    token_payload = parse_jwt_token(token)
+    refresh_payload = parse_jwt_token(refresh)
+
+    assert token_payload["activation_instance_id"] == str(activation_id)
+    assert refresh_payload["activation_instance_id"] == str(activation_id)
+    assert token_payload["token_type"] == "access"
+    assert refresh_payload["token_type"] == "refresh"
+
+
+@pytest.mark.django_db
+def test_create_jwt_token_with_uuid_activation_instance_id():
+    """Test creating tokens with UUID activation_instance_id."""
+    activation_id = "550e8400-e29b-41d4-a716-446655440000"
+    token, refresh = create_jwt_token(activation_instance_id=activation_id)
+
+    # Parse and verify UUID is preserved as string
+    token_payload = parse_jwt_token(token)
+    refresh_payload = parse_jwt_token(refresh)
+
+    assert token_payload["activation_instance_id"] == activation_id
+    assert refresh_payload["activation_instance_id"] == activation_id
+
+
+@pytest.mark.django_db
+def test_create_jwt_token_without_activation_instance_id():
+    """Test creating tokens without activation_instance_id (legacy)."""
+    token, refresh = create_jwt_token()
+
+    # Parse and verify activation_instance_id is not in payload
+    token_payload = parse_jwt_token(token)
+    refresh_payload = parse_jwt_token(refresh)
+
+    assert "activation_instance_id" not in token_payload
+    assert "activation_instance_id" not in refresh_payload
+
+
+@pytest.mark.django_db
+def test_jwt_access_token_with_activation_instance_id():
+    """Test jwt_access_token function with activation_instance_id."""
+    from aap_eda.core.models.user import User
+
+    user = User.objects.create(username="test_user")
+    activation_id = "456"
+
+    token = jwt_access_token(user.id, activation_instance_id=activation_id)
+    payload = parse_jwt_token(token)
+
+    assert payload["user_id"] == user.id
+    assert payload["activation_instance_id"] == activation_id
+    assert payload["token_type"] == "access"
+
+
+@pytest.mark.django_db
+def test_jwt_refresh_token_with_activation_instance_id():
+    """Test jwt_refresh_token function with activation_instance_id."""
+    from aap_eda.core.models.user import User
+
+    user = User.objects.create(username="test_user")
+    activation_id = "789"
+
+    token = jwt_refresh_token(user.id, activation_instance_id=activation_id)
+    payload = parse_jwt_token(token)
+
+    assert payload["user_id"] == user.id
+    assert payload["activation_instance_id"] == activation_id
+    assert payload["token_type"] == "refresh"
+
+
+@pytest.mark.django_db
+def test_validate_jwt_token_with_matching_activation_instance_id():
+    """Test validation succeeds when activation_instance_id matches."""
+    activation_id = 123
+    token, _ = create_jwt_token(activation_instance_id=activation_id)
+
+    # Should not raise exception
+    user, _ = validate_jwt_token(
+        token, "access", activation_instance_id=activation_id
+    )
+    assert user is not None
+
+
+@pytest.mark.django_db
+def test_validate_jwt_token_with_matching_activation_instance_id_uuid():
+    """Test validation with UUID activation_instance_id."""
+    activation_id = "550e8400-e29b-41d4-a716-446655440000"
+    token, _ = create_jwt_token(activation_instance_id=activation_id)
+
+    # Should not raise exception
+    user, _ = validate_jwt_token(
+        token, "access", activation_instance_id=activation_id
+    )
+    assert user is not None
+
+
+@pytest.mark.django_db
+def test_validate_jwt_token_with_mismatched_activation_instance_id():
+    """Test validation fails when activation_instance_id doesn't match."""
+    token, _ = create_jwt_token(activation_instance_id=123)
+
+    with pytest.raises(InvalidTokenError) as error_info:
+        validate_jwt_token(token, "access", activation_instance_id=456)
+
+    assert "Token scope does not match" in str(error_info.value)
+
+
+@pytest.mark.django_db
+def test_validate_jwt_token_string_int_comparison():
+    """Test that string and int IDs are compared correctly."""
+    # Create token with int
+    token, _ = create_jwt_token(activation_instance_id=123)
+
+    # Validate with string - should work due to string comparison
+    user, _ = validate_jwt_token(token, "access", activation_instance_id="123")
+    assert user is not None
+
+
+@pytest.mark.django_db
+def test_validate_jwt_token_without_activation_instance_id_legacy():
+    """Test validation of legacy tokens without activation_instance_id."""
+    # Create legacy token without activation_instance_id
+    token, _ = create_jwt_token()
+
+    # Should succeed when no activation_instance_id is required
+    user, _ = validate_jwt_token(token, "access")
+    assert user is not None
+
+    # Should fail when activation_instance_id is required
+    with pytest.raises(InvalidTokenError) as error_info:
+        validate_jwt_token(token, "access", activation_instance_id=123)
+
+    assert "Token is not scoped to an activation instance" in str(
+        error_info.value
+    )
+
+
+@pytest.mark.django_db
+def test_validate_jwt_token_type_mismatch_with_activation_id():
+    """Test that token type is still validated with activation_instance_id."""
+    token, _ = create_jwt_token(activation_instance_id=123)
+
+    with pytest.raises(InvalidTokenError) as error_info:
+        validate_jwt_token(token, "refresh", activation_instance_id=123)
+
+    assert str(error_info.value) == "Invalid token type"

--- a/tests/integration/wsapi/test_consumer.py
+++ b/tests/integration/wsapi/test_consumer.py
@@ -18,6 +18,7 @@ from pydantic.error_wrappers import ValidationError
 from aap_eda.core import enums, models
 from aap_eda.core.models.activation import ActivationStatus
 from aap_eda.services.activation.activation_manager import ActivationManager
+from aap_eda.services.auth import create_jwt_token
 from aap_eda.wsapi.consumers import AnsibleRulebookConsumer, logger
 
 # TODO(doston): this test module needs a whole refactor to use already
@@ -79,6 +80,7 @@ async def test_handle_workers_without_credentials(
     payload = {
         "type": "Worker",
         "activation_id": rulebook_process_with_extra_var,
+        "activation_instance_id": rulebook_process_with_extra_var,
     }
     await ws_communicator.send_json_to(payload)
 
@@ -96,6 +98,7 @@ async def test_handle_workers_without_credentials(
     payload = {
         "type": "Worker",
         "activation_id": rulebook_process_without_extra_var,
+        "activation_instance_id": rulebook_process_without_extra_var,
     }
     await ws_communicator.send_json_to(payload)
 
@@ -112,6 +115,7 @@ async def test_handle_workers_without_credentials(
     payload = {
         "type": "Worker",
         "activation_id": rulebook_process_no_token,
+        "activation_instance_id": rulebook_process_no_token,
     }
     await ws_communicator.send_json_to(payload)
 
@@ -125,7 +129,6 @@ async def test_handle_workers_without_credentials(
 
 @pytest.mark.django_db(transaction=True)
 async def test_handle_workers_with_eda_system_vault_credential(
-    ws_communicator: WebsocketCommunicator,
     preseed_credential_types,
     default_organization: models.Organization,
 ):
@@ -137,9 +140,17 @@ async def test_handle_workers_with_eda_system_vault_credential(
         [credential],
     )
 
+    # Create communicator with scoped token
+    ws_communicator = await create_ws_communicator_with_token(
+        rulebook_process_id
+    )
+    connected, _ = await ws_communicator.connect()
+    assert connected
+
     payload = {
         "type": "Worker",
         "activation_id": rulebook_process_id,
+        "activation_instance_id": rulebook_process_id,
     }
     await ws_communicator.send_json_to(payload)
 
@@ -157,10 +168,11 @@ async def test_handle_workers_with_eda_system_vault_credential(
             assert data[0]["password"] == "secret"
             assert data[0]["label"] == "adam"
 
+    await ws_communicator.disconnect()
+
 
 @pytest.mark.django_db(transaction=True)
 async def test_handle_workers_with_controller_info(
-    ws_communicator: WebsocketCommunicator,
     preseed_credential_types,
     default_organization: models.Organization,
 ):
@@ -168,9 +180,16 @@ async def test_handle_workers_with_controller_info(
         default_organization,
     )
 
+    ws_communicator = await create_ws_communicator_with_token(
+        rulebook_process_id
+    )
+    connected, _ = await ws_communicator.connect()
+    assert connected
+
     payload = {
         "type": "Worker",
         "activation_id": rulebook_process_id,
+        "activation_instance_id": rulebook_process_id,
     }
     await ws_communicator.send_json_to(payload)
 
@@ -194,14 +213,14 @@ async def test_handle_workers_with_controller_info(
         elif type == "EnvVars":
             assert response["data"].startswith("QUFQX0hPU1ROQU1FOiBodHRwczovL")
 
+    await ws_communicator.disconnect()
+
 
 @pytest.mark.django_db(transaction=True)
 async def test_handle_workers_with_validation_errors(
     default_organization: models.Organization,
 ):
-    communicator = WebsocketCommunicator(
-        AnsibleRulebookConsumer.as_asgi(), "ws/"
-    )
+    communicator = await create_ws_communicator_with_token()
     connected, _ = await communicator.connect(timeout=3)
     assert connected
 
@@ -246,8 +265,16 @@ async def test_handle_jobs(
 
 
 @pytest.mark.django_db(transaction=True)
-async def test_handle_events(ws_communicator: WebsocketCommunicator):
+async def test_handle_events(
+    ws_communicator: WebsocketCommunicator,
+    default_organization: models.Organization,
+):
+    # Prepare activation instance to associate with job
+    activation_id = await _prepare_db_data(default_organization)
     job_instance = await _prepare_job_instance()
+
+    # Create association between activation and job for security validation
+    await _create_activation_job_association(activation_id, job_instance.id)
 
     assert (await get_job_instance_event_count()) == 0
     payload = {
@@ -267,11 +294,16 @@ async def test_handle_events(ws_communicator: WebsocketCommunicator):
 
 @pytest.mark.django_db(transaction=True)
 async def test_handle_actions_multiple_firing(
-    ws_communicator: WebsocketCommunicator,
     default_organization: models.Organization,
 ):
     rulebook_process_id = await _prepare_db_data(default_organization)
     job_instance = await _prepare_job_instance()
+
+    ws_communicator = await create_ws_communicator_with_token(
+        rulebook_process_id
+    )
+    connected, _ = await ws_communicator.connect()
+    assert connected
 
     assert (await get_audit_rule_count()) == 0
     payload1 = create_action_payload(
@@ -298,13 +330,24 @@ async def test_handle_actions_multiple_firing(
     assert (await get_audit_action_count()) == 2
     assert (await get_audit_event_count()) == 4
 
+    try:
+        await ws_communicator.disconnect()
+    except asyncio.CancelledError:
+        pass
+
 
 @pytest.mark.django_db(transaction=True)
 async def test_handle_actions_with_empty_job_uuid(
-    ws_communicator: WebsocketCommunicator,
     default_organization: models.Organization,
 ):
     rulebook_process_id = await _prepare_db_data(default_organization)
+
+    ws_communicator = await create_ws_communicator_with_token(
+        rulebook_process_id
+    )
+    connected, _ = await ws_communicator.connect()
+    assert connected
+
     assert (await get_audit_rule_count()) == 0
 
     # job uuid is empty string
@@ -323,14 +366,24 @@ async def test_handle_actions_with_empty_job_uuid(
     assert (await get_audit_action_count()) == 1
     assert (await get_audit_event_count()) == 2
 
+    try:
+        await ws_communicator.disconnect()
+    except asyncio.CancelledError:
+        pass
+
 
 @pytest.mark.django_db(transaction=True)
 async def test_handle_actions(
-    ws_communicator: WebsocketCommunicator,
     default_organization: models.Organization,
 ):
     rulebook_process_id = await _prepare_db_data(default_organization)
     job_instance = await _prepare_job_instance()
+
+    ws_communicator = await create_ws_communicator_with_token(
+        rulebook_process_id
+    )
+    connected, _ = await ws_communicator.connect()
+    assert connected
 
     assert (await get_audit_rule_count()) == 0
     payload = create_action_payload(
@@ -366,14 +419,24 @@ async def test_handle_actions(
         assert event.source_name == meta["source"]["name"]
         assert event.source_type == meta["source"]["type"]
 
+    try:
+        await ws_communicator.disconnect()
+    except asyncio.CancelledError:
+        pass
+
 
 @pytest.mark.django_db(transaction=True)
 async def test_rule_status_with_multiple_failed_actions(
-    ws_communicator: WebsocketCommunicator,
     default_organization: models.Organization,
 ):
     rulebook_process_id = await _prepare_db_data(default_organization)
     job_instance = await _prepare_job_instance()
+
+    ws_communicator = await create_ws_communicator_with_token(
+        rulebook_process_id
+    )
+    connected, _ = await ws_communicator.connect()
+    assert connected
 
     action1 = create_action_payload(
         DUMMY_UUID,
@@ -402,14 +465,25 @@ async def test_rule_status_with_multiple_failed_actions(
     rule = await get_first_audit_rule()
     assert rule.status == "failed"
 
+    try:
+        await ws_communicator.disconnect()
+    except asyncio.CancelledError:
+        pass
+
 
 @pytest.mark.django_db(transaction=True)
 async def test_handle_heartbeat(
-    ws_communicator: WebsocketCommunicator,
     default_organization: models.Organization,
 ):
     rulebook_process_id = await _prepare_db_data(default_organization)
     rulebook_process = await get_rulebook_process(rulebook_process_id)
+
+    ws_communicator = await create_ws_communicator_with_token(
+        rulebook_process_id
+    )
+    connected, _ = await ws_communicator.connect()
+    assert connected
+
     activation = await get_activation_by_rulebook_process(rulebook_process_id)
     assert activation.ruleset_stats == {}
 
@@ -450,6 +524,7 @@ async def test_handle_heartbeat(
         {
             "type": "SessionStats",
             "activation_id": rulebook_process_id,
+            "activation_instance_id": rulebook_process_id,
             "stats": stat,
             "reported_at": timezone.now().strftime(DATETIME_FORMAT),
         }
@@ -472,10 +547,14 @@ async def test_handle_heartbeat(
         stat["ruleSetName"] for stat in stats
     ]
 
+    try:
+        await ws_communicator.disconnect()
+    except asyncio.CancelledError:
+        pass
+
 
 @pytest.mark.django_db(transaction=True)
 async def test_handle_heartbeat_running_status(
-    ws_communicator: WebsocketCommunicator,
     default_organization: models.Organization,
 ):
     rulebook_process_id = await _prepare_db_data(
@@ -483,6 +562,13 @@ async def test_handle_heartbeat_running_status(
         ActivationStatus.STARTING,
     )
     rulebook_process = await get_rulebook_process(rulebook_process_id)
+
+    ws_communicator = await create_ws_communicator_with_token(
+        rulebook_process_id
+    )
+    connected, _ = await ws_communicator.connect()
+    assert connected
+
     activation = await get_activation_by_rulebook_process(rulebook_process_id)
     assert activation.ruleset_stats == {}
 
@@ -508,6 +594,7 @@ async def test_handle_heartbeat_running_status(
         {
             "type": "SessionStats",
             "activation_id": rulebook_process_id,
+            "activation_instance_id": rulebook_process_id,
             "stats": stat,
             "reported_at": timezone.now().strftime(DATETIME_FORMAT),
         }
@@ -522,6 +609,11 @@ async def test_handle_heartbeat_running_status(
     activation = await monitor_activation(activation)
     assert activation.status == ActivationStatus.RUNNING
 
+    try:
+        await ws_communicator.disconnect()
+    except asyncio.CancelledError:
+        pass
+
 
 @database_sync_to_async
 def monitor_activation(activation: models.Activation):
@@ -534,11 +626,16 @@ def monitor_activation(activation: models.Activation):
 
 @pytest.mark.django_db(transaction=True)
 async def test_multiple_rules_for_one_event(
-    ws_communicator: WebsocketCommunicator,
     default_organization: models.Organization,
 ):
     rulebook_process_id = await _prepare_db_data(default_organization)
     job_instance = await _prepare_job_instance()
+
+    ws_communicator = await create_ws_communicator_with_token(
+        rulebook_process_id
+    )
+    connected, _ = await ws_communicator.connect()
+    assert connected
 
     matching_events = _matching_events()
 
@@ -569,6 +666,11 @@ async def test_multiple_rules_for_one_event(
 
     for event in await get_audit_events():
         assert await get_audit_event_action_count(event) == 2
+
+    try:
+        await ws_communicator.disconnect()
+    except asyncio.CancelledError:
+        pass
 
 
 job_url_test_data = [
@@ -644,7 +746,6 @@ job_url_test_data = [
 )
 @pytest.mark.django_db(transaction=True)
 async def test_controller_job_url(
-    ws_communicator: WebsocketCommunicator,
     preseed_credential_types,
     action_type,
     controller_job_id,
@@ -665,6 +766,12 @@ async def test_controller_job_url(
     )
     job_instance = await _prepare_job_instance()
 
+    ws_communicator = await create_ws_communicator_with_token(
+        rulebook_process_id
+    )
+    connected, _ = await ws_communicator.connect()
+    assert connected
+
     assert (await get_audit_rule_count()) == 0
     payload = create_action_payload(
         DUMMY_UUID,
@@ -684,6 +791,11 @@ async def test_controller_job_url(
     assert (await get_audit_action_count()) == 1
     action = await get_audit_action_first()
     assert action.url == new_url
+
+    try:
+        await ws_communicator.disconnect()
+    except asyncio.CancelledError:
+        pass
 
 
 @database_sync_to_async
@@ -1079,11 +1191,51 @@ def _prepare_job_instance():
     return job_instance
 
 
+@database_sync_to_async
+def _create_activation_job_association(
+    activation_instance_id: int, job_instance_id: int
+):
+    """Create association between activation instance and job instance.
+
+    Required for ANSIBLE_EVENT security validation which resolves
+    activation from job_id.
+    """
+    models.ActivationInstanceJobInstance.objects.get_or_create(
+        activation_instance_id=activation_instance_id,
+        job_instance_id=job_instance_id,
+    )
+
+
+@database_sync_to_async
+def _create_jwt_token_sync(activation_id=None):
+    """Sync wrapper for creating JWT tokens."""
+    return create_jwt_token(activation_instance_id=activation_id)
+
+
+async def create_ws_communicator_with_token(activation_id=None):
+    """Helper to create a WebSocket communicator with proper JWT
+    authentication.
+
+    Args:
+        activation_id: Optional activation instance ID to scope the token
+        to. If None, creates a token without scope.
+    """
+    # Create a JWT token scoped to the activation instance
+    access_token, _ = await _create_jwt_token_sync(activation_id)
+
+    return WebsocketCommunicator(
+        AnsibleRulebookConsumer.as_asgi(),
+        "ws/",
+        headers=[(b"authorization", f"Bearer {access_token}".encode())],
+    )
+
+
 @pytest_asyncio.fixture(scope="function")
 async def ws_communicator() -> Generator[WebsocketCommunicator, None, None]:
-    communicator = WebsocketCommunicator(
-        AnsibleRulebookConsumer.as_asgi(), "ws/"
-    )
+    # Create a communicator without token for backwards compatibility
+    # Individual tests should use create_ws_communicator_with_token()
+    # if they need tokens
+    communicator = await create_ws_communicator_with_token()
     connected, _ = await communicator.connect()
     assert connected
 
@@ -1116,6 +1268,7 @@ def create_action_payload(
         "action": action_name,
         "action_uuid": action_uuid,
         "activation_id": activation_instance_id,
+        "activation_instance_id": activation_instance_id,
         "job_id": job_instance_uuid,
         "ruleset": "ruleset",
         "rule": "rule",
@@ -1256,7 +1409,6 @@ def _create_event(data, uuid):
 )
 @pytest.mark.django_db(transaction=True)
 async def test_handle_workers_with_file_contents(
-    ws_communicator: WebsocketCommunicator,
     preseed_credential_types,
     default_organization: models.Organization,
     credential_type_inputs: dict[str, any],
@@ -1276,9 +1428,16 @@ async def test_handle_workers_with_file_contents(
         [eda_credential],
     )
 
+    ws_communicator = await create_ws_communicator_with_token(
+        rulebook_process_id
+    )
+    connected, _ = await ws_communicator.connect()
+    assert connected
+
     payload = {
         "type": "Worker",
         "activation_id": rulebook_process_id,
+        "activation_instance_id": rulebook_process_id,
     }
     await ws_communicator.send_json_to(payload)
     check_data = [("Rulebook", None)]
@@ -1293,10 +1452,11 @@ async def test_handle_workers_with_file_contents(
             for key, value in data.items():
                 assert response[key] == value
 
+    await ws_communicator.disconnect()
+
 
 @pytest.mark.django_db(transaction=True)
 async def test_handle_workers_with_env_vars(
-    ws_communicator: WebsocketCommunicator,
     preseed_credential_types,
     default_organization: models.Organization,
 ):
@@ -1310,9 +1470,16 @@ async def test_handle_workers_with_env_vars(
         system_credential,
     )
 
+    ws_communicator = await create_ws_communicator_with_token(
+        rulebook_process_id
+    )
+    connected, _ = await ws_communicator.connect()
+    assert connected
+
     payload = {
         "type": "Worker",
         "activation_id": rulebook_process_id,
+        "activation_instance_id": rulebook_process_id,
     }
     await ws_communicator.send_json_to(payload)
 
@@ -1327,6 +1494,8 @@ async def test_handle_workers_with_env_vars(
         assert response["type"] == type
         if type == "EnvVars":
             assert response["data"].startswith("QUFQX0hPU1ROQU1FOiBodHRwczovL")
+
+    await ws_communicator.disconnect()
 
 
 @pytest.mark.django_db(transaction=True)
@@ -1351,7 +1520,6 @@ async def test_receive_object_not_exist(
 
 @pytest.mark.django_db(transaction=True)
 async def test_insert_audit_rule_invalid_activation(
-    ws_communicator: WebsocketCommunicator,
     default_organization: models.Organization,
     eda_caplog,
 ):
@@ -1360,6 +1528,15 @@ async def test_insert_audit_rule_invalid_activation(
     # Test with invalid activation ID
     invalid_activation_id = 100000000
     job_uuid = "940730a1-8b6f-45f3-84c9-bde8f04390e0"
+
+    # Create communicator with token scoped to invalid activation ID
+    # This allows token validation to pass and reach the code that checks
+    # if the RulebookProcess exists
+    ws_communicator = await create_ws_communicator_with_token(
+        invalid_activation_id
+    )
+    connected, _ = await ws_communicator.connect()
+    assert connected
 
     payload = create_action_payload(
         str(uuid.uuid4()),
@@ -1381,6 +1558,11 @@ async def test_insert_audit_rule_invalid_activation(
         # Verify no audit records created and error is logged
         assert await get_audit_rule_count() == initial_audit_count
         assert "RulebookProcess 100000000 not found" in eda_caplog.text
+
+    try:
+        await ws_communicator.disconnect()
+    except asyncio.CancelledError:
+        pass
 
 
 @pytest.mark.django_db(transaction=True)
@@ -1596,7 +1778,6 @@ def _prepare_activation_with_rule_engine_credential(
 
 @pytest.mark.django_db(transaction=True)
 async def test_get_rule_engine_credential_with_user_provided(
-    ws_communicator: WebsocketCommunicator,
     default_organization: models.Organization,
     preseed_credential_types,
 ):
@@ -1611,10 +1792,15 @@ async def test_get_rule_engine_credential_with_user_provided(
         default_organization, rule_engine_cred
     )
 
+    ws_communicator = await create_ws_communicator_with_token(process_id)
+    connected, _ = await ws_communicator.connect()
+    assert connected
+
     # Send Worker payload - should work without errors
     payload = {
         "type": "Worker",
         "activation_id": process_id,
+        "activation_instance_id": process_id,
     }
     await ws_communicator.send_json_to(payload)
 
@@ -1631,10 +1817,11 @@ async def test_get_rule_engine_credential_with_user_provided(
 
     assert received_end, "Should receive EndOfResponse"
 
+    await ws_communicator.disconnect()
+
 
 @pytest.mark.django_db(transaction=True)
 async def test_get_rule_engine_credential_persistence_disabled(
-    ws_communicator: WebsocketCommunicator,
     default_organization: models.Organization,
     preseed_credential_types,
 ):
@@ -1642,10 +1829,15 @@ async def test_get_rule_engine_credential_persistence_disabled(
     # Create activation WITHOUT persistence
     process_id = await _prepare_db_data(default_organization)
 
+    ws_communicator = await create_ws_communicator_with_token(process_id)
+    connected, _ = await ws_communicator.connect()
+    assert connected
+
     # Send Worker payload
     payload = {
         "type": "Worker",
         "activation_id": process_id,
+        "activation_instance_id": process_id,
     }
     await ws_communicator.send_json_to(payload)
 
@@ -1658,6 +1850,8 @@ async def test_get_rule_engine_credential_persistence_disabled(
     ]:
         response = await ws_communicator.receive_json_from(timeout=TIMEOUT)
         assert response["type"] == message_type
+
+    await ws_communicator.disconnect()
 
 
 @database_sync_to_async
@@ -1768,7 +1962,6 @@ def _prepare_activation_with_default_rule_engine_credential(
 
 @pytest.mark.django_db(transaction=True)
 async def test_get_rule_engine_credential_uses_default(
-    ws_communicator: WebsocketCommunicator,
     default_organization: models.Organization,
     preseed_credential_types,
 ):
@@ -1783,10 +1976,15 @@ async def test_get_rule_engine_credential_uses_default(
         default_organization
     )
 
+    ws_communicator = await create_ws_communicator_with_token(process_id)
+    connected, _ = await ws_communicator.connect()
+    assert connected
+
     # Send Worker payload - should use default credential
     payload = {
         "type": "Worker",
         "activation_id": process_id,
+        "activation_instance_id": process_id,
     }
     await ws_communicator.send_json_to(payload)
 
@@ -1802,3 +2000,5 @@ async def test_get_rule_engine_credential_uses_default(
             break
 
     assert received_end, "Should receive EndOfResponse with default credential"
+
+    await ws_communicator.disconnect()

--- a/tests/integration/wsapi/test_consumer_token_validation.py
+++ b/tests/integration/wsapi/test_consumer_token_validation.py
@@ -1,0 +1,650 @@
+#  Copyright 2024 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tests for WebSocket consumer JWT token validation.
+
+Tests JWT token validation with activation instance scoping.
+"""
+
+import pytest
+from channels.db import database_sync_to_async
+
+from aap_eda.services.auth import create_jwt_token
+from aap_eda.services.exceptions import InvalidTokenError
+from aap_eda.wsapi.consumers import AnsibleRulebookConsumer
+
+
+@pytest.fixture
+def mock_consumer():
+    """Create a mock consumer with scope headers."""
+    consumer = AnsibleRulebookConsumer()
+    consumer.scope = {"headers": []}
+    return consumer
+
+
+def set_consumer_token(consumer, token):
+    """Set authorization header in consumer scope."""
+    consumer.scope["headers"] = [
+        (b"authorization", f"Bearer {token}".encode())
+    ]
+
+
+@pytest.mark.django_db
+class TestConsumerTokenValidation:
+    """Tests for consumer token scope validation."""
+
+    def test_get_token_payload_success(self, mock_consumer):
+        """Test successfully extracting token payload."""
+        token, _ = create_jwt_token(activation_instance_id=123)
+        set_consumer_token(mock_consumer, token)
+
+        payload = mock_consumer._get_token_payload()
+
+        assert payload is not None
+        assert payload["activation_instance_id"] == "123"
+        assert payload["token_type"] == "access"
+
+    def test_get_token_payload_caching(self, mock_consumer):
+        """Test that token payload is cached after first parse."""
+        token, _ = create_jwt_token(activation_instance_id=123)
+        set_consumer_token(mock_consumer, token)
+
+        # First call
+        payload1 = mock_consumer._get_token_payload()
+        # Second call should return cached value
+        payload2 = mock_consumer._get_token_payload()
+
+        assert payload1 is payload2  # Same object reference
+
+    def test_get_token_payload_no_auth_header(self, mock_consumer):
+        """Test error when no authorization header is present."""
+        mock_consumer.scope["headers"] = []
+
+        with pytest.raises(InvalidTokenError) as exc_info:
+            mock_consumer._get_token_payload()
+
+        assert "No authorization header found" in str(exc_info.value)
+
+    def test_get_token_payload_invalid_format(self, mock_consumer):
+        """Test error when authorization header has invalid format."""
+        mock_consumer.scope["headers"] = [(b"authorization", b"InvalidFormat")]
+
+        with pytest.raises(InvalidTokenError) as exc_info:
+            mock_consumer._get_token_payload()
+
+        assert "Invalid authorization header format" in str(exc_info.value)
+
+    def test_get_token_payload_not_bearer(self, mock_consumer):
+        """Test error when authorization header is not Bearer type."""
+        mock_consumer.scope["headers"] = [
+            (b"authorization", b"Basic dXNlcjpwYXNz")
+        ]
+
+        with pytest.raises(InvalidTokenError) as exc_info:
+            mock_consumer._get_token_payload()
+
+        assert "Invalid authorization header format" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_validate_token_scope_matching_id(self, mock_consumer):
+        """Test validation succeeds when activation_instance_id matches."""
+        activation_id = 123
+        token, _ = await database_sync_to_async(create_jwt_token)(
+            activation_instance_id=activation_id
+        )
+        set_consumer_token(mock_consumer, token)
+
+        # Should not raise exception
+        await mock_consumer._validate_token_scope(activation_id)
+
+    @pytest.mark.asyncio
+    async def test_validate_token_scope_matching_uuid(self, mock_consumer):
+        """Test validation succeeds with UUID activation_instance_id."""
+        activation_id = "550e8400-e29b-41d4-a716-446655440000"
+        token, _ = await database_sync_to_async(create_jwt_token)(
+            activation_instance_id=activation_id
+        )
+        set_consumer_token(mock_consumer, token)
+
+        # Should not raise exception
+        await mock_consumer._validate_token_scope(activation_id)
+
+    @pytest.mark.asyncio
+    async def test_validate_token_scope_string_int_matching(
+        self, mock_consumer
+    ):
+        """Test validation with string vs int comparison."""
+        token, _ = await database_sync_to_async(create_jwt_token)(
+            activation_instance_id=123
+        )
+        set_consumer_token(mock_consumer, token)
+
+        # Should work with string "123"
+        await mock_consumer._validate_token_scope("123")
+
+    @pytest.mark.asyncio
+    async def test_validate_token_scope_mismatched_id(self, mock_consumer):
+        """Test validation fails when activation_instance_id doesn't match."""
+        token, _ = await database_sync_to_async(create_jwt_token)(
+            activation_instance_id=123
+        )
+        set_consumer_token(mock_consumer, token)
+
+        with pytest.raises(InvalidTokenError) as exc_info:
+            await mock_consumer._validate_token_scope(456)
+
+        assert "Token scope does not match" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_validate_token_scope_legacy_token_without_scope(
+        self, mock_consumer
+    ):
+        """Test legacy tokens without activation_instance_id are allowed.
+
+        Legacy tokens should be allowed with async warning.
+        """
+        # Create legacy token without activation_instance_id
+        token, _ = await database_sync_to_async(create_jwt_token)()
+        set_consumer_token(mock_consumer, token)
+
+        # Should not raise exception - legacy tokens are allowed
+        # Note: This is now an async method that logs warning
+        await mock_consumer._validate_token_scope(123)
+
+    @pytest.mark.asyncio
+    async def test_validate_token_scope_scoped_token_validates_mismatch(
+        self, mock_consumer
+    ):
+        """Test that scoped tokens reject mismatched activation_instance_id."""
+        # Token with activation_instance_id
+        token, _ = await database_sync_to_async(create_jwt_token)(
+            activation_instance_id=123
+        )
+        set_consumer_token(mock_consumer, token)
+
+        # Should still fail on mismatch
+        with pytest.raises(InvalidTokenError) as exc_info:
+            await mock_consumer._validate_token_scope(456)
+
+        assert "Token scope does not match" in str(exc_info.value)
+
+
+@pytest.mark.django_db
+class TestConsumerRefreshTokenRejection:
+    """Tests for refresh token rejection in WebSocket auth."""
+
+    def test_get_token_payload_rejects_refresh_token(self, mock_consumer):
+        """Test that refresh tokens are rejected in WebSocket auth.
+
+        Security fix: Refresh tokens should only be used to obtain new
+        access tokens, never for direct WebSocket authentication.
+        """
+        # Create token pair - use refresh token (index 1)
+        _, refresh_token = create_jwt_token(activation_instance_id=123)
+        set_consumer_token(mock_consumer, refresh_token)
+
+        with pytest.raises(InvalidTokenError) as exc_info:
+            mock_consumer._get_token_payload()
+
+        assert "Invalid token type 'refresh'" in str(exc_info.value)
+        assert "Only access tokens are permitted" in str(exc_info.value)
+
+    def test_get_token_payload_accepts_access_token(self, mock_consumer):
+        """Test that access tokens are accepted in WebSocket auth."""
+        # Create token pair - use access token (index 0)
+        access_token, _ = create_jwt_token(activation_instance_id=123)
+        set_consumer_token(mock_consumer, access_token)
+
+        # Should not raise exception
+        payload = mock_consumer._get_token_payload()
+
+        assert payload is not None
+        assert payload["token_type"] == "access"
+        assert payload["activation_instance_id"] == "123"
+
+    def test_get_token_payload_rejects_missing_token_type(self, mock_consumer):
+        """Test rejection of tokens without token_type field.
+
+        Legacy tokens or malformed tokens without token_type should
+        be rejected.
+        """
+        from datetime import datetime, timedelta
+
+        import jwt
+        from django.conf import settings
+
+        # Create malformed token without token_type (but valid exp)
+        payload = {
+            "user_id": 1,
+            "exp": datetime.now() + timedelta(days=1),
+            "activation_instance_id": "123",
+            # Missing token_type field
+        }
+        malformed_token = jwt.encode(
+            payload, settings.SECRET_KEY, algorithm="HS256"
+        )
+        set_consumer_token(mock_consumer, malformed_token)
+
+        with pytest.raises(InvalidTokenError) as exc_info:
+            mock_consumer._get_token_payload()
+
+        assert "Invalid token type 'None'" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_receive_rejects_refresh_token_in_job_message(
+        self, mock_consumer
+    ):
+        """Test that JOB messages with refresh token are rejected.
+
+        Integration test: Verify refresh token rejection works in
+        the full receive() flow.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from channels.db import database_sync_to_async
+
+        # Use refresh token (index 1) instead of access token
+        _, refresh_token = await database_sync_to_async(create_jwt_token)(
+            activation_instance_id=123
+        )
+        set_consumer_token(mock_consumer, refresh_token)
+
+        # Mock the close method and _set_log_tracking_id
+        mock_consumer.close = AsyncMock()
+        mock_consumer._set_log_tracking_id = AsyncMock()
+
+        # Mock handle_jobs to verify it's NOT called on rejection
+        with patch.object(
+            mock_consumer, "handle_jobs", new_callable=AsyncMock
+        ) as mock_handle_jobs:
+            # Try to send a JOB message with refresh token
+            await mock_consumer.receive(
+                text_data='{"type": "Job", "activation_instance_id": 123, '
+                '"ansible_rulebook_id": 123, '
+                '"job_id": "test-job-123", "name": "Test Job", '
+                '"action": "run_playbook", "ruleset": "test_ruleset", '
+                '"hosts": "localhost", "rule": "test_rule"}'
+            )
+
+            # Verify message was NOT dispatched
+            mock_handle_jobs.assert_not_called()
+            # Verify connection was closed with auth failure code
+            mock_consumer.close.assert_called_once_with(code=4003)
+
+    @pytest.mark.asyncio
+    async def test_receive_accepts_access_token_in_job_message(
+        self, mock_consumer
+    ):
+        """Test that JOB messages with access token are accepted.
+
+        Integration test: Verify access token works in full receive() flow.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from channels.db import database_sync_to_async
+
+        # Use access token (index 0)
+        access_token, _ = await database_sync_to_async(create_jwt_token)(
+            activation_instance_id=123
+        )
+        set_consumer_token(mock_consumer, access_token)
+
+        # Mock the close method and _set_log_tracking_id
+        mock_consumer.close = AsyncMock()
+        mock_consumer._set_log_tracking_id = AsyncMock()
+
+        # Send a JOB message with access token
+        with patch.object(
+            mock_consumer, "handle_jobs", new_callable=AsyncMock
+        ) as mock_handle_jobs:
+            await mock_consumer.receive(
+                text_data='{"type": "Job", "activation_instance_id": 123, '
+                '"ansible_rulebook_id": 123, '
+                '"job_id": "test-job-123", "name": "Test Job", '
+                '"action": "run_playbook", "ruleset": "test_ruleset", '
+                '"hosts": "localhost", "rule": "test_rule"}'
+            )
+
+            # Should succeed
+            mock_consumer.close.assert_not_called()
+            mock_handle_jobs.assert_called_once()
+
+
+@pytest.mark.django_db
+class TestConsumerTokenScopeIntegration:
+    """Integration tests for token scope validation in consumer."""
+
+    @pytest.mark.asyncio
+    async def test_token_validation_with_matching_scope(self, mock_consumer):
+        """Test that validation passes when token scope matches."""
+        # This test verifies the full flow works correctly
+        token, _ = await database_sync_to_async(create_jwt_token)(
+            activation_instance_id=123
+        )
+        set_consumer_token(mock_consumer, token)
+
+        # Should not raise - validation succeeds
+        await mock_consumer._validate_token_scope(123)
+        # String comparison works
+        await mock_consumer._validate_token_scope("123")
+
+    @pytest.mark.asyncio
+    async def test_token_validation_rejects_wrong_scope(self, mock_consumer):
+        """Test that validation fails when token scope doesn't match."""
+        token, _ = await database_sync_to_async(create_jwt_token)(
+            activation_instance_id=123
+        )
+        set_consumer_token(mock_consumer, token)
+
+        # Should raise InvalidTokenError
+        with pytest.raises(InvalidTokenError) as exc_info:
+            await mock_consumer._validate_token_scope(456)
+
+        assert "Token scope does not match" in str(exc_info.value)
+
+
+@pytest.mark.django_db
+class TestConsumerLegacyTokenWarning:
+    """Tests for legacy token warning functionality."""
+
+    @pytest.mark.asyncio
+    async def test_legacy_token_warning_logged_once(self, mock_consumer):
+        """Test warning is logged only once per connection.
+
+        Legacy tokens should trigger a warning only once per connection.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from channels.db import database_sync_to_async
+
+        # Mock _get_activation_name to return the test activation name
+        mock_consumer._get_activation_name = AsyncMock(
+            return_value="Test Activation"
+        )
+
+        # Create legacy token
+        token, _ = await database_sync_to_async(create_jwt_token)()
+        set_consumer_token(mock_consumer, token)
+
+        # Call validate multiple times with a test activation ID
+        activation_id = 123
+        with patch("aap_eda.wsapi.consumers.logger") as mock_logger:
+            await mock_consumer._validate_token_scope(activation_id)
+            await mock_consumer._validate_token_scope(activation_id)
+            await mock_consumer._validate_token_scope(activation_id)
+
+            # Should log warning only once
+            assert mock_logger.warning.call_count == 1
+            warning_msg = mock_logger.warning.call_args[0][0]
+            assert "SECURITY WARNING" in warning_msg
+            assert "Test Activation" in warning_msg
+            assert "Legacy token without activation_instance_id" in warning_msg
+
+    @pytest.mark.asyncio
+    async def test_legacy_token_warning_includes_activation_name(
+        self, mock_consumer
+    ):
+        """Test that warning includes the activation name."""
+        from unittest.mock import AsyncMock, patch
+
+        from channels.db import database_sync_to_async
+
+        # Mock _get_activation_name to return the production activation name
+        mock_consumer._get_activation_name = AsyncMock(
+            return_value="Production Webhook Handler"
+        )
+
+        token, _ = await database_sync_to_async(create_jwt_token)()
+        set_consumer_token(mock_consumer, token)
+
+        activation_id = 456
+        with patch("aap_eda.wsapi.consumers.logger") as mock_logger:
+            await mock_consumer._validate_token_scope(activation_id)
+
+            warning_msg = mock_logger.warning.call_args[0][0]
+            assert "Production Webhook Handler" in warning_msg
+            assert str(activation_id) in warning_msg
+            assert "RECOMMENDATION: Restart activation" in warning_msg
+
+    @pytest.mark.asyncio
+    async def test_scoped_token_does_not_warn(self, mock_consumer):
+        """Test that scoped tokens do not generate warnings."""
+        from unittest.mock import AsyncMock, patch
+
+        from channels.db import database_sync_to_async
+
+        # Mock _get_activation_name (should not be called for scoped tokens)
+        mock_consumer._get_activation_name = AsyncMock(
+            return_value="Test Activation"
+        )
+
+        # Create scoped token
+        activation_id = 789
+        token, _ = await database_sync_to_async(create_jwt_token)(
+            activation_instance_id=activation_id
+        )
+        set_consumer_token(mock_consumer, token)
+
+        with patch("aap_eda.wsapi.consumers.logger") as mock_logger:
+            await mock_consumer._validate_token_scope(activation_id)
+
+            # Should not log any warning for properly scoped tokens
+            mock_logger.warning.assert_not_called()
+            # And _get_activation_name should not be called
+            mock_consumer._get_activation_name.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestConsumerReceiveTokenValidation:
+    """Tests for token validation in receive() method."""
+
+    @pytest.mark.asyncio
+    async def test_job_message_validates_token_with_activation_instance_id(
+        self, mock_consumer
+    ):
+        """Test JOB message validates token using activation_instance_id."""
+        from unittest.mock import AsyncMock, patch
+
+        from channels.db import database_sync_to_async
+
+        activation_id = 123
+        token, _ = await database_sync_to_async(create_jwt_token)(
+            activation_instance_id=activation_id
+        )
+        set_consumer_token(mock_consumer, token)
+
+        mock_consumer.close = AsyncMock()
+        mock_consumer._set_log_tracking_id = AsyncMock()
+
+        with patch.object(
+            mock_consumer, "handle_jobs", new_callable=AsyncMock
+        ) as mock_handle_jobs:
+            await mock_consumer.receive(
+                text_data='{"type": "Job", "activation_instance_id": 123, '
+                '"ansible_rulebook_id": 123, '
+                '"job_id": "test-job-123", "name": "Test Job", '
+                '"action": "run_playbook", "ruleset": "test_ruleset", '
+                '"hosts": "localhost", "rule": "test_rule"}'
+            )
+
+            mock_handle_jobs.assert_called_once()
+            mock_consumer.close.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_job_message_rejects_mismatched_activation_instance_id(
+        self, mock_consumer
+    ):
+        """Test JOB message rejects token when activation_instance_id
+        mismatches."""
+        from unittest.mock import AsyncMock, patch
+
+        from channels.db import database_sync_to_async
+
+        token, _ = await database_sync_to_async(create_jwt_token)(
+            activation_instance_id=123
+        )
+        set_consumer_token(mock_consumer, token)
+
+        mock_consumer.close = AsyncMock()
+        mock_consumer._set_log_tracking_id = AsyncMock()
+
+        with patch.object(
+            mock_consumer, "handle_jobs", new_callable=AsyncMock
+        ) as mock_handle_jobs:
+            await mock_consumer.receive(
+                text_data='{"type": "Job", "activation_instance_id": 456, '
+                '"ansible_rulebook_id": 456, '
+                '"job_id": "test-job-456", "name": "Test Job", '
+                '"action": "run_playbook", "ruleset": "test_ruleset", '
+                '"hosts": "localhost", "rule": "test_rule"}'
+            )
+
+            mock_handle_jobs.assert_not_called()
+            mock_consumer.close.assert_called_once_with(code=4003)
+
+    @pytest.mark.asyncio
+    async def test_worker_message_validates_token_with_activation_instance_id(
+        self, mock_consumer
+    ):
+        """Test Worker message validates token using
+        activation_instance_id."""
+        from unittest.mock import AsyncMock, patch
+
+        from channels.db import database_sync_to_async
+
+        activation_id = 123
+        token, _ = await database_sync_to_async(create_jwt_token)(
+            activation_instance_id=activation_id
+        )
+        set_consumer_token(mock_consumer, token)
+
+        mock_consumer.close = AsyncMock()
+        mock_consumer._set_log_tracking_id = AsyncMock()
+
+        with patch.object(
+            mock_consumer, "handle_workers", new_callable=AsyncMock
+        ) as mock_handle_workers:
+            await mock_consumer.receive(
+                text_data='{"type": "Worker", '
+                '"activation_id": 123, '
+                '"activation_instance_id": 123}'
+            )
+
+            mock_handle_workers.assert_called_once()
+            mock_consumer.close.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_worker_message_rejects_mismatched_activation_instance_id(
+        self, mock_consumer
+    ):
+        """Test Worker message rejects token when activation_instance_id
+        mismatches."""
+        from unittest.mock import AsyncMock, patch
+
+        from channels.db import database_sync_to_async
+
+        token, _ = await database_sync_to_async(create_jwt_token)(
+            activation_instance_id=123
+        )
+        set_consumer_token(mock_consumer, token)
+
+        mock_consumer.close = AsyncMock()
+        mock_consumer._set_log_tracking_id = AsyncMock()
+
+        with patch.object(
+            mock_consumer, "handle_workers", new_callable=AsyncMock
+        ) as mock_handle_workers:
+            await mock_consumer.receive(
+                text_data='{"type": "Worker", '
+                '"activation_id": 456, '
+                '"activation_instance_id": 456}'
+            )
+
+            mock_handle_workers.assert_not_called()
+            mock_consumer.close.assert_called_once_with(code=4003)
+
+    @pytest.mark.asyncio
+    async def test_action_message_validates_token_with_activation_instance_id(
+        self, mock_consumer
+    ):
+        """Test Action message validates token using
+        activation_instance_id."""
+        from unittest.mock import AsyncMock, patch
+
+        from channels.db import database_sync_to_async
+
+        activation_id = 123
+        token, _ = await database_sync_to_async(create_jwt_token)(
+            activation_instance_id=activation_id
+        )
+        set_consumer_token(mock_consumer, token)
+
+        mock_consumer.close = AsyncMock()
+        mock_consumer._set_log_tracking_id = AsyncMock()
+
+        with patch.object(
+            mock_consumer, "handle_actions", new_callable=AsyncMock
+        ) as mock_handle_actions:
+            await mock_consumer.receive(
+                text_data='{"type": "Action", '
+                '"activation_instance_id": 123, '
+                '"activation_id": 123, '
+                '"action": "run_playbook", '
+                '"action_uuid": "uuid-1", '
+                '"run_at": "2024-01-01T00:00:00Z", '
+                '"ruleset": "test_ruleset", '
+                '"ruleset_uuid": "uuid-2", '
+                '"rule": "test_rule", '
+                '"rule_uuid": "uuid-3"}'
+            )
+
+            mock_handle_actions.assert_called_once()
+            mock_consumer.close.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_malformed_auth_header_closes_connection(
+        self, mock_consumer
+    ):
+        """Test malformed UTF-8 in auth header triggers failure.
+
+        Regression test for UnicodeDecodeError not being caught.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        # Set malformed UTF-8 bytes in authorization header
+        mock_consumer.scope["headers"] = [
+            (b"authorization", b"Bearer \xff\xfe invalid-utf8")
+        ]
+
+        # Mock the close method and _set_log_tracking_id
+        mock_consumer.close = AsyncMock()
+        mock_consumer._set_log_tracking_id = AsyncMock()
+
+        # Mock handle_jobs to verify it's NOT called on rejection
+        with patch.object(
+            mock_consumer, "handle_jobs", new_callable=AsyncMock
+        ) as mock_handle_jobs:
+            # Try to receive a message
+            await mock_consumer.receive(
+                text_data='{"type": "Job", "activation_instance_id": 123, '
+                '"ansible_rulebook_id": 123, '
+                '"job_id": "test-job-123", "name": "Test Job", '
+                '"action": "run_playbook", "ruleset": "test_ruleset", '
+                '"hosts": "localhost", "rule": "test_rule"}'
+            )
+
+            # Verify message was NOT dispatched
+            mock_handle_jobs.assert_not_called()
+            # Verify connection was closed with auth failure code
+            mock_consumer.close.assert_called_once_with(code=4003)


### PR DESCRIPTION
WebSocket Authentication

This commit adds security enhancements to ensure JWT tokens are scoped to specific activation instances, preventing token reuse across different instances. It also implements secure token refresh with scope preservation and backward- compatible legacy token support with actionable warnings.

https://redhat.atlassian.net/browse/AAP-83971

Key changes:
- Add activation_instance_id to JWT token payload (supports int and UUID)
- Validate token scope in WebSocket consumer before processing messages
- Implement secure token refresh that preserves activation_instance_id scope
- Support backward compatibility with legacy tokens (no forced logout)
- Add actionable warnings for legacy tokens with activation name
- Implement token payload caching for performance

Security improvements:
- Tokens cannot be used for different activation instances
- Token refresh preserves scope (prevents scope escalation vulnerability)
- Two-layer validation: middleware (signature/expiry) + consumer (scope)
- Automatic revocation via database existence checks
- Comprehensive error logging for audit trails

Token Refresh Security:
- RefreshTokenSerializer extracts activation_instance_id from refresh token
- New access tokens preserve the scope from refresh token (trusted source)
- Prevents privilege escalation by not accepting client-provided scope
- Legacy refresh tokens continue to work (no scope added)

Backward Compatibility:
- Legacy tokens without activation_instance_id are accepted with warnings
- Warnings logged once per connection to avoid log spam
- Warnings include activation name for easy operator action
- No event loss, no forced disconnection

Files modified:
- src/aap_eda/services/auth.py: Token creation and validation
- src/aap_eda/services/activation/engine/common.py: Pass activation_instance_id
- src/aap_eda/wsapi/consumers.py: Token scope validation with async warnings
- src/aap_eda/api/serializers/auth.py: Extract scope from refresh tokens
- src/aap_eda/api/views/auth.py: Preserve scope in token refresh endpoint

Tests added:
- 9 tests for auth service (token creation, validation, scope checking)
- 14 tests for consumer validation (scope matching, legacy token warnings)
- 3 tests for token refresh endpoint (scope preservation, legacy handling)
- 7 tests for RefreshTokenSerializer (scope extraction, error handling)
- Total: 33 passing tests

All code formatted with black, sorted with isort, and linted with flake8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
<!-- If applicable, provide a link to the issue that is being addressed -->

<!-- What is being changed? -->
<!-- Why is this change needed? -->
<!-- How does this change address the issue? -->
<!-- Does this change introduce any new dependencies, blockers or breaking changes? -->
<!-- How it can be tested? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * JWT access/refresh tokens now optionally include an activation-instance scope claim.
  * Refreshing a token preserves any existing activation-instance scope when issuing the new access token.
  * WebSocket requests validate that the token scope matches the message’s activation context; mismatches now fail authentication (connection closes with auth error). Legacy tokens without scope are allowed with a one-time security warning.

* **Tests**
  * Added/expanded integration coverage for scoped vs legacy refresh behavior (including UUID/non-UUID forms) and WebSocket authorization/scope enforcement (including malformed headers).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->