### PR TITLE
fix: sonar issues - Exclude awx.py from complexity rule.

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -128,13 +128,16 @@ sonar.cpd.exclusions=\
 # =============================================================================
 
 # Ignore specific rules for certain file patterns
-sonar.issue.ignore.multicriteria=e1,e2
+sonar.issue.ignore.multicriteria=e1,e2,e3
 # Ignore "should be a variable" in migrations
 sonar.issue.ignore.multicriteria.e1.ruleKey=python:S1192
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/migrations/**/*
 # Ignore complexity issues in migrations
 sonar.issue.ignore.multicriteria.e2.ruleKey=python:S3776
 sonar.issue.ignore.multicriteria.e2.resourceKey=**/migrations/**/*
+# Ignore complexity in awx.py (code copied from AWX repo)
+sonar.issue.ignore.multicriteria.e3.ruleKey=python:S3776
+sonar.issue.ignore.multicriteria.e3.resourceKey=src/aap_eda/core/utils/awx.py
 
 # =============================================================================
 # GITHUB INTEGRATION


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AAP-77394

One of multiple PRs addressing sonar quality gate issues. This particular PR excludes awx.py from counting towards the sonar computational complexity rule. This is because the function was originally copied from AWX. As such I didn't want to modify it and lose track of it's origin and function. 

Attached is a document describing the actions taken here.

[sonarcloud-remediation-report.md](https://github.com/user-attachments/files/29103602/sonarcloud-remediation-report.md)

Assisted-by: Claude