### PR TITLE
throws a 400 if rulebook does not exist

### DIFF
--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -761,6 +761,8 @@ class ActivationCopySerializer(serializers.ModelSerializer):
         validators.validate_k8s_pod_tolerations(
             activation.k8s_pod_tolerations or []
         )
+        validators.check_if_rulebook_exists(activation.rulebook_id)
+
         copied_data = {
             "name": self.validated_data["name"],
             "description": activation.description,

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -1375,6 +1375,30 @@ def test_copy_activation_invalid_body(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
+@pytest.mark.django_db
+def test_copy_activation_with_deleted_rulebook(
+    activation_payload: Dict[str, Any],
+    default_rulebook: models.Rulebook,
+    admin_client: APIClient,
+):
+    activation_payload["is_enabled"] = False
+    response = admin_client.post(
+        f"{api_url_v1}/activations/", data=activation_payload
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    a_id = response.data["id"]
+
+    activation = models.Activation.objects.get(id=a_id)
+    activation.rulebook = None
+    activation.save(update_fields=["rulebook"])
+
+    response = admin_client.post(
+        f"{api_url_v1}/activations/{a_id}/copy/",
+        data={"name": "copied-activation"},
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
 # ------------------------------------------------------------------
 # Project sync dependency tests
 # ------------------------------------------------------------------


### PR DESCRIPTION
When copying a rulebook activation we now throw a 400 error if the rulebook id doesn't exist. 
AAP-78605


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Copying an activation now correctly returns a clear bad-request response when the activation’s associated rulebook is no longer available.
  * Adds an integration test to ensure the copy endpoint rejects activations with cleared rulebook links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->