### PR TITLE
fix: sonar issues: Add test cases to SCM.py and replace regex with the ansible runner API for event reading

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -8,7 +8,7 @@ runs:
       run: pipx install poetry
 
     - name: Set up Python
-      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: '3.11'
         cache: 'poetry'

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -12,7 +12,7 @@ runs:
       run: pipx install poetry
 
     - name: Set up Python
-      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ inputs.python-version }}
         cache: 'poetry'

--- a/.github/actions/validate-openapi-spec/action.yml
+++ b/.github/actions/validate-openapi-spec/action.yml
@@ -8,7 +8,7 @@ runs:
       run: pipx install poetry
 
     - name: Set up Python
-      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: '3.11'
         cache: 'poetry'

--- a/.github/workflows/autoupdate-poetry.yml
+++ b/.github/workflows/autoupdate-poetry.yml
@@ -18,7 +18,7 @@ jobs:
       lock-changed: ${{ steps.lock-changed.outputs.lock-changed }}
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           ref: main

--- a/.github/workflows/autoupdate-poetry.yml
+++ b/.github/workflows/autoupdate-poetry.yml
@@ -24,7 +24,7 @@ jobs:
           ref: main
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -98,7 +98,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -171,7 +171,7 @@ jobs:
           token: ${{ secrets.EDA_QA_GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
@@ -274,7 +274,7 @@ jobs:
           token: ${{ secrets.EDA_QA_GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -134,7 +134,7 @@ jobs:
             });
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           repository: ${{ github.event_name == 'issue_comment' && needs.check-trigger.outputs.pr_repo || github.repository }}
@@ -161,7 +161,7 @@ jobs:
           done
 
       - name: Fetch test suite
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -250,7 +250,7 @@ jobs:
     environment: ${{ github.event_name == 'issue_comment' && 'protected' || '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           repository: ${{ github.event_name == 'issue_comment' && needs.check-trigger.outputs.pr_repo || github.repository }}
@@ -264,7 +264,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Fetch test suite
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -40,7 +40,7 @@ jobs:
           done
 
       - name: Fetch test suite
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -49,7 +49,7 @@ jobs:
           token: ${{ secrets.EDA_QA_GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.9"
 

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -37,7 +37,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' && 
       github.event.workflow_run.event == 'pull_request'
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -181,7 +181,7 @@ jobs:
       github.event.workflow_run.event == 'push' &&
       github.repository == 'ansible/eda-server'
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/sync-openapi-spec.yml
+++ b/.github/workflows/sync-openapi-spec.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout spec repo
         id: checkout_spec_repo
         continue-on-error: true
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ secrets.OPENAPI_SPEC_REPO }}
           ref: ${{ steps.branch_map.outputs.spec_branch }}

--- a/.github/workflows/ui-e2e.yml
+++ b/.github/workflows/ui-e2e.yml
@@ -127,7 +127,7 @@ jobs:
             });
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           repository: ${{ github.event_name == 'issue_comment' && needs.check-trigger.outputs.pr_repo || github.repository }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -931,7 +931,7 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-ansible-base"
-version = "2026.6.9.0.dev4+g67526308c"
+version = "2026.7.22.0.dev29+gc70965eed"
 description = "A Django app used by ansible services"
 optional = false
 python-versions = ">=3.11"
@@ -971,7 +971,7 @@ testing = ["cryptography", "pytest", "pytest-django"]
 type = "git"
 url = "https://github.com/ansible/django-ansible-base.git"
 reference = "devel"
-resolved_reference = "2fdc8291ca7d190b0a44b25ad6c7ca28fca0a9bb"
+resolved_reference = "c70965eed60a23922b4ab98aae2336a98cd8a688"
 
 [[package]]
 name = "django-crum"

--- a/src/aap_eda/services/project/scm.py
+++ b/src/aap_eda/services/project/scm.py
@@ -380,12 +380,8 @@ class GitAnsibleRunnerExecutor:
                 )
                 if match:
                     return match.group(1)
-            match = re.search(
-                r'fatal: \[localhost\]: FAILED! => \{.+"msg": (.+)\}',
-                outputs.getvalue(),
-            )
-            if match:
-                err_msg = match.group(1)
+            err_msg = self._extract_error_msg(outputs.getvalue())
+            if err_msg:
                 if "Authentication failed" in err_msg:
                     raise ScmAuthenticationError("Authentication failed")
                 if (
@@ -396,6 +392,29 @@ class GitAnsibleRunnerExecutor:
                     raise ScmAuthenticationError(err_msg)
                 raise ScmError(f"{self.ERROR_PREFIX} {err_msg}")
             raise ScmError(f"{self.ERROR_PREFIX} {outputs.getvalue().strip()}")
+
+    @staticmethod
+    def _extract_error_msg(output):
+        """Extract msg value from Ansible FAILED output.
+
+        Looks for the fatal error marker, then finds the "msg"
+        key and extracts its value up to the last closing brace.
+        Handles msg values that contain } characters.
+        """
+        fatal_marker = "fatal: [localhost]: FAILED! => {"
+        fatal_idx = output.find(fatal_marker)
+        if fatal_idx < 0:
+            return None
+        block = output[fatal_idx + len(fatal_marker) :]
+        msg_marker = '"msg": '
+        msg_idx = block.find(msg_marker)
+        if msg_idx < 0:
+            return None
+        msg_value = block[msg_idx + len(msg_marker) :]
+        brace_idx = msg_value.rfind("}")
+        if brace_idx < 0:
+            return None
+        return msg_value[:brace_idx]
 
 
 def is_refspec_valid(refspec: str, is_branch: bool) -> bool:

--- a/src/aap_eda/services/project/scm.py
+++ b/src/aap_eda/services/project/scm.py
@@ -14,10 +14,8 @@
 from __future__ import annotations
 
 import contextlib
-import io
 import logging
 import os
-import re
 import shutil
 import subprocess
 import tempfile
@@ -365,22 +363,20 @@ class GitAnsibleRunnerExecutor:
             os.makedirs(env_dir)
             safe_yaml.dump(os.path.join(env_dir, "extravars"), extra_vars)
 
-            outputs = io.StringIO()
-            with contextlib.redirect_stdout(outputs):
-                runner = ansible_runner.run(
-                    private_data_dir=data_dir,
-                    playbook=PLAYBOOK,
-                    envvars=env_vars,
-                )
+            runner = ansible_runner.run(
+                private_data_dir=data_dir,
+                playbook=PLAYBOOK,
+                envvars=env_vars,
+                quiet=True,
+            )
+
+            events = list(runner.events)
 
             if runner.rc == 0:
-                match = re.search(
-                    r'"msg": "Repository Version ([0-9a-fA-F]+)"',
-                    outputs.getvalue(),
-                )
-                if match:
-                    return match.group(1)
-            err_msg = self._extract_error_msg(outputs.getvalue())
+                git_hash = self._extract_git_hash(events)
+                if git_hash:
+                    return git_hash
+            err_msg = self._extract_error_msg(events)
             if err_msg:
                 if "Authentication failed" in err_msg:
                     raise ScmAuthenticationError("Authentication failed")
@@ -391,30 +387,29 @@ class GitAnsibleRunnerExecutor:
                     err_msg = "Credentials not provided or incorrect"
                     raise ScmAuthenticationError(err_msg)
                 raise ScmError(f"{self.ERROR_PREFIX} {err_msg}")
-            raise ScmError(f"{self.ERROR_PREFIX} {outputs.getvalue().strip()}")
+            raise ScmError(self.ERROR_PREFIX)
 
     @staticmethod
-    def _extract_error_msg(output):
-        """Extract msg value from Ansible FAILED output.
+    def _extract_git_hash(events):
+        for event in events:
+            if event.get("event") != "runner_on_ok":
+                continue
+            res = event.get("event_data", {}).get("res", {})
+            scm_version = res.get("ansible_facts", {}).get("scm_version")
+            if scm_version:
+                return scm_version
+        return None
 
-        Looks for the fatal error marker, then finds the "msg"
-        key and extracts its value up to the last closing brace.
-        Handles msg values that contain } characters.
-        """
-        fatal_marker = "fatal: [localhost]: FAILED! => {"
-        fatal_idx = output.find(fatal_marker)
-        if fatal_idx < 0:
-            return None
-        block = output[fatal_idx + len(fatal_marker) :]
-        msg_marker = '"msg": '
-        msg_idx = block.find(msg_marker)
-        if msg_idx < 0:
-            return None
-        msg_value = block[msg_idx + len(msg_marker) :]
-        brace_idx = msg_value.rfind("}")
-        if brace_idx < 0:
-            return None
-        return msg_value[:brace_idx]
+    @staticmethod
+    def _extract_error_msg(events):
+        for event in events:
+            if event.get("event") != "runner_on_failed":
+                continue
+            res = event.get("event_data", {}).get("res", {})
+            msg = res.get("msg")
+            if msg:
+                return msg
+        return None
 
 
 def is_refspec_valid(refspec: str, is_branch: bool) -> bool:

--- a/tests/integration/api/test_root.py
+++ b/tests/integration/api/test_root.py
@@ -65,6 +65,7 @@ from tests.integration.constants import api_url_v1
                 "/service-index/metadata/",
                 "/service-index/object-delete/",
                 "/service-index/resources/",
+                "/service-index/resources/bulk-update/",
                 "/service-index/resource-types/",
                 "/service-index/role-types/",
                 "/service-index/role-permissions/",

--- a/tests/unit/test_scm.py
+++ b/tests/unit/test_scm.py
@@ -452,99 +452,78 @@ def test_git_clone_ssh_key(ssh_credential: models.EdaCredential, url: str):
 
 
 #################################################################
+# Tests for GitAnsibleRunnerExecutor._extract_git_hash
+#################################################################
+
+_extract_hash = scm.GitAnsibleRunnerExecutor._extract_git_hash
+_extract_error = scm.GitAnsibleRunnerExecutor._extract_error_msg
+
+
+def _ok_event(res=None):
+    return {"event": "runner_on_ok", "event_data": {"res": res or {}}}
+
+
+def _failed_event(res=None):
+    return {
+        "event": "runner_on_failed",
+        "event_data": {"res": res or {}},
+    }
+
+
+def test_extract_git_hash_from_set_fact():
+    events = [
+        _ok_event({"changed": True}),
+        _ok_event(
+            {
+                "ansible_facts": {
+                    "scm_version": "abc123def456",
+                },
+            }
+        ),
+        _ok_event({"msg": "Repository Version abc123def456"}),
+    ]
+    assert _extract_hash(events) == "abc123def456"
+
+
+def test_extract_git_hash_no_matching_event():
+    events = [
+        _ok_event({"changed": True}),
+        {"event": "runner_on_start", "event_data": {}},
+    ]
+    assert _extract_hash(events) is None
+
+
+def test_extract_git_hash_empty_events():
+    assert _extract_hash([]) is None
+
+
+#################################################################
 # Tests for GitAnsibleRunnerExecutor._extract_error_msg
 #################################################################
 
-_extract = scm.GitAnsibleRunnerExecutor._extract_error_msg
+
+def test_extract_error_msg_from_failed_event():
+    events = [_failed_event({"msg": "Authentication failed"})]
+    assert _extract_error(events) == "Authentication failed"
 
 
-def test_extract_error_msg_standard():
-    output = (
-        "fatal: [localhost]: FAILED! => "
-        '{"changed": false, "msg": "Authentication failed"}'
-    )
-    assert _extract(output) == '"Authentication failed"'
+def test_extract_error_msg_no_failure_event():
+    events = [_ok_event({"changed": True})]
+    assert _extract_error(events) is None
 
 
-def test_extract_error_msg_multiple_keys():
-    output = (
-        "fatal: [localhost]: FAILED! => "
-        '{"changed": false, "rc": 1, '
-        '"msg": "Could not clone repo"}'
-    )
-    assert _extract(output) == '"Could not clone repo"'
+def test_extract_error_msg_missing_msg_key():
+    events = [_failed_event({"changed": False, "rc": 1})]
+    assert _extract_error(events) is None
 
 
-def test_extract_error_msg_only_key():
-    output = (
-        "fatal: [localhost]: FAILED! => " '{"msg": "could not read Username"}'
-    )
-    assert _extract(output) == '"could not read Username"'
+def test_extract_error_msg_empty_msg():
+    events = [_failed_event({"msg": ""})]
+    assert _extract_error(events) is None
 
 
-def test_extract_error_msg_brace_in_value():
-    output = (
-        "fatal: [localhost]: FAILED! => "
-        '{"changed": false, '
-        '"msg": "failed with {error: bad}"}'
-    )
-    assert _extract(output) == '"failed with {error: bad}"'
-
-
-def test_extract_error_msg_success_returns_none():
-    output = 'ok: [localhost]: SUCCESS => {"changed": true}'
-    assert _extract(output) is None
-
-
-def test_extract_error_msg_no_msg_key_returns_none():
-    output = (
-        "fatal: [localhost]: FAILED! => "
-        '{"changed": false, "error": "something"}'
-    )
-    assert _extract(output) is None
-
-
-def test_extract_error_msg_empty():
-    output = "fatal: [localhost]: FAILED! => " '{"changed": false, "msg": ""}'
-    assert _extract(output) == '""'
-
-
-def test_extract_error_msg_multiline():
-    output = (
-        "some log output\n"
-        "fatal: [localhost]: FAILED! => "
-        '{"msg": "real error"}'
-    )
-    assert _extract(output) == '"real error"'
-
-
-def test_extract_error_msg_auth_failed():
-    output = (
-        "fatal: [localhost]: FAILED! => "
-        '{"msg": "Authentication failed for user@host"}'
-    )
-    assert _extract(output) == '"Authentication failed for user@host"'
-
-
-def test_extract_error_msg_username_prompt():
-    output = (
-        "fatal: [localhost]: FAILED! => "
-        '{"msg": "could not read Username for '
-        "'https://git.example.com'\"}"
-    )
-    assert _extract(output) == (
-        '"could not read Username for ' "'https://git.example.com'\""
-    )
-
-
-def test_extract_error_msg_no_closing_brace():
-    output = 'fatal: [localhost]: FAILED! => {"msg": "truncated output'
-    assert _extract(output) is None
-
-
-def test_extract_error_msg_fatal_marker_only():
-    output = "fatal: [localhost]: FAILED! => {"
-    assert _extract(output) is None
+def test_extract_error_msg_empty_events():
+    assert _extract_error([]) is None
 
 
 @pytest.mark.django_db
@@ -712,70 +691,61 @@ def test_add_gpg_key_failure():
 #################################################################
 
 
-def _run_executor(runner_rc, runner_stdout):
+def _run_executor(runner_rc, events):
     """Helper to run GitAnsibleRunnerExecutor with mocked runner."""
     executor = scm.GitAnsibleRunnerExecutor()
     mock_runner = mock.Mock()
     mock_runner.rc = runner_rc
-
-    def fake_run(**kwargs):
-        # Write to the captured stdout so redirect_stdout picks it up
-        import sys
-
-        sys.stdout.write(runner_stdout)
-        return mock_runner
+    mock_runner.events = events
 
     with mock.patch(
         "aap_eda.services.project.scm.ansible_runner.run",
-        side_effect=fake_run,
+        return_value=mock_runner,
     ):
         return executor(
-            extra_vars={"project_path": "/tmp"},
+            extra_vars={"project_path": "/mock/path"},
             env_vars={},
         )
 
 
 def test_executor_call_success():
-    output = '"msg": "Repository Version abc123def456"'
-    result = _run_executor(0, output)
+    events = [
+        _ok_event({"ansible_facts": {"scm_version": "abc123def456"}}),
+    ]
+    result = _run_executor(0, events)
     assert result == "abc123def456"
 
 
 def test_executor_call_success_no_version():
+    events = [_ok_event({"changed": True})]
     with pytest.raises(scm.ScmError) as exc_info:
-        _run_executor(0, "some output without version")
+        _run_executor(0, events)
     assert "Project Import Error:" in str(exc_info.value)
 
 
 def test_executor_call_auth_failure():
-    output = (
-        "fatal: [localhost]: FAILED! => "
-        '{"changed": false, "msg": "Authentication failed"}'
-    )
+    events = [_failed_event({"msg": "Authentication failed"})]
     with pytest.raises(scm.ScmAuthenticationError):
-        _run_executor(1, output)
+        _run_executor(1, events)
 
 
 def test_executor_call_username_prompt():
-    output = (
-        "fatal: [localhost]: FAILED! => " '{"msg": "could not read Username"}'
-    )
+    events = [_failed_event({"msg": "could not read Username"})]
     with pytest.raises(scm.ScmAuthenticationError) as exc_info:
-        _run_executor(1, output)
+        _run_executor(1, events)
     assert "Credentials not provided" in str(exc_info.value)
 
 
 def test_executor_call_generic_error():
-    output = (
-        "fatal: [localhost]: FAILED! => " '{"msg": "repository not found"}'
-    )
+    events = [_failed_event({"msg": "repository not found"})]
     with pytest.raises(scm.ScmError) as exc_info:
-        _run_executor(1, output)
+        _run_executor(1, events)
     assert "Project Import Error:" in str(exc_info.value)
     assert "repository not found" in str(exc_info.value)
 
 
-def test_executor_call_no_fatal_output():
+def test_executor_call_no_error_event():
+    events = [_ok_event({"changed": True})]
     with pytest.raises(scm.ScmError) as exc_info:
-        _run_executor(1, "some generic failure output")
+        _run_executor(1, events)
     assert "Project Import Error:" in str(exc_info.value)

--- a/tests/unit/test_scm.py
+++ b/tests/unit/test_scm.py
@@ -157,6 +157,44 @@ def test_git_clone_sets_proxy_env_during_credential_resolution(
 
 
 @pytest.mark.django_db
+def test_set_proxy_environ_restores_existing_vars(
+    credential: models.EdaCredential,
+):
+    """Pre-existing proxy env vars are restored after clone."""
+    executor = mock.MagicMock()
+    original_value = "http://original-proxy:8080"
+
+    for key in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ[key] = original_value
+
+    try:
+        with tempfile.TemporaryDirectory() as dest_path:
+            scm.ScmRepository.clone(
+                "https://git.example.com/repo.git",
+                dest_path,
+                credential=credential,
+                proxy="http://override-proxy:3128",
+                _executor=executor,
+            )
+
+        for key in (
+            "http_proxy",
+            "https_proxy",
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+        ):
+            assert os.environ.get(key) == original_value
+    finally:
+        for key in (
+            "http_proxy",
+            "https_proxy",
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+        ):
+            os.environ.pop(key, None)
+
+
+@pytest.mark.django_db
 def test_git_clone_leak_password(
     credential: models.EdaCredential,
 ):
@@ -497,3 +535,107 @@ def test_extract_error_msg_username_prompt():
     assert _extract(output) == (
         '"could not read Username for ' "'https://git.example.com'\""
     )
+
+
+def test_extract_error_msg_no_closing_brace():
+    output = 'fatal: [localhost]: FAILED! => {"msg": "truncated output'
+    assert _extract(output) is None
+
+
+def test_extract_error_msg_fatal_marker_only():
+    output = "fatal: [localhost]: FAILED! => {"
+    assert _extract(output) is None
+
+
+@pytest.mark.django_db
+def test_git_clone_gpg_credential(
+    default_organization: models.Organization,
+):
+    """GPG credential sets up verify_commit and GNUPGHOME."""
+    gpg_credential = models.EdaCredential.objects.create(
+        name="test-gpg-credential",
+        inputs={"gpg_public_key": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n"},
+        organization=default_organization,
+    )
+    gpg_credential.refresh_from_db()
+    executor = mock.MagicMock()
+
+    with mock.patch.object(scm.ScmRepository, "add_gpg_key"):
+        with tempfile.TemporaryDirectory() as dest_path:
+            scm.ScmRepository.clone(
+                "https://git.example.com/repo.git",
+                dest_path,
+                gpg_credential=gpg_credential,
+                _executor=executor,
+            )
+            call_kwargs = executor.call_args
+            assert call_kwargs[1]["extra_vars"]["verify_commit"] == "true"
+            assert "GNUPGHOME" in call_kwargs[1]["env_vars"]
+
+
+@pytest.mark.django_db
+def test_git_clone_creates_directory():
+    """Clone creates the destination directory if it doesn't exist."""
+    executor = mock.MagicMock()
+
+    with tempfile.TemporaryDirectory() as parent:
+        dest_path = os.path.join(parent, "nonexistent")
+        scm.ScmRepository.clone(
+            "https://git.example.com/repo.git",
+            dest_path,
+            _executor=executor,
+        )
+        assert os.path.isdir(dest_path)
+
+
+@pytest.mark.django_db
+def test_git_clone_decrypt_key_file(
+    default_organization: models.Organization,
+):
+    """Clone calls decrypt_key_file when ssh_key_unlock is provided."""
+    credential = models.EdaCredential.objects.create(
+        name="test-ssh-unlock",
+        inputs={
+            "ssh_key_data": "-----BEGIN OPENSSH PRIVATE KEY-----\n",
+            "ssh_key_unlock": "passphrase",
+        },
+        organization=default_organization,
+    )
+    credential.refresh_from_db()
+    executor = mock.MagicMock()
+
+    with mock.patch.object(
+        scm.ScmRepository, "decrypt_key_file"
+    ) as mock_decrypt:
+        with tempfile.TemporaryDirectory() as dest_path:
+            scm.ScmRepository.clone(
+                "git@git.example.com:repo.git",
+                dest_path,
+                credential=credential,
+                _executor=executor,
+            )
+        mock_decrypt.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_git_clone_gpg_add_key(
+    default_organization: models.Organization,
+):
+    """Clone calls add_gpg_key when gpg_credential is provided."""
+    gpg_credential = models.EdaCredential.objects.create(
+        name="test-gpg",
+        inputs={"gpg_public_key": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n"},
+        organization=default_organization,
+    )
+    gpg_credential.refresh_from_db()
+    executor = mock.MagicMock()
+
+    with mock.patch.object(scm.ScmRepository, "add_gpg_key") as mock_add_gpg:
+        with tempfile.TemporaryDirectory() as dest_path:
+            scm.ScmRepository.clone(
+                "https://git.example.com/repo.git",
+                dest_path,
+                gpg_credential=gpg_credential,
+                _executor=executor,
+            )
+        mock_add_gpg.assert_called_once()

--- a/tests/unit/test_scm.py
+++ b/tests/unit/test_scm.py
@@ -411,3 +411,89 @@ def test_git_clone_ssh_key(ssh_credential: models.EdaCredential, url: str):
         # SSH key file must be provided
         assert "key_file" in extra_vars
         assert extra_vars["key_file"]  # non-empty path
+
+
+#################################################################
+# Tests for GitAnsibleRunnerExecutor._extract_error_msg
+#################################################################
+
+_extract = scm.GitAnsibleRunnerExecutor._extract_error_msg
+
+
+def test_extract_error_msg_standard():
+    output = (
+        "fatal: [localhost]: FAILED! => "
+        '{"changed": false, "msg": "Authentication failed"}'
+    )
+    assert _extract(output) == '"Authentication failed"'
+
+
+def test_extract_error_msg_multiple_keys():
+    output = (
+        "fatal: [localhost]: FAILED! => "
+        '{"changed": false, "rc": 1, '
+        '"msg": "Could not clone repo"}'
+    )
+    assert _extract(output) == '"Could not clone repo"'
+
+
+def test_extract_error_msg_only_key():
+    output = (
+        "fatal: [localhost]: FAILED! => " '{"msg": "could not read Username"}'
+    )
+    assert _extract(output) == '"could not read Username"'
+
+
+def test_extract_error_msg_brace_in_value():
+    output = (
+        "fatal: [localhost]: FAILED! => "
+        '{"changed": false, '
+        '"msg": "failed with {error: bad}"}'
+    )
+    assert _extract(output) == '"failed with {error: bad}"'
+
+
+def test_extract_error_msg_success_returns_none():
+    output = 'ok: [localhost]: SUCCESS => {"changed": true}'
+    assert _extract(output) is None
+
+
+def test_extract_error_msg_no_msg_key_returns_none():
+    output = (
+        "fatal: [localhost]: FAILED! => "
+        '{"changed": false, "error": "something"}'
+    )
+    assert _extract(output) is None
+
+
+def test_extract_error_msg_empty():
+    output = "fatal: [localhost]: FAILED! => " '{"changed": false, "msg": ""}'
+    assert _extract(output) == '""'
+
+
+def test_extract_error_msg_multiline():
+    output = (
+        "some log output\n"
+        "fatal: [localhost]: FAILED! => "
+        '{"msg": "real error"}'
+    )
+    assert _extract(output) == '"real error"'
+
+
+def test_extract_error_msg_auth_failed():
+    output = (
+        "fatal: [localhost]: FAILED! => "
+        '{"msg": "Authentication failed for user@host"}'
+    )
+    assert _extract(output) == '"Authentication failed for user@host"'
+
+
+def test_extract_error_msg_username_prompt():
+    output = (
+        "fatal: [localhost]: FAILED! => "
+        '{"msg": "could not read Username for '
+        "'https://git.example.com'\"}"
+    )
+    assert _extract(output) == (
+        '"could not read Username for ' "'https://git.example.com'\""
+    )

--- a/tests/unit/test_scm.py
+++ b/tests/unit/test_scm.py
@@ -42,7 +42,23 @@ def ssh_credential(
 ) -> models.EdaCredential:
     credential = models.EdaCredential.objects.create(
         name="test-ssh-credential",
-        inputs={"ssh_key_data": "-----BEGIN OPENSSH PRIVATE KEY-----\n"},
+        inputs={
+            "ssh_key_data": "-----BEGIN OPENSSH PRIVATE KEY-----\n",
+            "ssh_key_unlock": "passphrase",
+        },
+        organization=default_organization,
+    )
+    credential.refresh_from_db()
+    return credential
+
+
+@pytest.fixture
+def gpg_credential(
+    default_organization: models.Organization,
+) -> models.EdaCredential:
+    credential = models.EdaCredential.objects.create(
+        name="test-gpg-credential",
+        inputs={"gpg_public_key": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n"},
         organization=default_organization,
     )
     credential.refresh_from_db()
@@ -159,39 +175,31 @@ def test_git_clone_sets_proxy_env_during_credential_resolution(
 @pytest.mark.django_db
 def test_set_proxy_environ_restores_existing_vars(
     credential: models.EdaCredential,
+    monkeypatch,
 ):
     """Pre-existing proxy env vars are restored after clone."""
     executor = mock.MagicMock()
     original_value = "http://original-proxy:8080"
 
     for key in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
-        os.environ[key] = original_value
+        monkeypatch.setenv(key, original_value)
 
-    try:
-        with tempfile.TemporaryDirectory() as dest_path:
-            scm.ScmRepository.clone(
-                "https://git.example.com/repo.git",
-                dest_path,
-                credential=credential,
-                proxy="http://override-proxy:3128",
-                _executor=executor,
-            )
+    with tempfile.TemporaryDirectory() as dest_path:
+        scm.ScmRepository.clone(
+            "https://git.example.com/repo.git",
+            dest_path,
+            credential=credential,
+            proxy="http://override-proxy:3128",
+            _executor=executor,
+        )
 
-        for key in (
-            "http_proxy",
-            "https_proxy",
-            "HTTP_PROXY",
-            "HTTPS_PROXY",
-        ):
-            assert os.environ.get(key) == original_value
-    finally:
-        for key in (
-            "http_proxy",
-            "https_proxy",
-            "HTTP_PROXY",
-            "HTTPS_PROXY",
-        ):
-            os.environ.pop(key, None)
+    for key in (
+        "http_proxy",
+        "https_proxy",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+    ):
+        assert os.environ.get(key) == original_value
 
 
 @pytest.mark.django_db
@@ -431,24 +439,28 @@ def test_is_refspec_valid(ref: str, is_branch: bool, expected: bool):
 def test_git_clone_ssh_key(ssh_credential: models.EdaCredential, url: str):
     """Clone with SSH key preserves URL and passes key_file."""
     executor = mock.MagicMock()
-    with tempfile.TemporaryDirectory() as dest_path:
-        scm.ScmRepository.clone(
-            url,
-            dest_path,
-            credential=ssh_credential,
-            depth=1,
-            _executor=executor,
-        )
-        executor.assert_called_once()
-        call_kwargs = executor.call_args
-        extra_vars = call_kwargs.kwargs["extra_vars"]
+    with mock.patch.object(
+        scm.ScmRepository, "decrypt_key_file"
+    ) as mock_decrypt:
+        with tempfile.TemporaryDirectory() as dest_path:
+            scm.ScmRepository.clone(
+                url,
+                dest_path,
+                credential=ssh_credential,
+                depth=1,
+                _executor=executor,
+            )
+            executor.assert_called_once()
+            call_kwargs = executor.call_args
+            extra_vars = call_kwargs.kwargs["extra_vars"]
 
-        # URL must reach the executor unchanged
-        assert extra_vars["scm_url"] == url
+            # URL must reach the executor unchanged
+            assert extra_vars["scm_url"] == url
 
-        # SSH key file must be provided
-        assert "key_file" in extra_vars
-        assert extra_vars["key_file"]  # non-empty path
+            # SSH key file must be provided
+            assert "key_file" in extra_vars
+            assert extra_vars["key_file"]  # non-empty path
+        mock_decrypt.assert_called_once()
 
 
 #################################################################
@@ -528,18 +540,12 @@ def test_extract_error_msg_empty_events():
 
 @pytest.mark.django_db
 def test_git_clone_gpg_credential(
-    default_organization: models.Organization,
+    gpg_credential: models.EdaCredential,
 ):
     """GPG credential sets up verify_commit and GNUPGHOME."""
-    gpg_credential = models.EdaCredential.objects.create(
-        name="test-gpg-credential",
-        inputs={"gpg_public_key": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n"},
-        organization=default_organization,
-    )
-    gpg_credential.refresh_from_db()
     executor = mock.MagicMock()
 
-    with mock.patch.object(scm.ScmRepository, "add_gpg_key"):
+    with mock.patch.object(scm.ScmRepository, "add_gpg_key") as mock_add_gpg:
         with tempfile.TemporaryDirectory() as dest_path:
             scm.ScmRepository.clone(
                 "https://git.example.com/repo.git",
@@ -550,6 +556,7 @@ def test_git_clone_gpg_credential(
             call_kwargs = executor.call_args
             assert call_kwargs[1]["extra_vars"]["verify_commit"] == "true"
             assert "GNUPGHOME" in call_kwargs[1]["env_vars"]
+        mock_add_gpg.assert_called_once()
 
 
 @pytest.mark.django_db
@@ -565,59 +572,6 @@ def test_git_clone_creates_directory():
             _executor=executor,
         )
         assert os.path.isdir(dest_path)
-
-
-@pytest.mark.django_db
-def test_git_clone_decrypt_key_file(
-    default_organization: models.Organization,
-):
-    """Clone calls decrypt_key_file when ssh_key_unlock is provided."""
-    credential = models.EdaCredential.objects.create(
-        name="test-ssh-unlock",
-        inputs={
-            "ssh_key_data": "-----BEGIN OPENSSH PRIVATE KEY-----\n",
-            "ssh_key_unlock": "passphrase",
-        },
-        organization=default_organization,
-    )
-    credential.refresh_from_db()
-    executor = mock.MagicMock()
-
-    with mock.patch.object(
-        scm.ScmRepository, "decrypt_key_file"
-    ) as mock_decrypt:
-        with tempfile.TemporaryDirectory() as dest_path:
-            scm.ScmRepository.clone(
-                "git@git.example.com:repo.git",
-                dest_path,
-                credential=credential,
-                _executor=executor,
-            )
-        mock_decrypt.assert_called_once()
-
-
-@pytest.mark.django_db
-def test_git_clone_gpg_add_key(
-    default_organization: models.Organization,
-):
-    """Clone calls add_gpg_key when gpg_credential is provided."""
-    gpg_credential = models.EdaCredential.objects.create(
-        name="test-gpg",
-        inputs={"gpg_public_key": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n"},
-        organization=default_organization,
-    )
-    gpg_credential.refresh_from_db()
-    executor = mock.MagicMock()
-
-    with mock.patch.object(scm.ScmRepository, "add_gpg_key") as mock_add_gpg:
-        with tempfile.TemporaryDirectory() as dest_path:
-            scm.ScmRepository.clone(
-                "https://git.example.com/repo.git",
-                dest_path,
-                gpg_credential=gpg_credential,
-                _executor=executor,
-            )
-        mock_add_gpg.assert_called_once()
 
 
 #################################################################

--- a/tests/unit/test_scm.py
+++ b/tests/unit/test_scm.py
@@ -639,3 +639,143 @@ def test_git_clone_gpg_add_key(
                 _executor=executor,
             )
         mock_add_gpg.assert_called_once()
+
+
+#################################################################
+# Tests for ScmRepository.decrypt_key_file and add_gpg_key
+#################################################################
+
+
+def test_decrypt_key_file_success():
+    mock_result = mock.Mock()
+    mock_result.returncode = 0
+
+    with mock.patch(
+        "aap_eda.services.project.scm.subprocess.run",
+        return_value=mock_result,
+    ) as mock_run:
+        scm.ScmRepository.decrypt_key_file("/tmp/keyfile", "passphrase")
+
+    mock_run.assert_called_once()
+    args = mock_run.call_args[0][0]
+    assert "-P" in args
+    assert "passphrase" in args
+
+
+def test_decrypt_key_file_failure():
+    mock_result = mock.Mock()
+    mock_result.returncode = 1
+    mock_result.stderr = "bad passphrase"
+    mock_result.stdout = ""
+
+    with mock.patch(
+        "aap_eda.services.project.scm.subprocess.run",
+        return_value=mock_result,
+    ):
+        with pytest.raises(scm.ScmError) as exc_info:
+            scm.ScmRepository.decrypt_key_file("/tmp/keyfile", "wrong")
+        assert "Failed to decrypt" in str(exc_info.value)
+
+
+def test_add_gpg_key_success():
+    mock_result = mock.Mock()
+    mock_result.returncode = 0
+
+    with mock.patch(
+        "aap_eda.services.project.scm.subprocess.run",
+        return_value=mock_result,
+    ) as mock_run:
+        scm.ScmRepository.add_gpg_key("/tmp/gpgkey", "/tmp/gnupg")
+
+    mock_run.assert_called_once()
+    call_kwargs = mock_run.call_args
+    assert call_kwargs[1]["env"] == {"GNUPGHOME": "/tmp/gnupg"}
+
+
+def test_add_gpg_key_failure():
+    mock_result = mock.Mock()
+    mock_result.returncode = 2
+    mock_result.stderr = "no valid OpenPGP data"
+    mock_result.stdout = ""
+
+    with mock.patch(
+        "aap_eda.services.project.scm.subprocess.run",
+        return_value=mock_result,
+    ):
+        with pytest.raises(scm.ScmError) as exc_info:
+            scm.ScmRepository.add_gpg_key("/tmp/gpgkey", "/tmp/gnupg")
+        assert "Failed to import" in str(exc_info.value)
+
+
+#################################################################
+# Tests for GitAnsibleRunnerExecutor.__call__
+#################################################################
+
+
+def _run_executor(runner_rc, runner_stdout):
+    """Helper to run GitAnsibleRunnerExecutor with mocked runner."""
+    executor = scm.GitAnsibleRunnerExecutor()
+    mock_runner = mock.Mock()
+    mock_runner.rc = runner_rc
+
+    def fake_run(**kwargs):
+        # Write to the captured stdout so redirect_stdout picks it up
+        import sys
+
+        sys.stdout.write(runner_stdout)
+        return mock_runner
+
+    with mock.patch(
+        "aap_eda.services.project.scm.ansible_runner.run",
+        side_effect=fake_run,
+    ):
+        return executor(
+            extra_vars={"project_path": "/tmp"},
+            env_vars={},
+        )
+
+
+def test_executor_call_success():
+    output = '"msg": "Repository Version abc123def456"'
+    result = _run_executor(0, output)
+    assert result == "abc123def456"
+
+
+def test_executor_call_success_no_version():
+    with pytest.raises(scm.ScmError) as exc_info:
+        _run_executor(0, "some output without version")
+    assert "Project Import Error:" in str(exc_info.value)
+
+
+def test_executor_call_auth_failure():
+    output = (
+        "fatal: [localhost]: FAILED! => "
+        '{"changed": false, "msg": "Authentication failed"}'
+    )
+    with pytest.raises(scm.ScmAuthenticationError):
+        _run_executor(1, output)
+
+
+def test_executor_call_username_prompt():
+    output = (
+        "fatal: [localhost]: FAILED! => " '{"msg": "could not read Username"}'
+    )
+    with pytest.raises(scm.ScmAuthenticationError) as exc_info:
+        _run_executor(1, output)
+    assert "Credentials not provided" in str(exc_info.value)
+
+
+def test_executor_call_generic_error():
+    output = (
+        "fatal: [localhost]: FAILED! => " '{"msg": "repository not found"}'
+    )
+    with pytest.raises(scm.ScmError) as exc_info:
+        _run_executor(1, output)
+    assert "Project Import Error:" in str(exc_info.value)
+    assert "repository not found" in str(exc_info.value)
+
+
+def test_executor_call_no_fatal_output():
+    with pytest.raises(scm.ScmError) as exc_info:
+        _run_executor(1, "some generic failure output")
+    assert "Project Import Error:" in str(exc_info.value)


### PR DESCRIPTION
Sonarcloud is complaining about a regex in a different PR. This PR gets rid of that regex in favor of utilizing the ansible runner API. Sonar has since scanned this file and determined that the tests only cover 83% of code in this file and is gating. So this PR will also add test cases to the rest of the file.  

Assisted-By: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SCM/Ansible execution parsing by using structured failure events to generate more accurate, credential-specific error messages.
  * Enhanced SCM version hash extraction on successful runs, including better handling when version details are missing.
  * Improved clone behavior around SSH/GPG credentials and key management, including proper environment setup.

* **Tests**
  * Added/expanded unit tests for proxy environment restoration, SSH key cloning behavior, GPG verification environment, directory creation, decryption/add-GPG success and failure paths, and executor event extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->