### PR TITLE
Add Prometheus metrics endpoint via ansible_base.prometheus

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ django-ansible-base = { git = "https://github.com/ansible/django-ansible-base.gi
     "jwt-consumer",
     "rest-filters",
     "feature-flags",
+    "prometheus",
 ] }
 jinja2 = ">=3.1.3,<3.2"
 pexpect = "^4.9.0"

--- a/src/aap_eda/api/urls.py
+++ b/src/aap_eda/api/urls.py
@@ -112,6 +112,7 @@ dab_urls = [
     path("", include(dab_urls)),
     path("", include(resource_api_urls)),
     path("", include(rbac_service_urls)),
+    path("", include("ansible_base.prometheus.urls")),
 ]
 
 v1_urls = eda_v1_urls + dab_urls

--- a/src/aap_eda/settings/core.py
+++ b/src/aap_eda/settings/core.py
@@ -35,6 +35,7 @@ INSTALLED_APPS = [
     "ansible_base.jwt_consumer",
     "ansible_base.rest_filters",
     "ansible_base.feature_flags",
+    "ansible_base.prometheus",
     # Local apps
     "aap_eda.api",
     "aap_eda.core",
@@ -45,6 +46,7 @@ MIDDLEWARE = [
     "aap_eda.middleware.request_log_middleware.RequestLogMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "ansible_base.prometheus.middleware.PrometheusMiddleware",
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/src/aap_eda/settings/defaults.py
+++ b/src/aap_eda/settings/defaults.py
@@ -261,3 +261,12 @@ INSIGHTS_TRACKING_STATE: bool = False
 AUTOMATION_ANALYTICS_GATHER_INTERVAL: int = 14400
 REDHAT_USERNAME: str = ""
 REDHAT_PASSWORD: str = ""
+
+# ---------------------------------------------------------
+# PROMETHEUS SETTINGS (ansible_base.prometheus)
+# ---------------------------------------------------------
+# Allow unauthenticated Prometheus scrapers to reach /api/eda/v1/metrics/.
+# When False (default), access requires superuser or platform_auditor.
+# Platform auditors are identified via the is_platform_auditor attribute
+# populated by EDAJWTAuthentication from JWT claims.
+ANSIBLE_PROMETHEUS_ALLOW_ANONYMOUS: bool = False


### PR DESCRIPTION
## Summary

- Adds a Prometheus-format metrics endpoint at `/api/eda/v1/metrics/` using the shared `ansible_base.prometheus` app
- Ships HTTP request counter and latency histogram (`django_http_requests_total`, `django_http_request_duration_seconds`) for all EDA API requests via `PrometheusMiddleware`
- Access is restricted to superusers and platform auditors by default; `is_platform_auditor` is populated from JWT claims by `EDAJWTAuthentication` when authenticating via the AAP gateway

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | Add `prometheus` to DAB extras |
| `src/aap_eda/settings/core.py` | Add `ansible_base.prometheus` to `INSTALLED_APPS`; add `PrometheusMiddleware` to `MIDDLEWARE` |
| `src/aap_eda/settings/defaults.py` | Add `ANSIBLE_PROMETHEUS_ALLOW_ANONYMOUS = False` |
| `src/aap_eda/api/urls.py` | Mount `ansible_base.prometheus.urls` in the v1 DAB url block |

## Endpoint

```
GET /api/eda/v1/metrics/          # Prometheus text format (default)
GET /api/eda/v1/metrics/?metric=django_http_requests_total  # name filter
Accept: application/json          # structured JSON output
```

## Auth

- **Superusers** — always allowed
- **Platform auditors** — `is_platform_auditor` is set in-memory by `EDAJWTAuthentication` from gateway JWT claims; no model change required
- **Anonymous scraping** — set `ANSIBLE_PROMETHEUS_ALLOW_ANONYMOUS = True` in deployment config and protect at the network layer

## Depends on

ansible/django-ansible-base#1020 *(DAB prometheus app)*

## AI Assistance
This change was developed with assistance from Claude Code (Claude Sonnet 4.6).
All generated code was reviewed, tested, and validated before merging.