### PR TITLE
Github actions update

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -8,7 +8,7 @@ runs:
       run: pipx install poetry
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
         cache: 'poetry'

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -12,7 +12,7 @@ runs:
       run: pipx install poetry
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
         cache: 'poetry'
@@ -69,13 +69,13 @@ runs:
     # Upload coverage artifact to Github for SonarCloud (only from Python 3.11)
     - name: Upload coverage as artifact
       if: inputs.python-version == '3.11'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: coverage
         path: ./coverage.xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         use_oidc: true
         fail_ci_if_error: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*/"
     schedule:
       interval: weekly


### PR DESCRIPTION
Do a one-off manual update of the github actions used in the composite actions; enable dependabot on them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated linting and test workflows to use newer action versions.
  * Improved coverage reporting integrations.
  * Expanded automated dependency monitoring to include custom workflow actions.
  * Preserved existing linting, coverage, and reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->