### PR TITLE
fix: sonar issues: Address security concerns regarding github actions

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -8,7 +8,7 @@ runs:
       run: pipx install poetry
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
       with:
         python-version: '3.11'
         cache: 'poetry'

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -8,7 +8,7 @@ runs:
       run: pipx install poetry
 
     - name: Set up Python
-      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.11'
         cache: 'poetry'

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -12,7 +12,7 @@ runs:
       run: pipx install poetry
 
     - name: Set up Python
-      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ inputs.python-version }}
         cache: 'poetry'
@@ -69,13 +69,13 @@ runs:
     # Upload coverage artifact to Github for SonarCloud (only from Python 3.11)
     - name: Upload coverage as artifact
       if: inputs.python-version == '3.11'
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: coverage
         path: ./coverage.xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         use_oidc: true
         fail_ci_if_error: false

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -12,7 +12,7 @@ runs:
       run: pipx install poetry
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
       with:
         python-version: ${{ inputs.python-version }}
         cache: 'poetry'
@@ -69,13 +69,13 @@ runs:
     # Upload coverage artifact to Github for SonarCloud (only from Python 3.11)
     - name: Upload coverage as artifact
       if: inputs.python-version == '3.11'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
       with:
         name: coverage
         path: ./coverage.xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7
       with:
         use_oidc: true
         fail_ci_if_error: false

--- a/.github/actions/validate-openapi-spec/action.yml
+++ b/.github/actions/validate-openapi-spec/action.yml
@@ -8,7 +8,7 @@ runs:
       run: pipx install poetry
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
       with:
         python-version: '3.11'
         cache: 'poetry'

--- a/.github/actions/validate-openapi-spec/action.yml
+++ b/.github/actions/validate-openapi-spec/action.yml
@@ -8,7 +8,7 @@ runs:
       run: pipx install poetry
 
     - name: Set up Python
-      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.11'
         cache: 'poetry'

--- a/.github/workflows/autoupdate-poetry.yml
+++ b/.github/workflows/autoupdate-poetry.yml
@@ -18,13 +18,13 @@ jobs:
       lock-changed: ${{ steps.lock-changed.outputs.lock-changed }}
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           ref: main
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/autoupdate-poetry.yml
+++ b/.github/workflows/autoupdate-poetry.yml
@@ -48,7 +48,7 @@ jobs:
           fi
 
       - name: Create a Pull Request
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         if: steps.lock-changed.outputs.lock-changed == 'true'
         with:
           # TODO: uses eda-ci pat token, replace with a bot.

--- a/.github/workflows/autoupdate-poetry.yml
+++ b/.github/workflows/autoupdate-poetry.yml
@@ -18,12 +18,13 @@ jobs:
       lock-changed: ${{ steps.lock-changed.outputs.lock-changed }}
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
         with:
+          persist-credentials: false
           ref: main
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: "3.11"
 
@@ -47,7 +48,7 @@ jobs:
           fi
 
       - name: Create a Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8
         if: steps.lock-changed.outputs.lock-changed == 'true'
         with:
           # TODO: uses eda-ci pat token, replace with a bot.

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -21,26 +21,26 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Log in to the Container registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.QUAY_USER }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -54,7 +54,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ${{ env.DOCKERFILE_PATH }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -21,24 +21,26 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.QUAY_USER }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -52,7 +54,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: ${{ env.DOCKERFILE_PATH }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
 
       - name: lint
         uses: ./.github/actions/lint
@@ -29,13 +31,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
 
       - name: validate-openapi-spec
         uses: ./.github/actions/validate-openapi-spec
 
       - name: Upload spec artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: openapi-spec
           path: openapi.json
@@ -94,7 +98,9 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
 
       - name: test
         uses: ./.github/actions/test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -39,7 +39,7 @@ jobs:
         uses: ./.github/actions/validate-openapi-spec
 
       - name: Upload spec artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: openapi-spec
           path: openapi.json
@@ -98,7 +98,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Check if commenter has write access
         id: check-permission
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           script: |
             const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -56,7 +56,7 @@ jobs:
 
       - name: Get PR info
         id: pr-info
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -72,7 +72,7 @@ jobs:
 
       - name: Create deployment
         id: create-deployment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           script: |
             try {
@@ -121,7 +121,7 @@ jobs:
     steps:
       - name: Update deployment to in_progress
         if: github.event_name == 'issue_comment' && needs.check-trigger.outputs.deployment_id != ''
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           script: |
             await github.rest.repos.createDeploymentStatus({
@@ -134,13 +134,14 @@ jobs:
             });
 
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
         with:
+          persist-credentials: false
           repository: ${{ github.event_name == 'issue_comment' && needs.check-trigger.outputs.pr_repo || github.repository }}
           ref: ${{ github.event_name == 'issue_comment' && needs.check-trigger.outputs.pr_sha || github.sha }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.QUAY_USER }}
@@ -160,8 +161,9 @@ jobs:
           done
 
       - name: Fetch test suite
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
         with:
+          persist-credentials: false
           fetch-depth: 0
           repository: ansible/eda-qa
           ref: ${{ github.event.inputs.edaqa_ref }}
@@ -169,7 +171,7 @@ jobs:
           token: ${{ secrets.EDA_QA_GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: "3.11"
 
@@ -201,10 +203,14 @@ jobs:
       - name: Upload jUnit test results (APDE CI)
         working-directory: ${{ env.EDA_QA_PATH }}
         if: github.ref == 'refs/heads/main'
+        env:
+          PDE_UPLOAD_USER: ${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}
+          PDE_UPLOAD_PASSWORD: ${{ secrets.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}
+          PDE_UPLOAD_URL: ${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_URL }}
         run: >-
           http --check-status --ignore-stdin
-          --auth "${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}:${{ secrets.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}"
-          -f POST "${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_URL }}/api/results/upload/"
+          --auth "$PDE_UPLOAD_USER:$PDE_UPLOAD_PASSWORD"
+          -f POST "$PDE_UPLOAD_URL/api/results/upload/"
           xunit_xml@eda-qa-e2e-test-results.xml
           component_name=eda
           git_commit_sha=${{ env.GIT_SHA }}
@@ -219,7 +225,7 @@ jobs:
 
       - name: Update deployment status
         if: always() && github.event_name == 'issue_comment' && needs.check-trigger.outputs.deployment_id != ''
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           script: |
             const state = '${{ job.status }}' === 'success' ? 'success' : 'failure';
@@ -244,21 +250,23 @@ jobs:
     environment: ${{ github.event_name == 'issue_comment' && 'protected' || '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
         with:
+          persist-credentials: false
           repository: ${{ github.event_name == 'issue_comment' && needs.check-trigger.outputs.pr_repo || github.repository }}
           ref: ${{ github.event_name == 'issue_comment' && needs.check-trigger.outputs.pr_sha || github.sha }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.QUAY_USER }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Fetch test suite
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
         with:
+          persist-credentials: false
           fetch-depth: 0
           repository: ansible/eda-qa
           ref: ${{ github.event.inputs.edaqa_ref }}
@@ -266,7 +274,7 @@ jobs:
           token: ${{ secrets.EDA_QA_GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: "3.11"
 
@@ -301,10 +309,14 @@ jobs:
       - name: Upload jUnit test results (APDE CI)
         working-directory: ${{ env.EDA_QA_PATH }}
         if: github.ref == 'refs/heads/main'
+        env:
+          PDE_UPLOAD_USER: ${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}
+          PDE_UPLOAD_PASSWORD: ${{ secrets.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}
+          PDE_UPLOAD_URL: ${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_URL }}
         run: >-
           http --check-status --ignore-stdin
-          --auth "${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}:${{ secrets.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}"
-          -f POST "${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_URL }}/api/results/upload/"
+          --auth "$PDE_UPLOAD_USER:$PDE_UPLOAD_PASSWORD"
+          -f POST "$PDE_UPLOAD_URL/api/results/upload/"
           xunit_xml@eda-qa-e2e-multinode-test-results.xml
           component_name=eda
           git_commit_sha=${{ env.GIT_SHA }}
@@ -312,7 +324,7 @@ jobs:
 
       - name: Update deployment status
         if: always() && github.event_name == 'issue_comment' && needs.check-trigger.outputs.deployment_id != ''
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           script: |
             const state = '${{ job.status }}' === 'success' ? 'success' : 'failure';

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Check if commenter has write access
         id: check-permission
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -56,7 +56,7 @@ jobs:
 
       - name: Get PR info
         id: pr-info
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -72,7 +72,7 @@ jobs:
 
       - name: Create deployment
         id: create-deployment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             try {
@@ -121,7 +121,7 @@ jobs:
     steps:
       - name: Update deployment to in_progress
         if: github.event_name == 'issue_comment' && needs.check-trigger.outputs.deployment_id != ''
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             await github.rest.repos.createDeploymentStatus({
@@ -134,14 +134,14 @@ jobs:
             });
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           repository: ${{ github.event_name == 'issue_comment' && needs.check-trigger.outputs.pr_repo || github.repository }}
           ref: ${{ github.event_name == 'issue_comment' && needs.check-trigger.outputs.pr_sha || github.sha }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.QUAY_USER }}
@@ -161,7 +161,7 @@ jobs:
           done
 
       - name: Fetch test suite
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -171,7 +171,7 @@ jobs:
           token: ${{ secrets.EDA_QA_GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
 
@@ -225,7 +225,7 @@ jobs:
 
       - name: Update deployment status
         if: always() && github.event_name == 'issue_comment' && needs.check-trigger.outputs.deployment_id != ''
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const state = '${{ job.status }}' === 'success' ? 'success' : 'failure';
@@ -250,21 +250,21 @@ jobs:
     environment: ${{ github.event_name == 'issue_comment' && 'protected' || '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           repository: ${{ github.event_name == 'issue_comment' && needs.check-trigger.outputs.pr_repo || github.repository }}
           ref: ${{ github.event_name == 'issue_comment' && needs.check-trigger.outputs.pr_sha || github.sha }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.QUAY_USER }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Fetch test suite
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -274,7 +274,7 @@ jobs:
           token: ${{ secrets.EDA_QA_GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
 
@@ -324,7 +324,7 @@ jobs:
 
       - name: Update deployment status
         if: always() && github.event_name == 'issue_comment' && needs.check-trigger.outputs.deployment_id != ''
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const state = '${{ job.status }}' === 'success' ? 'success' : 'failure';

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -18,10 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.QUAY_USER }}
@@ -38,15 +40,16 @@ jobs:
           done
 
       - name: Fetch test suite
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
         with:
+          persist-credentials: false
           fetch-depth: 0
           repository: ansible/eda-qa
           path: ${{ env.EDA_QA_PATH }}
           token: ${{ secrets.EDA_QA_GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: "3.9"
 
@@ -70,7 +73,7 @@ jobs:
 
       - name: Notify to slack if failure
         if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58  # v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: GH Slack Notifier for EDA

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Notify to slack if failure
         if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58  # v2
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2.4.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: GH Slack Notifier for EDA

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Log in to the Container registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.QUAY_USER }}
@@ -40,7 +40,7 @@ jobs:
           done
 
       - name: Fetch test suite
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -49,7 +49,7 @@ jobs:
           token: ${{ secrets.EDA_QA_GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.9"
 

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -37,7 +37,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' && 
       github.event.workflow_run.event == 'pull_request'
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -181,7 +181,7 @@ jobs:
       github.event.workflow_run.event == 'push' &&
       github.repository == 'ansible/eda-server'
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -37,7 +37,9 @@ jobs:
       github.event.workflow_run.conclusion == 'success' && 
       github.event.workflow_run.event == 'pull_request'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
 
       # Download coverage artifact from CI workflow
       - name: Download coverage artifact
@@ -179,7 +181,9 @@ jobs:
       github.event.workflow_run.event == 'push' &&
       github.repository == 'ansible/eda-server'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
 
       # Download coverage artifact from CI workflow
       - name: Download coverage artifact

--- a/.github/workflows/sync-openapi-spec.yml
+++ b/.github/workflows/sync-openapi-spec.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout spec repo
         id: checkout_spec_repo
         continue-on-error: true
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ secrets.OPENAPI_SPEC_REPO }}
           ref: ${{ steps.branch_map.outputs.spec_branch }}

--- a/.github/workflows/sync-openapi-spec.yml
+++ b/.github/workflows/sync-openapi-spec.yml
@@ -37,7 +37,7 @@ jobs:
           echo "📌 EDA branch: $SOURCE_BRANCH → Spec repo branch: $SPEC_BRANCH"
 
       - name: Download spec artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: openapi-spec
 
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout spec repo
         id: checkout_spec_repo
         continue-on-error: true
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
         with:
           repository: ${{ secrets.OPENAPI_SPEC_REPO }}
           ref: ${{ steps.branch_map.outputs.spec_branch }}

--- a/.github/workflows/sync-openapi-spec.yml
+++ b/.github/workflows/sync-openapi-spec.yml
@@ -37,7 +37,7 @@ jobs:
           echo "📌 EDA branch: $SOURCE_BRANCH → Spec repo branch: $SPEC_BRANCH"
 
       - name: Download spec artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: openapi-spec
 

--- a/.github/workflows/ui-e2e.yml
+++ b/.github/workflows/ui-e2e.yml
@@ -160,8 +160,8 @@ jobs:
         run: |
           docker run --rm \
           -e EDA_SERVER=${{ env.EDA_API_URL }} \
-          -e EDA_USERNAME=$EDA_USERNAME \
-          -e EDA_PASSWORD=$EDA_PASSWORD \
+          -e EDA_USERNAME="$EDA_USERNAME" \
+          -e EDA_PASSWORD="$EDA_PASSWORD" \
           -e CYPRESS_baseUrl=${{ env.EDA_UI_URL }} \
           -e CYPRESS_E2E_MODE=EDA \
           -e NODE_OPTIONS=--max-old-space-size=3500 \

--- a/.github/workflows/ui-e2e.yml
+++ b/.github/workflows/ui-e2e.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Check if commenter has write access
         id: check-permission
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -49,7 +49,7 @@ jobs:
 
       - name: Get PR info
         id: pr-info
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -65,7 +65,7 @@ jobs:
 
       - name: Create deployment
         id: create-deployment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             try {
@@ -114,7 +114,7 @@ jobs:
     steps:
       - name: Update deployment to in_progress
         if: github.event_name == 'issue_comment' && needs.check-trigger.outputs.deployment_id != ''
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             await github.rest.repos.createDeploymentStatus({
@@ -127,14 +127,14 @@ jobs:
             });
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           repository: ${{ github.event_name == 'issue_comment' && needs.check-trigger.outputs.pr_repo || github.repository }}
           ref: ${{ github.event_name == 'issue_comment' && needs.check-trigger.outputs.pr_sha || github.sha }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.QUAY_USER }}
@@ -171,7 +171,7 @@ jobs:
 
       - name: Update deployment status
         if: always() && github.event_name == 'issue_comment' && needs.check-trigger.outputs.deployment_id != ''
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const state = '${{ job.status }}' === 'success' ? 'success' : 'failure';

--- a/.github/workflows/ui-e2e.yml
+++ b/.github/workflows/ui-e2e.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Check if commenter has write access
         id: check-permission
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           script: |
             const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -49,7 +49,7 @@ jobs:
 
       - name: Get PR info
         id: pr-info
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -65,7 +65,7 @@ jobs:
 
       - name: Create deployment
         id: create-deployment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           script: |
             try {
@@ -114,7 +114,7 @@ jobs:
     steps:
       - name: Update deployment to in_progress
         if: github.event_name == 'issue_comment' && needs.check-trigger.outputs.deployment_id != ''
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           script: |
             await github.rest.repos.createDeploymentStatus({
@@ -127,13 +127,14 @@ jobs:
             });
 
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
         with:
+          persist-credentials: false
           repository: ${{ github.event_name == 'issue_comment' && needs.check-trigger.outputs.pr_repo || github.repository }}
           ref: ${{ github.event_name == 'issue_comment' && needs.check-trigger.outputs.pr_sha || github.sha }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.QUAY_USER }}
@@ -153,11 +154,14 @@ jobs:
           done
 
       - name: Run UI E2E Tests
+        env:
+          EDA_USERNAME: ${{ secrets.EDA_USERNAME }}
+          EDA_PASSWORD: ${{ secrets.EDA_PASSWORD }}
         run: |
           docker run --rm \
           -e EDA_SERVER=${{ env.EDA_API_URL }} \
-          -e EDA_USERNAME=${{ secrets.EDA_USERNAME }} \
-          -e EDA_PASSWORD=${{ secrets.EDA_PASSWORD }} \
+          -e EDA_USERNAME=$EDA_USERNAME \
+          -e EDA_PASSWORD=$EDA_PASSWORD \
           -e CYPRESS_baseUrl=${{ env.EDA_UI_URL }} \
           -e CYPRESS_E2E_MODE=EDA \
           -e NODE_OPTIONS=--max-old-space-size=3500 \
@@ -167,7 +171,7 @@ jobs:
 
       - name: Update deployment status
         if: always() && github.event_name == 'issue_comment' && needs.check-trigger.outputs.deployment_id != ''
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           script: |
             const state = '${{ job.status }}' === 'success' ? 'success' : 'failure';


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AAP-77394

One of multiple Sonarcloud PRs. Addresses multiple security concerns by:
 - Pinning all GitHub Actions to immutable commit SHAs to prevent supply-chain attacks via tag mutation 
 - Move secrets out of run: block interpolation into env: declarations in e2e-dispatch.yml and ui-e2e.yml 
 - Add persist-credentials: false to checkout steps that don't require authenticated git operations, reducing token exposure to subsequent steps 
 
 Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Reliability**
  * Pinned third-party GitHub Actions to specific commit SHAs across linting, validation, CI, Docker image builds, E2E (UI/API), OpenAPI syncing, scheduled tests, and Sonar analysis for stronger supply-chain stability.
  * Disabled credential persistence (`persist-credentials: false`) on relevant checkout steps.

* **Workflow Maintenance**
  * Kept existing workflow behavior the same while improving determinism.
  * Updated E2E request/container credential handling to use step environment variables (including PDE uploads and UI E2E container runs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->