### PR TITLE
fix: truncate and hash long FQDN when using dispatcherd instead of crashing the worker

### DIFF
--- a/src/aap_eda/services/activation/activation_manager.py
+++ b/src/aap_eda/services/activation/activation_manager.py
@@ -15,7 +15,6 @@
 
 import contextlib
 import logging
-import os
 import typing as tp
 from datetime import timedelta
 
@@ -1088,11 +1087,7 @@ class ActivationManager(StatusManager):
         )
 
     def _get_queue_name(self) -> str:
-        # Read directly from environment to support multinode configuration
-        # where each worker has its own EDA_RULEBOOK_QUEUE_NAME value
-        return os.environ.get(
-            "EDA_RULEBOOK_QUEUE_NAME", settings.RULEBOOK_QUEUE_NAME
-        )
+        return settings.RULEBOOK_QUEUE_NAME
 
     def _get_container_request(self) -> ContainerRequest:
         try:

--- a/src/aap_eda/settings/post_load.py
+++ b/src/aap_eda/settings/post_load.py
@@ -11,7 +11,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import logging
 import types
+import uuid
 from typing import Optional, Union, get_args, get_origin, get_type_hints
 
 from django.core.exceptions import ImproperlyConfigured
@@ -21,6 +23,28 @@ from aap_eda import utils
 from aap_eda.core.enums import RulebookProcessLogLevel
 
 from . import defaults
+
+logger = logging.getLogger(__name__)
+
+MAX_PG_IDENTIFIER_LENGTH = 63
+
+
+def _normalize_queue_name(name: str) -> str:
+    """Normalize a queue name to fit PostgreSQL's 63-byte identifier limit.
+
+    Short names are returned unchanged. Names exceeding the limit are
+    replaced with a deterministic UUID5-based name and a warning is logged.
+    """
+    if len(name) <= MAX_PG_IDENTIFIER_LENGTH:
+        return name
+    normalized = f"eda-{uuid.uuid5(uuid.NAMESPACE_OID, name)}"
+    logger.warning(
+        "Queue name '%s' exceeds %d characters; changed into '%s'.",
+        name,
+        MAX_PG_IDENTIFIER_LENGTH,
+        normalized,
+    )
+    return normalized
 
 
 def _get_secret_key(settings: Dynaconf) -> str:
@@ -532,6 +556,27 @@ def post_loading(loaded_settings: Dynaconf):
             },
         },
     }
+
+    if (
+        settings.RULEBOOK_WORKER_QUEUES
+        and settings.RULEBOOK_QUEUE_NAME not in settings.RULEBOOK_WORKER_QUEUES
+    ):
+        raise ImproperlyConfigured(
+            f"RULEBOOK_QUEUE_NAME '{settings.RULEBOOK_QUEUE_NAME}' "
+            f"is not in RULEBOOK_WORKER_QUEUES: "
+            f"{settings.RULEBOOK_WORKER_QUEUES}. "
+            f"The worker's queue name must be listed in the "
+            f"worker queues configuration."
+        )
+
+    if settings.get("DISPATCHERD_DEFAULT_WORKER_SETTINGS"):
+        settings.RULEBOOK_QUEUE_NAME = _normalize_queue_name(
+            settings.RULEBOOK_QUEUE_NAME,
+        )
+        settings.RULEBOOK_WORKER_QUEUES = [
+            _normalize_queue_name(name)
+            for name in settings.RULEBOOK_WORKER_QUEUES
+        ]
 
     data = {
         key: settings[key]

--- a/src/aap_eda/tasks/orchestrator.py
+++ b/src/aap_eda/tasks/orchestrator.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 import logging
-import os
 import random
 import uuid
 from collections import Counter
@@ -137,9 +136,7 @@ def _manage_no_lock(
             )
             queue_name = None
 
-        local_queue = os.environ.get(
-            "EDA_RULEBOOK_QUEUE_NAME", settings.RULEBOOK_QUEUE_NAME
-        )
+        local_queue = settings.RULEBOOK_QUEUE_NAME
         if queue_name and queue_name != local_queue:
             LOGGER.info(
                 f"Skipping monitor for {process_parent_type} {id}: "

--- a/tests/unit/test_normalize_queue_name.py
+++ b/tests/unit/test_normalize_queue_name.py
@@ -1,0 +1,56 @@
+#  Copyright 2024 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import uuid
+
+import pytest
+
+from aap_eda.settings.post_load import (
+    MAX_PG_IDENTIFIER_LENGTH,
+    _normalize_queue_name,
+)
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("activation", "activation"),
+        ("activation-node1", "activation-node1"),
+        ("a" * 63, "a" * 63),
+        (
+            "a" * 64,
+            f"eda-{uuid.uuid5(uuid.NAMESPACE_OID, 'a' * 64)}",
+        ),
+    ],
+)
+def test_normalize_queue_name(name, expected):
+    assert _normalize_queue_name(name) == expected
+
+
+def test_normalize_queue_name_unique():
+    name1 = "eda-" + "a" * 60 + "-node1"
+    name2 = "eda-" + "a" * 60 + "-node2"
+    assert _normalize_queue_name(name1) != _normalize_queue_name(name2)
+
+
+def test_normalize_queue_name_idempotent():
+    long_name = "x" * 100
+    once = _normalize_queue_name(long_name)
+    twice = _normalize_queue_name(once)
+    assert once == twice
+
+
+def test_normalize_queue_name_fits_pg_limit():
+    result = _normalize_queue_name("x" * 200)
+    assert len(result) <= MAX_PG_IDENTIFIER_LENGTH

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -419,9 +419,9 @@ def test_manage_monitor_called_with_no_requests(
             "aap_eda.tasks.orchestrator.get_queue_name_by_parent_id",
             return_value="activation",
         ),
-        mock.patch.dict(
-            "os.environ",
-            {"EDA_RULEBOOK_QUEUE_NAME": "activation"},
+        mock.patch(
+            "aap_eda.tasks.orchestrator.settings.RULEBOOK_QUEUE_NAME",
+            "activation",
         ),
     ):
         mock_manager.return_value = manager_mock
@@ -641,9 +641,9 @@ def test_manage_monitor_skipped_on_wrong_queue(
             "aap_eda.tasks.orchestrator.get_queue_name_by_parent_id",
             return_value="eda-other-node-queue",
         ),
-        mock.patch.dict(
-            "os.environ",
-            {"EDA_RULEBOOK_QUEUE_NAME": "eda-local-node-queue"},
+        mock.patch(
+            "aap_eda.tasks.orchestrator.settings.RULEBOOK_QUEUE_NAME",
+            "eda-local-node-queue",
         ),
     ):
         mock_manager.return_value = manager_mock
@@ -671,9 +671,9 @@ def test_manage_monitor_runs_on_matching_queue(
             "aap_eda.tasks.orchestrator.get_queue_name_by_parent_id",
             return_value="eda-local-node-queue",
         ),
-        mock.patch.dict(
-            "os.environ",
-            {"EDA_RULEBOOK_QUEUE_NAME": "eda-local-node-queue"},
+        mock.patch(
+            "aap_eda.tasks.orchestrator.settings.RULEBOOK_QUEUE_NAME",
+            "eda-local-node-queue",
         ),
     ):
         mock_manager.return_value = manager_mock
@@ -701,9 +701,9 @@ def test_manage_monitor_runs_when_no_queue_assigned(
             "aap_eda.tasks.orchestrator.get_queue_name_by_parent_id",
             side_effect=ValueError("No queue"),
         ),
-        mock.patch.dict(
-            "os.environ",
-            {"EDA_RULEBOOK_QUEUE_NAME": "eda-local-node-queue"},
+        mock.patch(
+            "aap_eda.tasks.orchestrator.settings.RULEBOOK_QUEUE_NAME",
+            "eda-local-node-queue",
         ),
     ):
         mock_manager.return_value = manager_mock
@@ -731,9 +731,9 @@ def test_manage_monitor_runs_when_queue_returns_none(
             "aap_eda.tasks.orchestrator" ".get_queue_name_by_parent_id",
             return_value=None,
         ),
-        mock.patch.dict(
-            "os.environ",
-            {"EDA_RULEBOOK_QUEUE_NAME": "eda-local-node-queue"},
+        mock.patch(
+            "aap_eda.tasks.orchestrator.settings.RULEBOOK_QUEUE_NAME",
+            "eda-local-node-queue",
         ),
     ):
         mock_manager.return_value = manager_mock

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -105,6 +105,16 @@ def test_duplicated_worker_queue(mock_settings):
         post_loading(mock_settings)
 
 
+def test_rulebook_queue_name_exists_in_worker_queues(mock_settings):
+    mock_settings.RULEBOOK_WORKER_QUEUES = [
+        "activation-node1",
+        "activation-node2",
+    ]
+    mock_settings.RULEBOOK_QUEUE_NAME = "some-other-name"
+    with pytest.raises(ImproperlyConfigured):
+        post_loading(mock_settings)
+
+
 @pytest.mark.parametrize(
     ("name", "value", "expected"),
     [
@@ -123,7 +133,7 @@ def test_duplicated_worker_queue(mock_settings):
         ("SESSION_COOKIE_AGE", "20", 20),
         ("SESSION_COOKIE_AGE", 20, 20),
         ("SESSION_COOKIE_AGE", "not number", ImproperlyConfigured),
-        ("RULEBOOK_QUEUE_NAME", " act ", "act"),
+        ("RULEBOOK_QUEUE_NAME", " activation ", "activation"),
         ("RULEBOOK_QUEUE_NAME", ["name"], ImproperlyConfigured),
         ("RULEBOOK_QUEUE_NAME", 20, ImproperlyConfigured),
         ("ALLOWED_HOSTS", "h1,h2", ["h1", "h2"]),


### PR DESCRIPTION
This PR addresses the issue mentioned in this Jira ticket: https://redhat.atlassian.net/jira/software/c/projects/AAP/boards/12632?selectedIssue=AAP-78938

I'm adding a new function `_normalize_queue_name` that changes long names using UUID5 if the broker being used is `pg_notify`. 

In addition to that, now an error `ImproperlyConfigured` is raised in `post_loading` when `RULEBOOK_QUEUE_NAME` is not found in `RULEBOOK_WORKER_QUEUES` (this check is performed before the UUID5 transformation step).

I also added some tests for the new function and the code path that checks the rulebook queue name exists in the list of worker queues.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved rulebook job routing and monitoring to consistently use the configured queue name, removing environment-based overrides.
  * Added deterministic normalization for overly long queue identifiers (with a warning) to keep queue matching reliable and within platform limits.
  * Applies the same normalization across both rulebook and worker queues for consistent routing.
* **Tests**
  * Added unit tests for deterministic, idempotent queue-name normalization.
  * Updated orchestrator routing tests to mock configured queue settings directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->