### PR TITLE
[AAP-82119] Update API root test for DAB bulk-update endpoint

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -931,7 +931,7 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-ansible-base"
-version = "2026.6.9.0.dev4+g67526308c"
+version = "2026.7.22.0.dev29+gc70965eed"
 description = "A Django app used by ansible services"
 optional = false
 python-versions = ">=3.11"
@@ -971,7 +971,7 @@ testing = ["cryptography", "pytest", "pytest-django"]
 type = "git"
 url = "https://github.com/ansible/django-ansible-base.git"
 reference = "devel"
-resolved_reference = "2fdc8291ca7d190b0a44b25ad6c7ca28fca0a9bb"
+resolved_reference = "c70965eed60a23922b4ab98aae2336a98cd8a688"
 
 [[package]]
 name = "django-crum"

--- a/tests/integration/api/test_root.py
+++ b/tests/integration/api/test_root.py
@@ -65,6 +65,7 @@ from tests.integration.constants import api_url_v1
                 "/service-index/metadata/",
                 "/service-index/object-delete/",
                 "/service-index/resources/",
+                "/service-index/resources/bulk-update/",
                 "/service-index/resource-types/",
                 "/service-index/role-types/",
                 "/service-index/role-permissions/",


### PR DESCRIPTION
<!-- What is being changed? -->
Add `/service-index/resources/bulk-update/` to the expected service-index URLs in the API root test (`test_v1_root`).

<!-- Why is this change needed? -->
The DAB PR [ansible/django-ansible-base#1054](https://github.com/ansible/django-ansible-base/pull/1054) adds a `bulk-update` action to `ResourceViewSet`. This registers a new URL in the DRF router (`/service-index/resources/bulk-update/`), which causes the `test_v1_root` test in EDA to fail with a count mismatch: the test expects a hardcoded number of service-index URLs but now the API returns one more.

<!-- How does this change address the issue? -->
Adds the new URL to the expected slugs list in the "no_shared_resource" test parametrization.

<!-- Does this change introduce any new dependencies, blockers or breaking changes? -->
This change should be merged alongside or after [ansible/django-ansible-base#1054](https://github.com/ansible/django-ansible-base/pull/1054) lands.

<!-- How it can be tested? -->
Run: `pytest tests/integration/api/test_root.py -v`

---

**Note:** This PR was developed with assistance from Claude AI assistant.