### PR TITLE
fix: use datetime.fromisoformat() to handle timezone offsets in event…

### DIFF
--- a/src/aap_eda/wsapi/consumers.py
+++ b/src/aap_eda/wsapi/consumers.py
@@ -237,7 +237,7 @@ class AnsibleRulebookConsumer(AsyncWebsocketConsumer):
 
         created = event_data.get("created")
         if created:
-            created = datetime.strptime(created, "%Y-%m-%dT%H:%M:%S.%f")
+            created = datetime.fromisoformat(created)
 
         job_instance_event = models.JobInstanceEvent.objects.create(
             job_uuid=event_data.get("job_id"),

--- a/tests/integration/wsapi/test_consumer.py
+++ b/tests/integration/wsapi/test_consumer.py
@@ -265,6 +265,40 @@ async def test_handle_events(ws_communicator: WebsocketCommunicator):
     assert (await get_job_instance_event_count()) == 1
 
 
+@pytest.mark.parametrize(
+    "created_timestamp",
+    [
+        pytest.param("2023-03-29T15:00:17.260803", id="naive"),
+        pytest.param("2023-03-29T15:00:17.260803Z", id="utc_z_suffix"),
+        pytest.param("2023-03-29T15:00:17.260803+00:00", id="utc_offset"),
+        pytest.param("2023-03-29T15:00:17.260803+05:30", id="positive_offset"),
+        pytest.param("2023-03-29T15:00:17.260803-04:00", id="negative_offset"),
+    ],
+)
+@pytest.mark.django_db(transaction=True)
+async def test_handle_events_with_timezone_in_created(
+    ws_communicator: WebsocketCommunicator,
+    created_timestamp: str,
+):
+    job_instance = await _prepare_job_instance()
+
+    initial_count = await get_job_instance_event_count()
+    payload = {
+        "type": "AnsibleEvent",
+        "event": {
+            "event": "verbose",
+            "job_id": job_instance.uuid,
+            "counter": 1,
+            "stdout": "the playbook is completed",
+            "created": created_timestamp,
+        },
+    }
+    await ws_communicator.send_json_to(payload)
+    await ws_communicator.wait()
+
+    assert (await get_job_instance_event_count()) == initial_count + 1
+
+
 @pytest.mark.django_db(transaction=True)
 async def test_handle_actions_multiple_firing(
     ws_communicator: WebsocketCommunicator,


### PR DESCRIPTION
Failure on parsing date time in AnsibleEvents which contain time zone offset

**strptime** with "%Y-%m-%dT%H:%M:%S.%f" fails on timestamps containing timezone offsets (e.g. +00:00) with:

  ValueError: unconverted data remains: +00:00
    File "consumers.py", line 240, in insert_event_related_data
      created = datetime.strptime(created, "%Y-%m-%dT%H:%M:%S.%f")

fromisoformat() handles all ISO 8601 variants including naive, Z-suffixed, and offset timestamps.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event processing to accept ISO 8601 timestamps in multiple formats, including UTC and timezone-offset values.
  * Ensured events with timezone-aware timestamps are stored and processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->