### PR TITLE
[AAP-79673] Add view_team to Organization Member role

### DIFF
--- a/src/aap_eda/core/management/commands/create_initial_data.py
+++ b/src/aap_eda/core/management/commands/create_initial_data.py
@@ -87,6 +87,7 @@ ORG_ROLES = [
         "description": "Users who are a part of the organization",
         "permissions": {
             "organization": ["view", "member"],
+            "team": ["view"],
         },
     },
     {

--- a/tests/integration/dab_rbac/conftest.py
+++ b/tests/integration/dab_rbac/conftest.py
@@ -24,9 +24,9 @@ from aap_eda.core.utils.credentials import inputs_to_display
 
 
 @pytest.fixture
-def user_api_client(db, user):
+def user_api_client(db, default_user):
     client = APIClient()
-    client.force_authenticate(user=user)
+    client.force_authenticate(user=default_user)
     return client
 
 

--- a/tests/integration/dab_rbac/test_managed_roles.py
+++ b/tests/integration/dab_rbac/test_managed_roles.py
@@ -17,6 +17,7 @@ from ansible_base.rbac.models import RoleDefinition
 from django.test import override_settings
 from rest_framework import status
 
+from aap_eda.core import models
 from aap_eda.core.management.commands.create_initial_data import ORG_ROLES
 from tests.integration.constants import api_url_v1
 
@@ -59,3 +60,104 @@ def test_org_role_user_assignments(
             f"{api_url_v1}/role_user_assignments/", data=post_data
         )
         assert response.status_code == status.HTTP_201_CREATED, response.data
+
+
+@pytest.mark.django_db
+def test_org_member_has_view_team_permission(create_managed_org_roles):
+    """Regression test for AAP-79673.
+
+    Organization Member role must include view_team so that org members
+    can see teams within their organization.
+    """
+    role = RoleDefinition.objects.get(name="Organization Member")
+    perm_codenames = set(role.permissions.values_list("codename", flat=True))
+    assert (
+        "view_team" in perm_codenames
+    ), f"Organization Member should have view_team, got: {perm_codenames}"
+    team_perms = {p for p in perm_codenames if p.endswith("_team")}
+    assert team_perms == {"view_team"}, (
+        "Organization Member should only have view_team"
+        f" for teams, got: {team_perms}"
+    )
+
+
+@pytest.mark.django_db
+def test_org_member_can_see_teams_in_org(
+    user_api_client,
+    default_user,
+    default_organization,
+    default_team,
+    create_managed_org_roles,
+):
+    """Regression test for AAP-79673.
+
+    A user with only the Organization Member role should be able to list
+    and retrieve teams in their organization.
+    """
+    org_member_rd = RoleDefinition.objects.get(name="Organization Member")
+    org_member_rd.give_permission(default_user, default_organization)
+
+    response = user_api_client.get(f"{api_url_v1}/teams/")
+    assert response.status_code == status.HTTP_200_OK
+    team_ids = {t["id"] for t in response.data["results"]}
+    assert (
+        default_team.id in team_ids
+    ), "Org member should see teams in their organization"
+
+    response = user_api_client.get(f"{api_url_v1}/teams/{default_team.id}/")
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_org_member_cannot_see_teams_in_other_org(
+    user_api_client,
+    default_user,
+    default_organization,
+    create_managed_org_roles,
+):
+    """Regression test for AAP-79673.
+
+    Organization members must NOT see teams in organizations they
+    don't belong to.  Without this negative test a regression that
+    accidentally grants view_team globally would go undetected.
+    """
+    other_org = models.Organization.objects.create(
+        name="Other Org",
+        description="A separate organization",
+    )
+    other_team = models.Team.objects.create(
+        name="Other Org Team",
+        organization=other_org,
+    )
+
+    org_member_rd = RoleDefinition.objects.get(name="Organization Member")
+    org_member_rd.give_permission(default_user, default_organization)
+
+    response = user_api_client.get(f"{api_url_v1}/teams/")
+    assert response.status_code == status.HTTP_200_OK
+    team_ids = {t["id"] for t in response.data["results"]}
+    assert (
+        other_team.id not in team_ids
+    ), "Org member should NOT see teams in organizations they do not belong to"
+
+    response = user_api_client.get(f"{api_url_v1}/teams/{other_team.id}/")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_user_without_roles_sees_no_teams(
+    user_api_client,
+    default_organization,
+    default_team,
+    create_managed_org_roles,
+):
+    """Baseline test: a user with no role assignments should see no teams.
+
+    This guards against the positive test passing trivially if the
+    default queryset returns all teams.
+    """
+    response = user_api_client.get(f"{api_url_v1}/teams/")
+    assert response.status_code == status.HTTP_200_OK
+    assert (
+        response.data["count"] == 0
+    ), "User with no role assignments should see no teams"


### PR DESCRIPTION
## What is being changed?

Add `view_team` permission to the **Organization Member** role in EDA's `create_initial_data` management command.

## Why is this change needed?

AAP-79673 reports that organization members cannot view teams within their organization. In EDA, the Organization Member role only had `organization: ["view", "member"]` — it was missing `team: ["view"]`. Every other org-level role (Editor, Contributor, Operator, Auditor, Viewer) already included `view_team`. Since EDA's `TeamViewSet` uses `access_qs` directly for visibility filtering, the missing permission meant org members got an empty team list.

## How does this change address the issue?

Adds `"team": ["view"]` to the Organization Member permissions in `ORG_ROLES`. The existing `_create_org_roles()` method uses `update_or_create` with `permissions.set()`, so the permission will be synced to existing role definitions when `create_initial_data` runs on upgrade.

## Does this change introduce any new dependencies, blockers or breaking changes?

No new dependencies. This is a standalone fix — unlike the gateway, EDA manages its own roles via `create_initial_data` rather than DAB's managed role registry.

Related PRs (same issue, different components):
- DAB: https://github.com/ansible/django-ansible-base/pull/1070
- Gateway: https://github.com/ansible/jewel/pull/178

## How it can be tested?

1. Run the managed role tests: `pytest tests/integration/dab_rbac/test_managed_roles.py -v`
2. New tests:
   - `test_org_member_has_view_team_permission` — verifies the role definition includes `view_team`
   - `test_org_member_can_see_teams_in_org` — verifies an org member can list and retrieve teams via the API
3. Manual: assign a user the Organization Member role on an org, confirm they can see teams in that org at `/api/eda/v1/teams/`

---
**Note:** This PR was developed with assistance from Claude AI assistant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Access Control**
  * Organization Members now have view-only access to teams.
  * Organization Members can list teams and view team details within their own organization.

* **Tests**
  * Added integration coverage ensuring Organization Members have the team view permission.
  * Added negative coverage confirming Organization Members cannot access teams from other organizations.
  * Added a baseline check that users without role assignments see zero teams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->