### PR TITLE
fix: check if rulebook queue name is different than default before checking if queue name is in worker queues list

### DIFF
--- a/src/aap_eda/settings/post_load.py
+++ b/src/aap_eda/settings/post_load.py
@@ -27,6 +27,7 @@ from . import defaults
 logger = logging.getLogger(__name__)
 
 MAX_PG_IDENTIFIER_LENGTH = 63
+DEFAULT_RULEBOOK_QUEUE_NAME = "activation"
 
 
 def _normalize_queue_name(name: str) -> str:
@@ -474,7 +475,7 @@ def post_loading(loaded_settings: Dynaconf):
 
     # If the list is empty, use the default queue name for single node mode
     if not settings.RULEBOOK_WORKER_QUEUES:
-        settings.RULEBOOK_WORKER_QUEUES = ["activation"]
+        settings.RULEBOOK_WORKER_QUEUES = [DEFAULT_RULEBOOK_QUEUE_NAME]
 
     # ---------------------------------------------------------
     # APPLICATION SETTINGS
@@ -558,7 +559,7 @@ def post_loading(loaded_settings: Dynaconf):
     }
 
     if (
-        settings.RULEBOOK_WORKER_QUEUES
+        settings.RULEBOOK_QUEUE_NAME != DEFAULT_RULEBOOK_QUEUE_NAME
         and settings.RULEBOOK_QUEUE_NAME not in settings.RULEBOOK_WORKER_QUEUES
     ):
         raise ImproperlyConfigured(

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -106,6 +106,7 @@ def test_duplicated_worker_queue(mock_settings):
 
 
 def test_rulebook_queue_name_exists_in_worker_queues(mock_settings):
+    """Explicitly set queue name not in worker queues should fail."""
     mock_settings.RULEBOOK_WORKER_QUEUES = [
         "activation-node1",
         "activation-node2",
@@ -113,6 +114,26 @@ def test_rulebook_queue_name_exists_in_worker_queues(mock_settings):
     mock_settings.RULEBOOK_QUEUE_NAME = "some-other-name"
     with pytest.raises(ImproperlyConfigured):
         post_loading(mock_settings)
+
+
+def test_default_queue_name_skips_validation_in_multinode(mock_settings):
+    """Non-worker services keep the default queue name in multinode."""
+    mock_settings.RULEBOOK_WORKER_QUEUES = [
+        "activation-node1",
+        "activation-node2",
+    ]
+    mock_settings.RULEBOOK_QUEUE_NAME = "activation"
+    post_loading(mock_settings)
+
+
+def test_matching_queue_name_passes_validation(mock_settings):
+    """Activation worker with queue name in worker queues should pass."""
+    mock_settings.RULEBOOK_WORKER_QUEUES = [
+        "activation-node1",
+        "activation-node2",
+    ]
+    mock_settings.RULEBOOK_QUEUE_NAME = "activation-node1"
+    post_loading(mock_settings)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR solves an issue mentioned in #1637 of a problem introduced with #1623.

Added a constant `DEFAULT_RULEBOOK_QUEUE_NAME = "activation"`. If the queue name passed to settings is different than `DEFAULT_RULEBOOK_QUEUE_NAME`, we start checking if the queue name is in the worker queues list. 

If the queue name is the same as default, we skip the check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rulebook queue-name validation for multinode configurations.
  * Ensured the default activation queue is consistently applied when worker queues are not configured.
  * Validation now correctly skips for the default activation queue in non-worker contexts and passes when an activation worker queue matches the configured worker queues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->