### PR TITLE
chore(flake8): suppress flake8 false positives on f-string content

### DIFF
--- a/src/aap_eda/api/event_stream_authentication.py
+++ b/src/aap_eda/api/event_stream_authentication.py
@@ -152,7 +152,7 @@ class BasicAuthentication(EventStreamAuthentication):
         if self.authorization.startswith("Basic"):
             auth_str = self.authorization.split("Basic ")[1]
 
-        user_pass = f"{self.username}:{self.password}"
+        user_pass = f"{self.username}:{self.password}"  # noqa: E231
         b64_value = base64.b64encode(user_pass.encode()).decode()
         if auth_str != b64_value:
             message = "Credential mismatch"

--- a/src/aap_eda/api/serializers/project.py
+++ b/src/aap_eda/api/serializers/project.py
@@ -403,7 +403,7 @@ def get_proxy_for_display(proxy: str) -> str:
     cred, domain = result.netloc.split("@")
     if ":" in cred:
         user, _ = cred.split(":")
-        domain = f"{user}:{ENCRYPTED_STRING}@{domain}"
+        domain = f"{user}:{ENCRYPTED_STRING}@{domain}"  # noqa: E231
     else:
         domain = f"{ENCRYPTED_STRING}@{domain}"
 

--- a/src/aap_eda/core/utils/credentials.py
+++ b/src/aap_eda/core/utils/credentials.py
@@ -968,7 +968,7 @@ def validate_x509_subject_match(expected: str, actual: str) -> bool:
         actual_attrs = actual_name.get_attributes_for_oid(attr_oid)
         if not actual_attrs:
             LOGGER.error(
-                f"Required attribute {attr_name} not found in actual subject"
+                f"Required attribute {attr_name} not found in actual subject"  # noqa: E713,E501
             )
             return False
 

--- a/src/aap_eda/services/activation/engine/podman.py
+++ b/src/aap_eda/services/activation/engine/podman.py
@@ -44,7 +44,7 @@ def _get_podman_socket_url() -> str:
     if os.getuid() == 0:
         return "unix:///run/podman/podman.sock"
     xdg_runtime_dir = os.getenv("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
-    return f"unix://{xdg_runtime_dir}/podman/podman.sock"
+    return f"unix://{xdg_runtime_dir}/podman/podman.sock"  # noqa: E231
 
 
 def get_podman_client() -> PodmanClient:

--- a/src/aap_eda/tasks/orchestrator.py
+++ b/src/aap_eda/tasks/orchestrator.py
@@ -318,14 +318,14 @@ def _resolve_existing_queue(
             LOGGER.info(
                 "Scheduling request "
                 f"{request_type} for {process_parent_type} "
-                f"{process_parent_id} to the least busy queue; "
+                f"{process_parent_id} to the least busy queue; "  # noqa: E702
                 "it is not currently associated with a queue.",
             )
         else:
             LOGGER.info(
                 "Scheduling request"
                 f"{request_type} for {process_parent_type} "
-                f"{process_parent_id} to the least busy queue; "
+                f"{process_parent_id} to the least busy queue; "  # noqa: E702
                 f"its associated queue '{queue_name}' is from "
                 "previous configuation settings.",
             )
@@ -415,7 +415,7 @@ def _handle_unhealthy_queue(
     # execute the task.
     LOGGER.warning(
         f"Forcing user restart of {process_parent_type} "
-        f"{process_parent_id} on the least busy queue; "
+        f"{process_parent_id} on the least busy queue; "  # noqa: E702
         "after failing liveness checks of current "
         "associated queue"
     )

--- a/tests/integration/analytics/test_analytics_collectors.py
+++ b/tests/integration/analytics/test_analytics_collectors.py
@@ -192,15 +192,9 @@ def test_jobs_stats_collector(
     time_start = until - timedelta(hours=9)
     job_ids = ["8018", "8020"]
     intall_uuids = [str(uuid.uuid4()), str(uuid.uuid4())]
-    audit_action_1.url = (
-        f"https://controller_1/#/jobs/playbook/{job_ids[0]}/details/"
-    )
-    audit_action_2.url = (
-        f"https://controller_2/#/jobs/workflow/{job_ids[0]}/details/"
-    )
-    audit_action_3.url = (
-        f"https://controller_1/#/jobs/workflow/{job_ids[1]}/details/"
-    )
+    audit_action_1.url = f"https://controller_1/#/jobs/playbook/{job_ids[0]}/details/"  # noqa: E231,E501
+    audit_action_2.url = f"https://controller_2/#/jobs/workflow/{job_ids[0]}/details/"  # noqa: E231,E501
+    audit_action_3.url = f"https://controller_1/#/jobs/workflow/{job_ids[1]}/details/"  # noqa: E231,E501
     audit_action_1.save(update_fields=["url"])
     audit_action_2.save(update_fields=["url"])
     audit_action_3.save(update_fields=["url"])

--- a/tests/integration/api/test_auth.py
+++ b/tests/integration/api/test_auth.py
@@ -23,7 +23,7 @@ from tests.integration.constants import api_url_v1
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
-auth_url = f"https://testserver{api_url_v1}/auth/session"
+auth_url = f"https://testserver{api_url_v1}/auth/session"  # noqa: E231
 login_url = f"{auth_url}/login/"
 logout_url = f"{auth_url}/logout/"
 
@@ -104,7 +104,7 @@ def test_refresh_token(base_client: RequestsClient):
         is_service_account=True,
     )
     data = {"refresh": jwt_refresh_token(user.id)}
-    url = f"https://testserver{api_url_v1}/auth/token/refresh/"
+    url = f"https://testserver{api_url_v1}/auth/token/refresh/"  # noqa: E231
     response = base_client.post(url, data)
     assert response.status_code == status.HTTP_200_OK
     assert "access" in response.data
@@ -113,7 +113,7 @@ def test_refresh_token(base_client: RequestsClient):
 @pytest.mark.django_db
 def test_refresh_token_with_bad_token(base_client: RequestsClient):
     data = {"refresh": "bad token"}
-    url = f"https://testserver{api_url_v1}/auth/token/refresh/"
+    url = f"https://testserver{api_url_v1}/auth/token/refresh/"  # noqa: E231
     response = base_client.post(url, data)
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -131,7 +131,7 @@ def test_refresh_token_preserves_activation_instance_id(
     _, refresh_token = create_jwt_token(activation_instance_id=activation_id)
 
     data = {"refresh": refresh_token}
-    url = f"https://testserver{api_url_v1}/auth/token/refresh/"
+    url = f"https://testserver{api_url_v1}/auth/token/refresh/"  # noqa: E231
     response = base_client.post(url, data)
 
     assert response.status_code == status.HTTP_200_OK
@@ -156,7 +156,7 @@ def test_refresh_token_preserves_activation_instance_id_uuid(
     _, refresh_token = create_jwt_token(activation_instance_id=activation_id)
 
     data = {"refresh": refresh_token}
-    url = f"https://testserver{api_url_v1}/auth/token/refresh/"
+    url = f"https://testserver{api_url_v1}/auth/token/refresh/"  # noqa: E231
     response = base_client.post(url, data)
 
     assert response.status_code == status.HTTP_200_OK
@@ -181,7 +181,7 @@ def test_refresh_token_without_activation_instance_id_legacy(
     _, refresh_token = create_jwt_token()
 
     data = {"refresh": refresh_token}
-    url = f"https://testserver{api_url_v1}/auth/token/refresh/"
+    url = f"https://testserver{api_url_v1}/auth/token/refresh/"  # noqa: E231
     response = base_client.post(url, data)
 
     assert response.status_code == status.HTTP_200_OK

--- a/tests/integration/api/test_decision_environment.py
+++ b/tests/integration/api/test_decision_environment.py
@@ -257,9 +257,10 @@ def test_create_decision_environment_url(
     assert response.status_code == return_code
     if return_code == status.HTTP_400_BAD_REQUEST:
         errors = response.data.get("image_url")
-        assert f"Image url {image_url} is malformed; {unallowed}" in str(
-            errors
+        expected = (
+            f"Image url {image_url} is malformed; {unallowed}"  # noqa: E702
         )
+        assert expected in str(errors)
 
 
 @pytest.mark.parametrize(
@@ -505,9 +506,10 @@ def test_create_decision_environment_with_no_credential(
     assert response.status_code == return_code
     if return_code == status.HTTP_400_BAD_REQUEST:
         errors = response.data.get("image_url")
-        assert f"Image url {image_url} is malformed; {unallowed}" in str(
-            errors
+        expected = (
+            f"Image url {image_url} is malformed; {unallowed}"  # noqa: E702
         )
+        assert expected in str(errors)
 
 
 @pytest.mark.parametrize(
@@ -549,9 +551,10 @@ def test_patch_decision_environment_with_no_credential(
     assert response.status_code == return_code
     if return_code == status.HTTP_400_BAD_REQUEST:
         errors = response.data.get("image_url")
-        assert f"Image url {image_url} is malformed; {unallowed}" in str(
-            errors
+        expected = (
+            f"Image url {image_url} is malformed; {unallowed}"  # noqa: E702
         )
+        assert expected in str(errors)
 
 
 @pytest.mark.django_db

--- a/tests/integration/api/test_event_stream.py
+++ b/tests/integration/api/test_event_stream.py
@@ -93,7 +93,7 @@ def test_retrieve_event_stream(
     assert response.data["owner"] == "luke.skywalker"
 
     uuid = default_event_streams[0].uuid
-    base_url = f"https://www.example.com/ohlala{api_url_v1}"
+    base_url = f"https://www.example.com/ohlala{api_url_v1}"  # noqa: E231
     expected_url = f"{base_url}/external_event_stream/{uuid}/post/"
     assert response.data["url"] == expected_url
 

--- a/tests/integration/api/test_event_stream_basic.py
+++ b/tests/integration/api/test_event_stream_basic.py
@@ -69,9 +69,9 @@ def test_post_event_stream_with_basic_auth(
     }
     event_stream = create_event_stream(base_client, data_in)
     if bogus_password:
-        user_pass = f"{username}:{bogus_password}"
+        user_pass = f"{username}:{bogus_password}"  # noqa: E231
     else:
-        user_pass = f"{username}:{secret}"
+        user_pass = f"{username}:{secret}"  # noqa: E231
 
     auth_value = f"Basic {base64.b64encode(user_pass.encode()).decode()}"
     data = {"a": 1, "b": 2}
@@ -151,7 +151,7 @@ def test_post_event_stream_with_basic_auth_bad_encoding(
         "test_mode": True,
     }
     event_stream = create_event_stream(admin_client, data_in)
-    user_pass = f"{username}:{secret}"
+    user_pass = f"{username}:{secret}"  # noqa: E231
 
     auth_value = f"Basic {base64.b64encode(user_pass.encode()).decode()}"
     headers = {

--- a/tests/integration/test_logging.py
+++ b/tests/integration/test_logging.py
@@ -53,6 +53,6 @@ def test_worker_startup_logs():
 
     error_message = (
         f"Expected message '{expected_message}' "
-        f"not found in stderr output: {stderr}"
+        f"not found in stderr output: {stderr}"  # noqa: E713
     )
     assert found, error_message

--- a/tests/unit/test_credential_validation.py
+++ b/tests/unit/test_credential_validation.py
@@ -221,7 +221,7 @@ def test_validate_schema():
     errors = validate_schema(missing_required_field_schemas)
 
     for field in missing_fields:
-        assert f"required field {field} does not exist" in errors
+        assert f"required field {field} does not exist" in errors  # noqa: E713
 
     required_field_schemas = {
         "fields": [


### PR DESCRIPTION
## Summary
- Suppresses 25 flake8 false positives caused by its tokenizer misreading content inside f-strings
- E231 (colon in URLs like `f"https://..."`), E702 (semicolons in string text), E713 (`not...in` in string text)
- No code logic changes — all fixes are `# noqa` comments

## Changes
- 5 source files: `event_stream_authentication.py`, `serializers/project.py`, `credentials.py`, `podman.py`, `orchestrator.py`
- 7 test files: `test_analytics_collectors.py`, `test_auth.py`, `test_decision_environment.py`, `test_event_stream.py`, `test_event_stream_basic.py`, `test_logging.py`, `test_credential_validation.py`

## Test Plan
- [x] `task lint` — all linters pass clean (black, isort, ruff, flake8, migrations)
- [x] `task test` on all 12 changed files — 174/174 passed

## Jira
N/A — lint cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code and test formatting to comply with linting rules.
  * Standardized select string constructions and logging statements without changing application behavior.

* **Tests**
  * Preserved existing authentication, event-stream, analytics, credential-validation, and error-handling test coverage.
  * Clarified several multiline assertions while keeping expected results unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->