### PR TITLE
fix: sonar issues: default factory vaultdata

### DIFF
--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -15,7 +15,7 @@ import json
 import logging
 import secrets
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 import yaml
@@ -83,7 +83,7 @@ PG_NOTIFY_DSN = (
 
 @dataclass
 class VaultData:
-    password: str = secrets.token_urlsafe()
+    password: str = field(default_factory=secrets.token_urlsafe)
     password_used: bool = False
 
 
@@ -207,16 +207,16 @@ def _normalize_activation_k8s_pod_fields(data: dict) -> None:
         sa = str(sa).strip()
         data["k8s_pod_service_account_name"] = sa or None
 
-    for field in (
+    for key in (
         "k8s_pod_labels",
         "k8s_pod_annotations",
         "k8s_pod_node_selector",
     ):
-        val = data.get(field)
+        val = data.get(key)
         if val is None:
-            data[field] = {}
+            data[key] = {}
         elif isinstance(val, dict):
-            data[field] = _trim_string_dict(val, field)
+            data[key] = _trim_string_dict(val, key)
 
 
 def _extend_extra_vars_from_credentials(


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AAP-77394

One of multiple PRs addressing sonar quality gate issues. This PR addresses what seems like a bug in our activations. The Vaultdata class password field was evaluated once at class definition. Which means that all activations ended up having the same vault password. This is a potential security issue because if one password was cracked then all activation vaults are compromised. This PR replaces that field with a factory that will dynamically produce unique passwords. 

A minor variable rename (field → key) in an unrelated loop was also needed to avoid shadowing the new dataclasses.field import.

Assisted-By: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password generation so each activation’s vault gets a fresh, unique password when created (rather than sharing a single computed default).
  * Maintained consistent Kubernetes pod metadata handling for labels, annotations, and node selectors—continuing to convert empty values to `{}` and trim whitespace from provided entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->