### PR TITLE
feat(api): add ordering query param to activation instance logs endpoint

### DIFF
--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -863,9 +863,13 @@ class ActivationInstanceViewSet(viewsets.ReadOnlyModelViewSet):
                 detail=f"Activation Instance with ID={id} does not exist.",
             )
 
+        ordering = request.query_params.get("ordering", "-id")
+        if ordering not in ("id", "-id"):
+            ordering = "-id"
+
         activation_instance_logs = models.RulebookProcessLog.objects.filter(
             activation_instance_id=id
-        ).order_by("-id")
+        ).order_by(ordering)
         activation_instance_logs = self.filter_queryset(
             activation_instance_logs
         )


### PR DESCRIPTION
## Summary
- Adds `?ordering=id` (oldest first) or `?ordering=-id` (newest first) query param to the `/activation-instances/{id}/logs/` endpoint
- Default remains `-id` (newest first) as set in PR #1633
- Fixes eda-qa e2e test `test_list_activation_instance_logs_with_log_levels[debug]` which broke when #1633 reversed the log ordering — early startup messages fell past `page_size=100`

## Changes
- `src/aap_eda/api/views/activation.py` — read `ordering` query param in `logs()` method, validate against allowed values (`id`, `-id`), apply to queryset

## Test Plan
- [x] `task test -- tests/integration/api/test_activation_instance.py` — 9/9 passed
- [x] `task lint` — black, isort, ruff pass; flake8 errors are pre-existing

## Jira
N/A — fixes e2e regression from PR #1633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional ordering for activation instance logs, allowing results to be sorted by ID in ascending or descending order.
  * Results default to descending order when no valid ordering is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->