### PR TITLE
chore(deps): bump poetry pre-commit hook from 2.1.3 to 2.3.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
         pass_filenames: false
         entry: bash -c 'command -v task > /dev/null && CMD=task || CMD=go-task; ${CMD} lint:migrations'
   - repo: https://github.com/python-poetry/poetry
-    rev: '2.1.3'
+    rev: '2.3.4'
     hooks:
       - id: poetry-check
       - id: poetry-lock


### PR DESCRIPTION
## Summary
- Bumps the Poetry pre-commit hook from 2.1.3 to 2.3.4
- The `poetry-lock` hook validates/regenerates the lock file using the pinned Poetry version. Contributors running Poetry 2.3.x locally produce lock files that fail validation against the 2.1.3 hook, causing pre-commit failures on every commit that touches dependencies.

## Changes
- `.pre-commit-config.yaml` — update Poetry repo `rev` from `2.1.3` to `2.3.4`

## Test Plan
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] `poetry lock --check` passes with Poetry 2.3.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Poetry pre-commit tool to the latest version for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->