### PR TITLE
fix(api): revert log endpoint to oldest-first ordering

### DIFF
--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -845,7 +845,7 @@ class ActivationInstanceViewSet(viewsets.ReadOnlyModelViewSet):
     )
     @action(
         detail=False,
-        queryset=models.RulebookProcessLog.objects.order_by("-id"),
+        queryset=models.RulebookProcessLog.objects.order_by("id"),
         filterset_class=filters.ActivationInstanceLogFilter,
         rbac_action=Action.READ,
         url_path="(?P<id>[^/.]+)/logs",
@@ -865,7 +865,7 @@ class ActivationInstanceViewSet(viewsets.ReadOnlyModelViewSet):
 
         activation_instance_logs = models.RulebookProcessLog.objects.filter(
             activation_instance_id=id
-        ).order_by("-id")
+        ).order_by("id")
         activation_instance_logs = self.filter_queryset(
             activation_instance_logs
         )

--- a/tests/integration/api/test_activation_instance.py
+++ b/tests/integration/api/test_activation_instance.py
@@ -106,7 +106,7 @@ def test_list_logs_from_activation_instance(
     response_logs = response.data["results"]
 
     assert len(response_logs) == 2
-    assert response_logs[0]["log"] == "activation-instance-log-2"
+    assert response_logs[0]["log"] == "activation-instance-log-1"
     assert list(response_logs[0]) == [
         "id",
         "log",


### PR DESCRIPTION
## Summary
- Reverts the `-id` (newest-first) ordering on the logs endpoint introduced in #1633
- The ordering change caused logs to display in reverse chronological order in the UI (newest line at top, oldest at bottom)
- The UI renders API results directly without re-sorting, so changing the API order broke the display
- Restoring oldest-first until Phase 2 UI pagination ships with client-side re-sorting support

## Test Plan
- [x] `task test -- tests/integration/api/test_activation_instance.py -v` (9 passed)
- [x] `task test -- tests/integration/api/test_pagination.py -v` (4 passed, regression)

## Related
- Fixes regression from #1633
- AAP-77938

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Activation instance logs are now displayed in ascending order, showing the earliest log first.
  * Updated log listing behavior for consistent ordering across activation instance views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->