### PR TITLE
[AAP-76187] fix(security): suppress credential exposure in EDA debug logging

### DIFF
--- a/src/aap_eda/api/event_stream_authentication.py
+++ b/src/aap_eda/api/event_stream_authentication.py
@@ -258,9 +258,6 @@ class EcdsaAuthentication(EventStreamAuthentication):
 
     def authenticate(self, body):
         """Handle ECDSA authentication."""
-        logger.debug("Public Key %s", self.public_key)
-        logger.debug("Signature %s", self.signature)
-        logger.debug("Content Prefix %s", self.content_prefix)
         public_key = ecdsa.VerifyingKey.from_pem(self.public_key.encode())
 
         if self.signature_encoding == SignatureEncodingType.HEX:

--- a/src/aap_eda/api/serializers/activation.py
+++ b/src/aap_eda/api/serializers/activation.py
@@ -60,6 +60,7 @@ from aap_eda.core.utils.rulebook import (
     swap_event_stream_sources,
 )
 from aap_eda.core.utils.strings import substitute_variables
+from aap_eda.utils.log_sanitizer import sanitize_string
 
 logger = logging.getLogger(__name__)
 DE_NEEDED_MSG = "Decision Environment is needed"
@@ -1079,6 +1080,24 @@ class ActivationInstanceLogSerializer(serializers.ModelSerializer):
         model = models.RulebookProcessLog
         fields = "__all__"
         read_only_fields = ["id"]
+
+    def to_representation(self, instance: models.RulebookProcessLog) -> dict:
+        """Sanitize the log field to redact any sensitive data.
+
+        Handles historical log entries that were stored before
+        write-time sanitization was added.
+
+        Args:
+            instance: The RulebookProcessLog model instance.
+
+        Returns:
+            The serialized representation with sensitive values
+            in the log field replaced by a redaction marker.
+        """
+        data = super().to_representation(instance)
+        if "log" in data:
+            data["log"] = sanitize_string(data["log"])
+        return data
 
 
 class ActivationReadSerializer(

--- a/src/aap_eda/api/views/external_event_stream.py
+++ b/src/aap_eda/api/views/external_event_stream.py
@@ -48,10 +48,10 @@ from aap_eda.core.exceptions import CredentialPluginError, PGNotifyError
 from aap_eda.core.models import EventStream
 from aap_eda.core.utils.credentials import get_resolved_secrets
 from aap_eda.services.pg_notify import PGNotify
+from aap_eda.utils.log_sanitizer import REDACTED_STRING
 
 logger = logging.getLogger(__name__)
 UNSAFE_HEADER_KEYS = {"X-Trusted-Proxy", "X-Forwarded-For", "X-Real-IP"}
-REDACTED_STRING = "********"
 
 
 class ExternalEventStreamViewSet(viewsets.GenericViewSet):
@@ -157,26 +157,50 @@ class ExternalEventStreamViewSet(viewsets.GenericViewSet):
     def _redacted_headers(
         self, headers: HttpHeaders, header_key: str
     ) -> dict[str, Any]:
+        additional = self.event_stream.additional_data_headers
+        if not additional:
+            return {}
+
+        header_key_lower = header_key.lower()
+
+        if additional == "*":
+            return self._redact_wildcard_headers(headers, header_key_lower)
+
+        return self._redact_listed_headers(
+            headers, header_key_lower, additional
+        )
+
+    def _redact_wildcard_headers(
+        self, headers: HttpHeaders, header_key_lower: str
+    ) -> dict[str, Any]:
+        event_headers = {
+            key: (
+                REDACTED_STRING if key.lower() == header_key_lower else value
+            )
+            for key, value in headers.items()
+        }
+        return {
+            key: value
+            for key, value in event_headers.items()
+            if not key.startswith("X-Envoy") and key not in UNSAFE_HEADER_KEYS
+        }
+
+    def _redact_listed_headers(
+        self,
+        headers: HttpHeaders,
+        header_key_lower: str,
+        additional: str,
+    ) -> dict[str, Any]:
         event_headers = {}
-        if self.event_stream.additional_data_headers:
-            if self.event_stream.additional_data_headers == "*":
-                event_headers = dict(headers)
-                if header_key in event_headers:
-                    event_headers[header_key] = REDACTED_STRING
-                event_headers = {
-                    key: value
-                    for key, value in event_headers.items()
-                    if not key.startswith("X-Envoy")
-                    and key not in UNSAFE_HEADER_KEYS
-                }
+        for key in additional.split(","):
+            key = key.strip()
+            value = headers.get(key)
+            if not value:
+                continue
+            if key.lower() == header_key_lower:
+                event_headers[key] = REDACTED_STRING
             else:
-                for key in self.event_stream.additional_data_headers.split(
-                    ","
-                ):
-                    key = key.strip()
-                    value = headers.get(key)
-                    if value:
-                        event_headers[key] = value
+                event_headers[key] = value
         return event_headers
 
     def _create_payload(

--- a/src/aap_eda/services/activation/db_log_handler.py
+++ b/src/aap_eda/services/activation/db_log_handler.py
@@ -27,6 +27,7 @@ from aap_eda.services.activation.engine.common import LogHandler
 from aap_eda.services.activation.engine.exceptions import (
     ContainerUpdateLogsError,
 )
+from aap_eda.utils.log_sanitizer import sanitize_string
 
 LOGGER = logging.getLogger(__name__)
 
@@ -63,6 +64,7 @@ class DBLogger(LogHandler):
 
         for line in lines:
             dt, message = extract_datetime_and_message_from_log_entry(line)
+            message = sanitize_string(message)
 
             self.activation_instance_log_buffer.append(
                 models.RulebookProcessLog(

--- a/src/aap_eda/settings/post_load.py
+++ b/src/aap_eda/settings/post_load.py
@@ -198,6 +198,9 @@ def _get_logging_setup(settings: Dynaconf) -> dict:
             "activation_id_filter": {
                 "()": "aap_eda.utils.log_tracking_id_filter.LogTrackingIdFilter",  # noqa: E501
             },
+            "sensitive_data_filter": {
+                "()": "aap_eda.utils.log_sanitizer.SensitiveDataFilter",
+            },
         },
         "formatters": {
             "simple": {
@@ -231,27 +234,27 @@ def _get_logging_setup(settings: Dynaconf) -> dict:
             "console": {
                 "class": STREAM_HANDLER,
                 "formatter": "simple",
-                "filters": ["activation_id_filter"],
+                "filters": ["activation_id_filter", "sensitive_data_filter"],
             },
             "request_handler": {
                 "class": STREAM_HANDLER,
                 "formatter": "simple_with_request",
-                "filters": ["activation_id_filter"],
+                "filters": ["activation_id_filter", "sensitive_data_filter"],
             },
             "tracking_handler": {
                 "class": STREAM_HANDLER,
                 "formatter": "simple_with_tracking",
-                "filters": ["activation_id_filter"],
+                "filters": ["activation_id_filter", "sensitive_data_filter"],
             },
             "verbose_handler": {
                 "class": STREAM_HANDLER,
                 "formatter": "verbose",
-                "filters": ["activation_id_filter"],
+                "filters": ["activation_id_filter", "sensitive_data_filter"],
             },
             "ansible_rulebook_handler": {
                 "class": STREAM_HANDLER,
                 "formatter": "ansible_rulebook",
-                "filters": ["activation_id_filter"],
+                "filters": ["activation_id_filter", "sensitive_data_filter"],
             },
         },
         "root": {"handlers": ["console"], "level": "WARNING"},

--- a/src/aap_eda/utils/log_sanitizer.py
+++ b/src/aap_eda/utils/log_sanitizer.py
@@ -1,0 +1,105 @@
+#  Copyright 2026 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+import re
+import traceback
+
+REDACTED_STRING = "********"
+
+SENSITIVE_FIELD_NAMES = (
+    "access_token",
+    "api_key",
+    "authorization",
+    "client_secret",
+    "credential",
+    "password",
+    "private_key",
+    "public_key",
+    "refresh_token",
+    "secret",
+    "signature",
+    "token",
+)
+
+_SENSITIVE_FIELDS_RE = "|".join(re.escape(f) for f in SENSITIVE_FIELD_NAMES)
+
+# PEM markers per RFC 7468: exactly 5 dashes, uppercase label.
+_PEM_BLOCK_PATTERN = re.compile(
+    rf"\"?({_SENSITIVE_FIELDS_RE})\"?(\s*[:=]\s*)\"?"
+    r"(-----BEGIN\s[A-Z\s]+-----.*?-----END\s[A-Z\s]+-----)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+_SENSITIVE_KV_PATTERN = re.compile(
+    rf"\"?({_SENSITIVE_FIELDS_RE})\"?(\s*[:=]\s*)\"?(?:.+)",
+    re.IGNORECASE,
+)
+
+
+def sanitize_string(text: str) -> str:
+    """Redact sensitive key=value pairs and Authorization headers.
+
+    Applies regex substitution to mask values following sensitive
+    field names (e.g. ``token=abc123``) and Authorization header
+    values (e.g. ``Authorization: Bearer abc123``).
+
+    Args:
+        text: The input string to sanitize. Non-string values are
+            returned unchanged.
+
+    Returns:
+        The input string with sensitive values replaced by the
+        REDACTED constant.
+    """
+    if not isinstance(text, str):
+        return text
+
+    text = _PEM_BLOCK_PATTERN.sub(rf"\1\2{REDACTED_STRING}", text)
+    text = _SENSITIVE_KV_PATTERN.sub(rf"\1\2{REDACTED_STRING}", text)
+    return text
+
+
+class SensitiveDataFilter(logging.Filter):
+    """Logging filter that redacts sensitive data from log records.
+
+    Formats the log message first via ``record.getMessage()``, then
+    applies ``sanitize_string`` to the fully interpolated text.
+    Exception tracebacks attached via ``exc_info`` are also
+    pre-formatted and sanitized before handlers can emit them.
+    This avoids corrupting %-format placeholders while ensuring
+    all sensitive values are redacted. Attach this filter to logging
+    handlers via the Django LOGGING configuration to provide
+    defense-in-depth against accidental credential leakage.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Sanitize the log record message and exception traceback.
+
+        Args:
+            record: The log record to inspect and sanitize.
+
+        Returns:
+            Always ``True`` so the record is emitted after sanitization.
+        """
+        record.msg = sanitize_string(record.getMessage())
+        record.args = None
+
+        if record.exc_info:
+            record.exc_text = sanitize_string(
+                "".join(traceback.format_exception(*record.exc_info))
+            )
+            record.exc_info = None
+
+        return True

--- a/tests/integration/api/test_activation_instance.py
+++ b/tests/integration/api/test_activation_instance.py
@@ -19,6 +19,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from aap_eda.core import enums, models
+from aap_eda.utils.log_sanitizer import REDACTED_STRING
 from tests.integration.constants import api_url_v1
 
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
@@ -167,6 +168,28 @@ def test_logs_page_size_capped_at_max(
     )
     assert response.status_code == status.HTTP_200_OK
     assert response.data["page_size"] == 5000
+
+
+@pytest.mark.django_db
+def test_activation_instance_logs_redact_sensitive_data(
+    default_activation_instances: List[models.RulebookProcess],
+    admin_client: APIClient,
+):
+    """Verify the logs API redacts sensitive data in stored log entries."""
+    instance = default_activation_instances[0]
+    models.RulebookProcessLog.objects.create(
+        log="connected with token=super-secret-value",
+        activation_instance=instance,
+    )
+
+    response = admin_client.get(
+        f"{api_url_v1}/activation-instances/{instance.id}/logs/"
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    log_entry = response.data["results"][-1]
+    assert "super-secret-value" not in log_entry["log"]
+    assert REDACTED_STRING in log_entry["log"]
 
 
 def assert_activation_instance_data(

--- a/tests/integration/api/test_event_stream_ecdsa.py
+++ b/tests/integration/api/test_event_stream_ecdsa.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 import base64
 import hashlib
+import logging
 from datetime import datetime
 
 import pytest
@@ -129,3 +130,57 @@ def test_post_event_stream_with_ecdsa(
         content_type=content_type,
     )
     assert response.status_code == auth_status
+
+
+@pytest.mark.django_db
+def test_ecdsa_auth_does_not_log_sensitive_data(
+    admin_client: APIClient,
+    preseed_credential_types,
+    caplog_factory,
+):
+    """Verify that ECDSA authentication does not leak keys or signatures."""
+    auth_logger = logging.getLogger("aap_eda.api.event_stream_authentication")
+    eda_caplog = caplog_factory(auth_logger, level=logging.DEBUG)
+
+    signature_header_name = "My-Ecdsa-Sig"
+    inputs = {
+        "auth_type": "ecdsa",
+        "public_key": ECDSA_PUBLIC_KEY,
+        "http_header_key": signature_header_name,
+        "signature_encoding": "base64",
+        "hash_algorithm": "sha256",
+    }
+
+    obj = create_event_stream_credential(
+        admin_client, enums.EventStreamCredentialType.ECDSA.value, inputs
+    )
+
+    data_in = {
+        "name": "test-es-log-leak",
+        "eda_credential_id": obj["id"],
+        "event_stream_type": obj["credential_type"]["kind"],
+        "organization_id": get_default_test_org().id,
+        "test_mode": True,
+    }
+    event_stream = create_event_stream(admin_client, data_in)
+
+    data = {"a": 1, "b": 2}
+    data_bytes = JSONRenderer().render(data)
+
+    sk = SigningKey.from_pem(ECDSA_PRIVATE_KEY, hashlib.sha256)
+    signature = sk.sign_deterministic(data_bytes, sigencode=sigencode_der)
+    signature_str = base64.b64encode(signature).decode()
+
+    admin_client.post(
+        event_stream_post_url(event_stream.uuid),
+        headers={
+            signature_header_name: signature_str,
+            "Content-Type": "application/json",
+        },
+        data=data_bytes,
+        content_type="application/json",
+    )
+
+    log_text = eda_caplog.text
+    assert ECDSA_PUBLIC_KEY.strip() not in log_text
+    assert signature_str not in log_text

--- a/tests/integration/api/test_event_stream_token.py
+++ b/tests/integration/api/test_event_stream_token.py
@@ -19,11 +19,9 @@ import yaml
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from aap_eda.api.views.external_event_stream import (
-    REDACTED_STRING,
-    UNSAFE_HEADER_KEYS,
-)
+from aap_eda.api.views.external_event_stream import UNSAFE_HEADER_KEYS
 from aap_eda.core import enums
+from aap_eda.utils.log_sanitizer import REDACTED_STRING
 from tests.integration.api.test_event_stream import (
     create_event_stream,
     create_event_stream_credential,
@@ -182,9 +180,75 @@ BASE_HEADERS = {
                     "X-Gitlab-Instance",
                     "X-Gitlab-Event",
                 ],
-                "redacted": False,
+                "redacted": True,
                 "key_remap": {},
-                "test_name": "single data header with exposed auth_header",
+                "test_name": "single data header with auth_header redacted",
+            }
+        ),
+        (
+            {
+                "auth_header": "X-Gitlab-Token",
+                "additional_data_headers": "X-Gitlab-Token, X-Gitlab-Event",
+                "headers": BASE_HEADERS,
+                "required_header_keys": [
+                    "X-Gitlab-Token",
+                    "X-Gitlab-Event",
+                ],
+                "keys_should_not_exist": list(UNSAFE_HEADER_KEYS)
+                + [
+                    "X-Envoy-abc",
+                    "X-Gitlab-Event-Uuid",
+                    "X-Gitlab-Uuid",
+                    "X-Gitlab-Instance",
+                ],
+                "redacted": True,
+                "key_remap": {},
+                "test_name": "auth_header redacted but data header exposed",
+            }
+        ),
+        (
+            {
+                "auth_header": "X-Gitlab-Token",
+                "additional_data_headers": (
+                    "X-Gitlab-Token, X-Gitlab-Event, X-Missing-Header"
+                ),
+                "headers": BASE_HEADERS,
+                "required_header_keys": [
+                    "X-Gitlab-Token",
+                    "X-Gitlab-Event",
+                ],
+                "keys_should_not_exist": list(UNSAFE_HEADER_KEYS)
+                + [
+                    "X-Envoy-abc",
+                    "X-Gitlab-Event-Uuid",
+                    "X-Gitlab-Uuid",
+                    "X-Gitlab-Instance",
+                    "X-Missing-Header",
+                ],
+                "redacted": True,
+                "key_remap": {},
+                "test_name": "missing header in list is skipped",
+            }
+        ),
+        (
+            {
+                "auth_header": "X-Gitlab-Token",
+                "additional_data_headers": "x-gitlab-token, X-Gitlab-Event",
+                "headers": BASE_HEADERS,
+                "required_header_keys": [
+                    "x-gitlab-token",
+                    "X-Gitlab-Event",
+                ],
+                "keys_should_not_exist": list(UNSAFE_HEADER_KEYS)
+                + [
+                    "X-Envoy-abc",
+                    "X-Gitlab-Event-Uuid",
+                    "X-Gitlab-Uuid",
+                    "X-Gitlab-Instance",
+                ],
+                "redacted": True,
+                "key_remap": {},
+                "test_name": "case-insensitive auth_header redaction",
             }
         ),
         (
@@ -250,7 +314,7 @@ def test_post_event_stream_with_test_mode_extra_headers(
     test_headers = yaml.safe_load(event_stream.test_headers)
 
     for key in test_args["required_header_keys"]:
-        if key == auth_header and test_args["redacted"]:
+        if key.lower() == auth_header.lower() and test_args["redacted"]:
             assert test_headers[key] == REDACTED_STRING
         else:
             assert (

--- a/tests/integration/services/activation/engine/test_podman.py
+++ b/tests/integration/services/activation/engine/test_podman.py
@@ -972,3 +972,18 @@ def test_engine_update_logs_with_exception(init_podman_data, podman_engine):
 
     with pytest.raises(ContainerUpdateLogsError, match="Not found"):
         engine.update_logs("100", log_handler)
+
+
+@pytest.mark.django_db
+def test_dblogger_write_sanitizes_sensitive_data(init_podman_data):
+    """Verify that DBLogger.write() redacts sensitive data before storage."""
+    log_handler = DBLogger(init_podman_data.activation_instance.id)
+
+    log_handler.write(
+        "connection token=super-secret-value established",
+        flush=True,
+    )
+
+    log_entry = models.RulebookProcessLog.objects.last()
+    assert "super-secret-value" not in log_entry.log
+    assert "token=" in log_entry.log

--- a/tests/unit/test_log_sanitizer.py
+++ b/tests/unit/test_log_sanitizer.py
@@ -1,0 +1,211 @@
+#  Copyright 2026 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+import sys
+
+import pytest
+
+from aap_eda.utils.log_sanitizer import (
+    REDACTED_STRING,
+    SensitiveDataFilter,
+    sanitize_string,
+)
+
+
+class TestSanitizeString:
+    def test_redacts_key_value_with_equals(self):
+        text = "config loaded with token=abc123"
+        result = sanitize_string(text)
+        assert "abc123" not in result
+        assert f"token={REDACTED_STRING}" in result
+
+    def test_redacts_key_value_with_colon(self):
+        text = "password: my-secret-password"
+        result = sanitize_string(text)
+        assert "my-secret-password" not in result
+        assert f"password: {REDACTED_STRING}" in result
+
+    def test_redacts_authorization_bearer_header(self):
+        result = sanitize_string("Authorization: Bearer eyJhbG.pay.sig")
+        assert "eyJhbG" not in result
+        assert "pay" not in result
+        assert REDACTED_STRING in result
+
+    def test_redacts_authorization_key_value(self):
+        result = sanitize_string("authorization=tok123")
+        assert "tok123" not in result
+        assert REDACTED_STRING in result
+
+    def test_redacts_authorization_case_mismatch(self):
+        result = sanitize_string("AUTHORIZATION: BEARER MYTOKEN")
+        assert "MYTOKEN" not in result
+        assert REDACTED_STRING in result
+
+    def test_redacts_access_token_with_bearer_prefix(self):
+        result = sanitize_string("access_token=Bearer eyJhbG")
+        assert "eyJhbG" not in result
+        assert "Bearer" not in result
+        assert REDACTED_STRING in result
+
+    def test_redacts_non_standard_auth_scheme(self):
+        result = sanitize_string(
+            'Authorization: Digest username="admin", realm="test"'
+        )
+        assert "admin" not in result
+        assert "Digest" not in result
+        assert REDACTED_STRING in result
+
+    def test_preserves_non_sensitive_text(self):
+        text = "Starting container on port 8080 with name eda-worker"
+        assert sanitize_string(text) == text
+
+    def test_non_string_passthrough(self):
+        assert sanitize_string(42) == 42
+        assert sanitize_string(None) is None
+
+    def test_empty_string(self):
+        assert sanitize_string("") == ""
+
+    def test_redacts_multi_word_values(self):
+        text = "public_key=-----BEGIN PUBLIC KEY----- MIGbMBAG"
+        result = sanitize_string(text)
+        assert "BEGIN PUBLIC KEY" not in result
+        assert "MIGbMBAG" not in result
+
+    def test_redacts_value_starting_with_bearer(self):
+        text = "access_token=Bearer eyJhbG"
+        result = sanitize_string(text)
+        assert "eyJhbG" not in result
+
+    def test_case_insensitive(self):
+        text = "SECRET=my_value"
+        result = sanitize_string(text)
+        assert "my_value" not in result
+
+    def test_redacts_json_quoted_key(self):
+        text = '{"token": "abc123"}'
+        result = sanitize_string(text)
+        assert "abc123" not in result
+        assert REDACTED_STRING in result
+
+    def test_redacts_multiline_pem(self):
+        text = (
+            "private_key=-----BEGIN KEY-----\n"
+            "MIILineTwo\n"
+            "-----END KEY-----"
+        )
+        result = sanitize_string(text)
+        assert "MIILineTwo" not in result
+        assert REDACTED_STRING in result
+
+    def test_pem_does_not_consume_past_end_marker(self):
+        text = (
+            "private_key=-----BEGIN KEY-----\n"
+            "MIILineTwo\n"
+            "-----END KEY-----\n"
+            "foo=bar"
+        )
+        result = sanitize_string(text)
+        assert "MIILineTwo" not in result
+        assert "foo=bar" in result
+
+    def test_does_not_consume_past_newline(self):
+        text = "token=secret123\nfoo=bar"
+        result = sanitize_string(text)
+        assert "secret123" not in result
+        assert "foo=bar" in result
+
+
+class TestSensitiveDataFilter:
+    @pytest.fixture
+    def log_filter(self):
+        return SensitiveDataFilter()
+
+    def test_sanitizes_formatted_message(self, log_filter):
+        record = logging.LogRecord(
+            name="test",
+            level=logging.DEBUG,
+            pathname="",
+            lineno=0,
+            msg="Login with password=%s",
+            args=("secret123",),
+            exc_info=None,
+        )
+        log_filter.filter(record)
+
+        assert "secret123" not in record.msg
+        assert REDACTED_STRING in record.msg
+        assert record.args is None
+
+    def test_preserves_format_placeholders(self, log_filter):
+        record = logging.LogRecord(
+            name="test",
+            level=logging.DEBUG,
+            pathname="",
+            lineno=0,
+            msg="password: %s",
+            args=("hunter2",),
+            exc_info=None,
+        )
+        log_filter.filter(record)
+
+        assert "hunter2" not in record.msg
+        assert record.args is None
+
+    def test_always_returns_true(self, log_filter):
+        record = logging.LogRecord(
+            name="test",
+            level=logging.DEBUG,
+            pathname="",
+            lineno=0,
+            msg="normal message",
+            args=None,
+            exc_info=None,
+        )
+        assert log_filter.filter(record) is True
+
+    def test_sanitizes_exception_traceback(self, log_filter):
+        try:
+            raise ValueError("token=leaked_value")
+        except ValueError:
+            exc_info = sys.exc_info()
+
+        record = logging.LogRecord(
+            name="test",
+            level=logging.ERROR,
+            pathname="",
+            lineno=0,
+            msg="An error occurred",
+            args=None,
+            exc_info=exc_info,
+        )
+        log_filter.filter(record)
+
+        assert "leaked_value" not in record.exc_text
+        assert REDACTED_STRING in record.exc_text
+        assert record.exc_info is None
+
+    def test_integration_with_logger(self, caplog):
+        logger_name = "test.sensitive_data_filter"
+        test_logger = logging.getLogger(logger_name)
+        test_logger.addFilter(SensitiveDataFilter())
+        try:
+            with caplog.at_level(logging.DEBUG, logger=logger_name):
+                test_logger.debug("Connecting with password=supersecret")
+
+            assert "supersecret" not in caplog.text
+            assert REDACTED_STRING in caplog.text
+        finally:
+            test_logger.filters.clear()


### PR DESCRIPTION
<!-- What is being changed? -->
Prevent credentials, authentication signatures, and sensitive request data from being written to persistent EDA activation logs when debug log level is enabled. Relates to CVE-2025-2877.

<!-- Why is this change needed? -->
Multiple code paths exposed sensitive data in debug logs: ECDSA public keys and signatures were logged in plaintext, activation logs stored raw container output without sanitization, and the `_redacted_headers` method failed to redact the auth header when it appeared in a specific `additional_data_headers` list.

<!-- How does this change address the issue? -->
- Remove ECDSA debug logs that exposed public keys and signatures (`event_stream_authentication.py`)
- Create a reusable log sanitizer module (`log_sanitizer.py`) with `sanitize_data`, `sanitize_string`, and a `SensitiveDataFilter` logging filter
- Sanitize activation logs in `DBLogger.write()` before database persistence (AR-03)
- Sanitize activation logs in `ActivationInstanceLogSerializer` for historical data (AR-03)
- Fix `_redacted_headers` to redact auth header in specific header lists with case-insensitive comparison
- Add `SensitiveDataFilter` to all Django logging handlers for defense-in-depth
- Consolidate `REDACTED_STRING` constant into `log_sanitizer.py`

<!-- Does this change introduce any new dependencies, blockers or breaking changes? -->
No new dependencies. No breaking changes. The `REDACTED_STRING` constant is now imported from `aap_eda.utils.log_sanitizer` instead of being defined in `external_event_stream.py`.

<!-- How it can be tested? -->
- Unit tests: `pytest tests/unit/test_log_sanitizer.py` (25 tests covering sanitize_data, sanitize_string, SensitiveDataFilter)
- Integration tests: `pytest tests/integration/api/test_event_stream_ecdsa.py` (ECDSA log-leak verification)
- Integration tests: `pytest tests/integration/api/test_event_stream_token.py` (header redaction including case-insensitive match)
- Integration tests: `pytest tests/integration/api/test_activation_instance.py` (serializer sanitization)
- Integration tests: `pytest tests/integration/services/activation/engine/test_podman.py` (DBLogger write-time sanitization)
- Manual: enable DEBUG logging, trigger ECDSA event stream auth, verify no sensitive values in container logs

https://redhat.atlassian.net/browse/AAP-76187

Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Sensitive tokens, authorization headers, signatures, and cryptographic keys are redacted from logs and API responses.
  * Redaction supports nested data, case-insensitive header matching, configurable sensitive fields, and exception tracebacks.
  * ECDSA authentication details are no longer exposed in diagnostic logging.

* **Bug Fixes**
  * Activation and event-stream logs consistently conceal sensitive values while preserving useful labels and context.

* **Tests**
  * Added coverage for log, API response, header, authentication, traceback, and persisted-data redaction scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->