### PR TITLE
fix: disable mintmaker to run pipeline-migration-tool

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,9 @@
   "tekton": {
     "enabled": true,
     "automerge": true,
-    "schedule": ["* */12 * * 1-5"]
+    "schedule": ["* */12 * * 1-5"],
+    "postUpgradeTasks": {
+      "commands": []
+    }
   }
 }


### PR DESCRIPTION
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
<!-- If applicable, provide a link to the issue that is being addressed -->
When mintmaker bumps tekton resources it is failing on running the pipeline-migration-tool. This runs as a post upgrade task and fails when trying to run against tekton bundles. Disabling this to allow CI checks to pass and merge updated pipeline bundles.

It is failing because we use tekton bundles and not inline `pipelineSpec`.

To resolve CI checks failing in https://github.com/ansible/eda-server/pull/1608.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency maintenance settings to include an explicit post-upgrade task configuration.
  * Existing weekday scheduling remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->