### PR TITLE
chore: reduce mint maker tekton pipeline bundle updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "tekton": {
     "enabled": true,
     "automerge": true,
-    "schedule": ["* */12 * * 1-5"],
+    "schedule": ["* 8,17 * * 5"],
     "postUpgradeTasks": {
       "commands": []
     }


### PR DESCRIPTION
## Summary

This PR adjusts the schedule to check for new tekton pipeline bundle shas to once a week on Fridays, at 8AM and 5PM. The current cadence is a new PR every day which is too much.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated dependency update schedule to run hourly on Fridays between 08:00 and 17:00.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->