### PR TITLE
feat: bump sqlparse to 0.6.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2999,19 +2999,19 @@ files = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.3"
+version = "0.6.0"
 description = "A non-validating SQL parser."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "sqlparse-0.5.3-py3-none-any.whl", hash = "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca"},
-    {file = "sqlparse-0.5.3.tar.gz", hash = "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272"},
+    {file = "sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f"},
+    {file = "sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9"},
 ]
 
 [package.extras]
-dev = ["build", "hatch"]
-doc = ["sphinx"]
+dev = ["build"]
+doc = ["furo", "sphinx"]
 
 [[package]]
 name = "stack-data"


### PR DESCRIPTION
Fixes: CVE-2026-59893
Fixes: CVE-2026-54284
Fixes: CVE-2026-71491

Related: https://redhat.atlassian.net/browse/AAP-89898
Related: https://redhat.atlassian.net/browse/AAP-89936
Related: https://redhat.atlassian.net/browse/AAP-89814