### PR TITLE
chore: enable renovate tekton updates also in stable branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     "enabled": true,
     "automerge": true,
     "schedule": ["* 8,17 * * 5"],
+    "baseBranchPatterns": ["main", "/^stable-\\d+\\.\\d+$/"],
     "postUpgradeTasks": {
       "commands": []
     }


### PR DESCRIPTION
This should make it easier to keep their pipelines up-to-date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated dependency updates now target only the `main` branch and versioned stable branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->