### PR TITLE
Skip color output in logging.sh when no usable terminal is available

### DIFF
--- a/scripts/common/logging.sh
+++ b/scripts/common/logging.sh
@@ -3,7 +3,10 @@
 # timestamp
 TIMESTAMP=$(date "+%Y-%m-%d %H:%M:%S")
 
-if which tput &> /dev/null; then
+if command -v tput &> /dev/null \
+    && [ -t 1 ] \
+    && [ -n "${TERM:-}" ] \
+    && tput setaf 1 &> /dev/null; then
   # colors
   ERR=$(tput setaf 1)
   INFO=$(tput setaf 178)


### PR DESCRIPTION
### What is being changed?
`scripts/common/logging.sh` only checked whether the `tput` binary existed before using it to set up colored log output. It didn't check whether `tput` would actually work in the current environment. This change strengthens that check to also verify that `stdout` is attached to a real terminal, that `$TERM` is set, and that a real `tput` call succeeds. Falling back to the existing plain-text log functions otherwise.

### Why is this change needed?
Refs #1670

### How does this change address the issue?
When a container runs a command via `/bin/bash -c "..."` without an allocated TTY (as docker-compose-dev.yaml does for eda-api), `$TERM` is unset, so `tput` fails with `tput: No value for $TERM and no -T specified`. Since `scripts/create_superuser.sh` (which sources this file) runs with `set -o errexit`, that failure aborted the whole startup chain, breaking the `eda-api` container and, in turn, the `E2E` test workflows.

### Files:

`scripts/common/logging.sh` — strengthen the guard before attempting colored output

### Does this change introduce any new dependencies, blockers or breaking changes?
No new dependencies. No behavior change for interactive terminal use; environments without a usable terminal now get plain-text logs instead of crashing.

### How it was tested?
Verified in isolation that a failing check inside the if condition doesn't trigger `set -o errexit` in the calling script (tested with a minimal reproduction script).

Reproduced the original failure and confirmed the fix resolves it:

```
bash
docker compose -p eda -f tools/docker/docker-compose-dev.yaml build
docker compose -p eda -f tools/docker/docker-compose-dev.yaml up -d
curl -s http://localhost:8000/_healthz
```

Before this change, `eda-api` exits with code 2 and every dependent service stays stuck waiting. After this change, `eda-api` reports healthy and the health check returns `{"status":"OK"}`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command-line log output detection to avoid ANSI colors when the terminal does not support them or the required environment settings are unavailable.
  - Plain, uncolored logs are now used automatically in unsupported terminal environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->