### PR TITLE
[DO NOT MERGE] test(advisory-lock): surface thread exceptions in test_job_uniqueness

### DIFF
--- a/tests/integration/test_advisory_lock.py
+++ b/tests/integration/test_advisory_lock.py
@@ -117,8 +117,7 @@ def test_job_uniqueness(module_data):
 
     if errors:
         pytest.fail(
-            f"Thread errors (call_log={call_log}):\n"
-            + "\n".join(errors)
+            f"Thread errors (call_log={call_log}):\n" + "\n".join(errors)
         )
 
     assert len(call_log) == 1

--- a/tests/integration/test_advisory_lock.py
+++ b/tests/integration/test_advisory_lock.py
@@ -108,4 +108,17 @@ def test_job_uniqueness(module_data):
         ]
         wait(futures, timeout=3)
 
+    errors = []
+    for i, f in enumerate(futures):
+        if f.done() and f.exception():
+            errors.append(f"Thread {i}: {f.exception()}")
+        elif not f.done():
+            errors.append(f"Thread {i}: timed out (not done after 3s)")
+
+    if errors:
+        pytest.fail(
+            f"Thread errors (call_log={call_log}):\n"
+            + "\n".join(errors)
+        )
+
     assert len(call_log) == 1


### PR DESCRIPTION
## Summary
- Diagnostic PR to identify the root cause of `test_job_uniqueness[gather_analytics]` failure
- The test currently swallows exceptions from `ThreadPoolExecutor` futures — `wait()` stores exceptions in `Future` objects but never re-raises them
- Adds `future.result()` diagnostics after `wait()` so CI output shows the actual exception causing `len(call_log) == 0`

## Changes
- `tests/integration/test_advisory_lock.py` — check futures for exceptions/timeouts before the final assert

## Test plan
- [ ] CI runs `test_job_uniqueness[gather_analytics]` with `-m multithreaded` and surfaces the actual error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved integration test diagnostics for concurrent worker failures and timeouts.
  - Failure messages now identify the affected worker and include relevant call activity, making test failures easier to investigate.
  - Retained validation that the expected single call is recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->