### PR TITLE
fix(ci): guard tput color init against missing or dumb TERM

### DIFF
--- a/scripts/common/logging.sh
+++ b/scripts/common/logging.sh
@@ -3,7 +3,7 @@
 # timestamp
 TIMESTAMP=$(date "+%Y-%m-%d %H:%M:%S")
 
-if which tput &> /dev/null; then
+if which tput &> /dev/null && tput setaf 1 &> /dev/null; then
   # colors
   ERR=$(tput setaf 1)
   INFO=$(tput setaf 178)


### PR DESCRIPTION
## Summary
- Fixes latent bug in shell logging helper that caused eda-api container to crash during startup
- Script now checks TERM is set and capable before calling tput for color initialization
- Fallback to no-color logging in non-interactive/CI environments
- Jira: https://redhat.atlassian.net/browse/AAP-91748

## Changes
- scripts/common/logging.sh — added TERM presence and capability checks to prevent tput failure in headless environments

## Test Plan
- [ ] Verify eda-api container starts successfully in CI environment
- [x] Test with TERM unset: `env -u TERM bash -c 'set -o errexit; source scripts/common/logging.sh && echo "✓ Success"'` — verified no crash, uses no-color fallback
- [x] Test with TERM=dumb: `TERM=dumb bash -c 'set -o errexit; source scripts/common/logging.sh && echo "✓ Success"'` — verified no crash, uses no-color fallback
- [x] Verify color output works with capable terminal: `TERM=xterm-256color bash -c 'source scripts/common/logging.sh; log-info "Test" | od -An -tx1'` — verified ANSI escape codes present

## Reference
GitHub Actions failure that exposed the bug: https://github.com/ansible/eda-server/actions/runs/33802904405/job/100831044458

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal compatibility by disabling colored log output when color support is unavailable or the terminal is set to `dumb`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->